### PR TITLE
chore: prepare 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to Pi Fallow are documented here.
+
+## [0.2.0] - 2026-07-01
+
+### Added
+- Added `/fallow about` with installed/latest npm versions, update status, update command, and project links.
+- Added `/fallow version` and `/fallow update` aliases for the about/update view.
+- Added a non-blocking, cached startup update notice when a newer `pi-fallow` npm version is available.
+- Added `PI_FALLOW_DISABLE_UPDATE_NOTICE=1` to disable startup update notices.
+- Added support for current Fallow CLI surfaces: `inspect`, `trace-symbol`, `security`, `workspaces`, `config`, `schema`, `decision-surface`, and `impact`.
+- Added CI, regression tests, native Node coverage reporting, and Codecov badge support.
+
+### Changed
+- Made the Fallow issue navigator overlay fluid: it sizes to content, stays centered, and caps at the available terminal width.
+- Kept Pi peer dependencies flexible while adding current Pi packages as dev dependencies for local and CI installs.
+- Split CI into clearer checks for tests, Fallow, coverage, and package validation.
+
+### Fixed
+- Fixed `/fallow check-changed` by mapping it to Fallow's root changed-file analysis with `--changed-since`.
+- Removed the persistent footer status line (`fallow ready · branch ... · base ...`) while keeping the transient `fallow running…` status during commands.
+- Improved output parsing, overview summaries, and navigator prompt coverage with regression tests.
+
+[0.2.0]: https://github.com/revazi/pi-fallow/compare/v0.1.3...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fallow",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fallow",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fallow",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "type": "module",
   "description": "Pi extension that brings Fallow codebase intelligence into Pi as an agent tool and slash command.",
   "license": "MIT",
@@ -47,6 +47,7 @@
   },
   "files": [
     "README.md",
+    "CHANGELOG.md",
     "CONTRIBUTING.md",
     "SECURITY.md",
     "LICENSE",


### PR DESCRIPTION
## Summary
   - Bump pi-fallow to 0.2.0
   - Add CHANGELOG.md
   - Include changelog in the npm package

   ## Validation
   - npm run pack:check