### PR TITLE
test: add core regression coverage

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,6 +1,7 @@
 {
   "entry": [
-    "extensions/index.ts"
+    "extensions/index.ts",
+    "tests/*.test.mjs"
   ],
   "usedClassMembers": [
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Bundle and health checks
+      - name: Unit, bundle, and health checks
         run: npm run check
 
       - name: Duplication check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,8 @@ npm run pack:check
 
 What these cover:
 
+- `npm run check` runs unit tests, bundle checks, and Fallow health checks.
+- `npm test` runs fast Node-based regression tests for argument mapping and overview parsing.
 - `npm run check:bundle` bundles the extension entrypoints with external Pi peer dependencies.
 - `npm run health` runs Fallow health checks.
 - `npm run dupes` checks for duplicate code.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/pi-fallow.svg)](https://www.npmjs.com/package/pi-fallow)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-Pi Fallow connects [Fallow](https://fallow.tools/docs/) to the [Pi coding agent](https://github.com/earendil-works/pi-coding-agent): you get a `fallow_run` tool for agent workflows and a `/fallow` slash command for interactive checks.
+Pi Fallow connects [Fallow](https://fallow.tools/docs/) to the [Pi coding agent](https://github.com/earendil-works/pi): you get a `fallow_run` tool for agent workflows and a `/fallow` slash command for interactive checks.
 
 Use it when you want Pi to verify changes, review a PR, find dead code, inspect duplication, check maintainability, or trace whether something is safe to remove.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://img.shields.io/npm/v/pi-fallow.svg)](https://www.npmjs.com/package/pi-fallow)
 [![npm downloads](https://img.shields.io/npm/dm/pi-fallow.svg)](https://www.npmjs.com/package/pi-fallow)
+[![CI](https://github.com/revazi/pi-fallow/actions/workflows/ci.yml/badge.svg)](https://github.com/revazi/pi-fallow/actions/workflows/ci.yml)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 Pi Fallow connects [Fallow](https://fallow.tools/docs/) to the [Pi coding agent](https://github.com/earendil-works/pi): you get a `fallow_run` tool for agent workflows and a `/fallow` slash command for interactive checks.

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "node": ">=20"
   },
   "scripts": {
-    "check": "npm run check:bundle && npm run health",
+    "check": "npm test && npm run check:bundle && npm run health",
     "check:bundle": "npx -y esbuild extensions/fallow.ts --bundle --platform=node --format=esm --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-tui --external:@earendil-works/pi-ai --external:typebox --outdir=/tmp/pi-fallow-esbuild && npx -y esbuild extensions/index.ts --bundle --platform=node --format=esm --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-tui --external:@earendil-works/pi-ai --external:typebox --outdir=/tmp/pi-fallow-esbuild",
     "health": "npx -y fallow health --format json --quiet",
     "dupes": "npx -y fallow dupes --format json --quiet",
     "dead-code": "npx -y fallow dead-code --format json --quiet",
+    "test": "node --test",
     "smoke:fallow": "node scripts/fallow-smoke.mjs",
     "pack:check": "npm pack --dry-run",
     "publish:public": "npm publish --access public"

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
+
+function build(params) {
+	return fallowCli.buildFallowArgs(params);
+}
+
+describe("fallowCli.buildFallowArgs", () => {
+	it("maps check-changed to root --changed-since analysis", () => {
+		assert.deepEqual(build({ command: "check-changed", changedSince: "main" }), [
+			"--format", "json", "--quiet", "--changed-since", "main",
+		]);
+	});
+
+	it("accepts base as check-changed changed-since alias", () => {
+		assert.deepEqual(build({ command: "check-changed", base: "origin/main", includeEntryExports: true }), [
+			"--format", "json", "--quiet", "--changed-since", "origin/main", "--include-entry-exports",
+		]);
+	});
+
+	it("requires a comparison ref for check-changed", () => {
+		assert.throws(() => build({ command: "check-changed" }), /requires changedSince or base/);
+	});
+
+	it("builds inspect file and symbol queries", () => {
+		assert.deepEqual(build({ command: "inspect", file: "@extensions/fallow/cli.ts" }), [
+			"inspect", "--format", "json", "--quiet", "--file", "extensions/fallow/cli.ts",
+		]);
+		assert.deepEqual(build({ command: "inspect", symbol: "@extensions/fallow/cli.ts:fallowCli", symbolChain: true }), [
+			"inspect", "--format", "json", "--quiet", "--symbol", "extensions/fallow/cli.ts:fallowCli", "--symbol-chain",
+		]);
+	});
+
+	it("builds trace-symbol queries", () => {
+		assert.deepEqual(build({ command: "trace-symbol", file: "extensions/fallow/cli.ts", exportName: "fallowCli", callers: true, depth: 2 }), [
+			"trace", "extensions/fallow/cli.ts:fallowCli", "--format", "json", "--quiet", "--callers", "--depth", "2",
+		]);
+	});
+
+	it("builds security and decision-surface commands", () => {
+		assert.deepEqual(build({ command: "security", changedSince: "HEAD~1", securityGate: "new", surface: true }), [
+			"security", "--format", "json", "--quiet", "--changed-since", "HEAD~1", "--gate", "new", "--surface",
+		]);
+		assert.deepEqual(build({ command: "decision-surface", base: "origin/main", maxDecisions: 4 }), [
+			"decision-surface", "--format", "json", "--quiet", "--changed-since", "origin/main", "--max-decisions", "4",
+		]);
+	});
+
+	it("builds project inspection commands", () => {
+		assert.deepEqual(build({ command: "workspaces" }), ["workspaces", "--format", "json", "--quiet"]);
+		assert.deepEqual(build({ command: "config" }), ["config", "--format", "json", "--quiet"]);
+		assert.deepEqual(build({ command: "schema" }), ["schema", "--format", "json", "--quiet"]);
+		assert.deepEqual(build({ command: "impact" }), ["impact", "--format", "json", "--quiet"]);
+		assert.deepEqual(build({ command: "project-info", listWorkspaces: true }), ["list", "--format", "json", "--quiet", "--workspaces"]);
+	});
+
+	it("rejects format overrides in extraArgs", () => {
+		assert.throws(() => build({ command: "health", extraArgs: ["--format", "human"] }), /must not include --format/);
+		assert.throws(() => build({ command: "health", extraArgs: ["--format=human"] }), /must not include --format/);
+		assert.throws(() => build({ command: "health", extraArgs: ["-f", "human"] }), /must not include --format/);
+	});
+});
+
+describe("fallowCli.splitArgs", () => {
+	it("splits quoted and escaped arguments", () => {
+		assert.deepEqual(fallowCli.splitArgs("audit --base origin/main --name 'hello world' path\\ with\\ spaces"), [
+			"audit", "--base", "origin/main", "--name", "hello world", "path with spaces",
+		]);
+	});
+
+	it("throws for unclosed quotes", () => {
+		assert.throws(() => fallowCli.splitArgs("audit --base 'origin/main"), /Unclosed quote/);
+	});
+});

--- a/tests/command-args.test.mjs
+++ b/tests/command-args.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { normalizeFallowArgs } = await jiti.import("../extensions/fallow/command/args.ts");
+
+function normalize(rawArgs, options = {}) {
+	const notifications = [];
+	const result = normalizeFallowArgs(
+		rawArgs,
+		options.baseRef ?? "origin/main",
+		options.lastArgs ?? null,
+		(message, level) => notifications.push({ message, level }),
+	);
+	return { result, notifications };
+}
+
+describe("normalizeFallowArgs", () => {
+	it("adds PR audit defaults", () => {
+		assert.deepEqual(normalize(["pr"]).result, ["audit", "--base", "origin/main", "--gate", "new-only"]);
+	});
+
+	it("does not duplicate explicit PR base or gate", () => {
+		assert.deepEqual(normalize(["pr", "--base", "main", "--gate=all"]).result, ["audit", "--base", "main", "--gate=all"]);
+	});
+
+	it("reruns the last command and warns when missing", () => {
+		assert.deepEqual(normalize(["rerun"], { lastArgs: ["health", "--score"] }).result, ["health", "--score"]);
+		const missing = normalize(["rerun"]);
+		assert.equal(missing.result, null);
+		assert.deepEqual(missing.notifications, [{ message: "No previous /fallow command to rerun.", level: "warning" }]);
+	});
+
+	it("maps convenience aliases to current Fallow commands", () => {
+		assert.deepEqual(normalize(["all"]).result, []);
+		assert.deepEqual(normalize(["project-info", "--files"]).result, ["list", "--files"]);
+		assert.deepEqual(normalize(["list-boundaries"]).result, ["list", "--boundaries"]);
+		assert.deepEqual(normalize(["fix-preview"]).result, ["fix", "--dry-run"]);
+		assert.deepEqual(normalize(["fix-apply"]).result, ["fix", "--yes"]);
+		assert.deepEqual(normalize(["coverage-analyze"]).result, ["coverage", "analyze"]);
+	});
+
+	it("maps check-changed to root changed-file analysis", () => {
+		assert.deepEqual(normalize(["check-changed", "--changed-since", "main"]).result, ["--changed-since", "main"]);
+		assert.deepEqual(normalize(["check-changed", "--base=origin/main"]).result, ["--base=origin/main"]);
+		assert.throws(() => normalize(["check-changed"]), /requires --changed-since or --base/);
+	});
+
+	it("maps trace aliases", () => {
+		assert.deepEqual(normalize(["trace-file", "extensions/fallow/cli.ts"]).result, [
+			"dead-code", "--trace-file", "extensions/fallow/cli.ts",
+		]);
+		assert.deepEqual(normalize(["trace-export", "extensions/fallow/cli.ts", "fallowCli"]).result, [
+			"dead-code", "--trace", "extensions/fallow/cli.ts:fallowCli",
+		]);
+		assert.deepEqual(normalize(["trace-dependency", "jiti"]).result, ["dead-code", "--trace-dependency", "jiti"]);
+		assert.deepEqual(normalize(["trace-clone", "extensions/fallow/cli.ts", "10"]).result, [
+			"dupes", "--trace", "extensions/fallow/cli.ts:10",
+		]);
+		assert.deepEqual(normalize(["trace-clone", "extensions/fallow/cli.ts:10"]).result, [
+			"dupes", "--trace", "extensions/fallow/cli.ts:10",
+		]);
+	});
+});

--- a/tests/overview.test.mjs
+++ b/tests/overview.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { buildFallowOverview } = await jiti.import("../extensions/fallow/overview.ts");
+
+describe("buildFallowOverview", () => {
+	it("summarizes security findings", () => {
+		const overview = buildFallowOverview({
+			kind: "security",
+			elapsed_ms: 12,
+			security_findings: [{
+				kind: "tainted-sink",
+				category: "command-injection",
+				cwe: 78,
+				path: "src/run.ts",
+				line: 10,
+				severity: "medium",
+				evidence: "Non-literal command passed to spawn().",
+				actions: [{ type: "suppress-file", description: "Suppress with a file-level comment" }],
+			}],
+		});
+
+		assert.equal(overview.title, "Fallow security");
+		assert.equal(overview.status, "warning");
+		assert.equal(overview.sections[0].title, "Security candidates");
+		assert.deepEqual(overview.sections[0].items[0], {
+			label: "tainted-sink: command-injection",
+			path: "src/run.ts",
+			line: 10,
+			meta: "medium · CWE-78",
+			action: "Suppress with a file-level comment",
+			severity: "medium",
+			raw: overview.sections[0].items[0].raw,
+		});
+	});
+
+	it("summarizes inspect output", () => {
+		const overview = buildFallowOverview({
+			kind: "inspect_target",
+			target: { type: "file", file: "src/a.ts" },
+			identity: {
+				file: "src/a.ts",
+				is_reachable: true,
+				export_count: 2,
+				import_count: 1,
+				imported_by_count: 3,
+			},
+			warnings: ["partial evidence"],
+		});
+
+		assert.equal(overview.title, "Fallow inspect");
+		assert.deepEqual(overview.stats.slice(0, 5), [
+			{ label: "target", value: "src/a.ts" },
+			{ label: "reachable", value: "true" },
+			{ label: "exports", value: 2 },
+			{ label: "imports", value: 1 },
+			{ label: "importers", value: 3 },
+		]);
+		assert.deepEqual(overview.notes, ["partial evidence"]);
+	});
+
+	it("summarizes decision-surface output", () => {
+		const overview = buildFallowOverview({
+			kind: "decision-surface",
+			decisions: [{
+				question: "Should this API stay public?",
+				path: "src/api.ts",
+				line: 20,
+				expert: "architecture",
+				confidence: "high",
+				prompt: "Review exported API shape.",
+			}],
+		});
+
+		assert.equal(overview.title, "Fallow decision surface");
+		assert.equal(overview.sections[0].title, "Structural decisions");
+		assert.deepEqual(overview.sections[0].items[0], {
+			label: "Should this API stay public?",
+			path: "src/api.ts",
+			line: 20,
+			meta: "architecture · high",
+			action: "Review exported API shape.",
+			raw: overview.sections[0].items[0].raw,
+		});
+	});
+
+	it("summarizes workspace, schema, and config outputs", () => {
+		const workspace = buildFallowOverview({ kind: "list-workspaces", workspace_count: 0, workspaces: [], workspace_diagnostics: [] });
+		assert.equal(workspace.title, "Fallow workspaces");
+		assert.deepEqual(workspace.stats, [{ label: "workspaces", value: 0 }]);
+
+		const schema = buildFallowOverview({ name: "fallow", version: "2.103.0", commands: [{ name: "health" }], issue_types: [{}, {}] });
+		assert.equal(schema.title, "Fallow schema");
+		assert.deepEqual(schema.stats, [
+			{ label: "version", value: "2.103.0" },
+			{ label: "commands", value: 1 },
+			{ label: "issue types", value: 2 },
+		]);
+
+		const config = buildFallowOverview({ entry: ["extensions/index.ts"], rules: { "unused-files": "error" }, duplicates: {}, health: {} });
+		assert.equal(config.title, "Fallow config");
+		assert.deepEqual(config.stats, [
+			{ label: "entries", value: 1 },
+			{ label: "rules", value: 1 },
+		]);
+	});
+});


### PR DESCRIPTION
   ## Summary
   - Adds Node test runner coverage for Fallow argument building and `/fallow` alias normalization
   - Adds overview parsing regression tests for security, inspect, decision-surface, workspace, schema, and config outputs
   - Runs tests as part of `npm run check` and CI
   - Adds CI badge to the README

   ## Validation
   - npm test
   - npm run check
   - npm run dupes
   - npm run dead-code
   - npm run smoke:fallow
   - npm run pack:check
   - Fallow PR audit passed