### PR TITLE
chore: establish execution performance baseline

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,7 +1,9 @@
 {
   "entry": [
     "extensions/index.ts",
-    "tests/*.test.mjs"
+    "tests/*.test.mjs",
+    "scripts/performance-memory-worker.mjs",
+    "benchmarks/bin/fallow-fixture.mjs"
   ],
   "ignoreDependencies": [
     "jiti",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ npm run smoke:fallow
 npm run coverage
 npm run bench:tokens -- --label candidate --output /tmp/pi-fallow-token-candidate.json
 npm run bench:tokens:compare -- benchmarks/baselines/v0.2.0.json /tmp/pi-fallow-token-candidate.json
+npm run bench:performance -- --label candidate --output /tmp/pi-fallow-performance-candidate.json
+npm run bench:performance:compare -- benchmarks/baselines/performance-v0.2.0.json /tmp/pi-fallow-performance-candidate.json
 npm run pack:check
 ```
 
@@ -55,6 +57,7 @@ What these cover:
 - `npm run smoke:fallow` smoke-tests modeled Fallow CLI surfaces.
 - `npm run coverage` generates text and lcov coverage reports.
 - `npm run bench:tokens` and `npm run bench:tokens:compare` measure model-visible output against the frozen `0.2.0` baseline.
+- `npm run bench:performance` and `npm run bench:performance:compare` measure runner, processing, Git, memory, and cold/warm behavior against the performance baseline.
 - `npm run pack:check` verifies the npm package contents.
 
 ## Pull requests

--- a/README.md
+++ b/README.md
@@ -138,9 +138,11 @@ npm run dupes
 npm run pack:check
 npm run bench:tokens -- --label candidate --output /tmp/pi-fallow-token-candidate.json
 npm run bench:tokens:compare -- benchmarks/baselines/v0.2.0.json /tmp/pi-fallow-token-candidate.json
+npm run bench:performance -- --label candidate --output /tmp/pi-fallow-performance-candidate.json
+npm run bench:performance:compare -- benchmarks/baselines/performance-v0.2.0.json /tmp/pi-fallow-performance-candidate.json
 ```
 
-See the [token benchmark documentation](https://github.com/revazi/pi-fallow/blob/main/benchmarks/README.md) for the frozen `0.2.0` baseline, fixture corpus, and before/after methodology.
+See the [token benchmark documentation](https://github.com/revazi/pi-fallow/blob/main/benchmarks/README.md) and [performance benchmark documentation](https://github.com/revazi/pi-fallow/blob/main/benchmarks/PERFORMANCE.md) for the frozen before states and comparison methodology.
 
 This repo includes `.fallowrc.json` so Fallow knows the Pi entrypoint is `extensions/index.ts` and treats TUI component callbacks such as `handleInput` and `invalidate` as framework-used.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ Measured on the current `0.2.0` checkout:
 - Reported coverage for loaded source files is 58.71% lines, 80.19% branches, and 67.58% functions. Unloaded production modules are not currently included, so true repository coverage is lower.
 - Fallow health score is 88.4 (A), average maintainability is 90.5, and there are no complexity-threshold, duplication, circular-dependency, or dead-export findings.
 - The remaining dead-code report is a test-classification finding for `jiti`, which is used by tests and should not be moved into runtime dependencies without another reason.
-- Local command measurements showed about 0.8–1.6 seconds through `npx -y fallow`, while invoking the cached Fallow executable directly took about 0.14 seconds for a small report. These numbers are machine-specific, but show that process discovery can cost more than analysis.
+- The frozen Apple M1 Pro performance baseline measures the same Fallow 3.6.0 installation at 124.72 ms warm median when invoked directly and 819.42 ms through cached npx fallback. Git ref autocomplete blocks for a 12.88 ms cold median, base detection takes 34.46 ms warm median through three Git processes, and large/schema reports retain roughly 2.43–2.45× their fixture size on the heap. These values are machine-specific and must be compared in a matching environment.
 - `fallow schema` currently produces roughly 180 KB of JSON, demonstrating why output and prompt budgets need to be independent of Fallow's report size.
 - The frozen canonical `fallow_run` contract contains 9,820 characters and 2,237 `o200k_base` tokens before provider-specific serialization. This is a fixed context cost whenever the tool is active and must be included in token optimization work.
 

--- a/benchmarks/PERFORMANCE.md
+++ b/benchmarks/PERFORMANCE.md
@@ -1,0 +1,101 @@
+# Performance benchmarks
+
+This benchmark freezes Pi Fallow's execution and memory behavior before runner, Git, parsing, or retention optimizations.
+
+## The five measured areas
+
+1. **Runner performance** — configured binary, PATH resolution, deterministic fallback, direct real Fallow, and real npx fallback.
+2. **Extension processing** — engine parsing, summaries, overview construction, truncation, and temp output using frozen reports.
+3. **Git and autocomplete** — cold/warm ref completion, event-loop blocking, base detection, and subprocess counts.
+4. **Memory** — retained heap, released heap, RSS, external memory, and fixture-size amplification in isolated workers.
+5. **Cold versus warm execution** — first invocation plus warm median, p95, maximum, mean, and parent-process CPU measurements.
+
+The standard run uses three warmups and 15 measured iterations. Real Fallow runner routes use one warmup and five iterations to keep the benchmark practical. Memory scenarios run in three isolated `node --expose-gc` workers.
+
+## Baseline environment
+
+The committed `performance-v0.2.0.json` result was measured with:
+
+- Apple M1 Pro, 10 logical CPUs, 16 GB RAM
+- macOS arm64
+- Node.js 24.12.0
+- Fallow 3.6.0
+- Pi Fallow runtime before execution optimizations
+
+Timing comparisons are machine-sensitive. Compare on the same machine, Node version, power state, and Fallow version. The comparison command warns when recorded environments differ. Retained-memory measurements are generally more stable but should still be compared on the same Node version.
+
+## Before findings
+
+### Runner
+
+| Route | Cold | Warm median | Warm p95 |
+|---|---:|---:|---:|
+| Direct real Fallow executable | 148.18 ms | 124.72 ms | 125.27 ms |
+| Current system resolution through npx | 852.07 ms | 819.42 ms | 845.81 ms |
+
+On this machine, cached npx fallback is **6.57× slower** than invoking the same Fallow installation directly and adds approximately **695 ms** per warm invocation.
+
+The deterministic fixture routes show about 31–34 ms of process startup/collection overhead. Their first samples are informational because operating-system file and executable caches can make individual cold measurements noisy.
+
+### Extension processing
+
+| Fixture | Warm median | Warm p95 |
+|---|---:|---:|
+| No findings | 0.16 ms | 0.43 ms |
+| 5 findings | 0.14 ms | 0.30 ms |
+| 40 findings | 0.26 ms | 0.38 ms |
+| 300 findings | 1.45 ms | 2.14 ms |
+| Fallow schema | 2.93 ms | 3.90 ms |
+
+Current orchestration is inexpensive relative to npx startup for these fixtures. Processing still matters for memory because the command result retains raw output, parsed objects, formatted JSON, and final content together.
+
+### Git and autocomplete
+
+| Operation | Cold/blocked median | Warm median | Git processes |
+|---|---:|---:|---:|
+| Ref autocomplete | 12.88 ms | 0.01 ms | 1 on a cold lookup |
+| Base detection | 37.03 ms first run | 34.46 ms | 3 per invocation |
+
+Cold autocomplete performs synchronous Git work and blocks the event loop. Base detection has no current cache and is performed for slash commands that do not need a PR base.
+
+### Retained memory
+
+| Fixture | Fixture size | Retained heap | Amplification | Worker max RSS |
+|---|---:|---:|---:|---:|
+| 5 findings | 3.63 KB | 87.59 KB | 24.12× | 189.16 MB |
+| 40 findings | 25.47 KB | 153.51 KB | 6.03× | 188.77 MB |
+| 300 findings | 141.03 KB | 342.18 KB | 2.43× | 189.56 MB |
+| Fallow schema | 177.32 KB | 434.63 KB | 2.45× | 190.48 MB |
+
+Max RSS includes Node, Jiti, Pi libraries, and the benchmark worker, so retained heap delta and amplification are the primary before/after signals.
+
+## Commands
+
+Generate a candidate result:
+
+```bash
+npm run bench:performance -- \
+  --label candidate \
+  --output /tmp/pi-fallow-performance-candidate.json
+```
+
+Compare it with the baseline:
+
+```bash
+npm run bench:performance:compare -- \
+  benchmarks/baselines/performance-v0.2.0.json \
+  /tmp/pi-fallow-performance-candidate.json
+```
+
+For a quicker exploratory run, lower the deterministic and memory iterations:
+
+```bash
+npm run bench:performance -- \
+  --label quick \
+  --iterations 3 \
+  --warmups 1 \
+  --memory-iterations 1 \
+  --output /tmp/pi-fallow-performance-quick.json
+```
+
+Quick artifacts intentionally cannot be compared with the committed baseline because their benchmark configurations differ.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 # Token benchmarks
 
-This directory freezes Pi Fallow's model-visible `0.2.0` behavior before token optimizations.
+This directory freezes Pi Fallow's model-visible `0.2.0` behavior before token optimizations. Execution, Git, cold/warm, and memory measurements are documented separately in [`PERFORMANCE.md`](./PERFORMANCE.md).
 
 ## What is measured
 

--- a/benchmarks/baselines/performance-v0.2.0.json
+++ b/benchmarks/baselines/performance-v0.2.0.json
@@ -1,0 +1,1299 @@
+{
+  "benchmarkVersion": 1,
+  "label": "v0.2.0-before",
+  "generatedAt": "2026-07-20T07:18:21.038Z",
+  "config": {
+    "warmups": 3,
+    "iterations": 15,
+    "gitColdIterations": 8,
+    "memoryIterations": 3,
+    "systemRunnerIterations": 5
+  },
+  "environment": {
+    "piFallowVersion": "0.2.0",
+    "gitSha": "9c5c3ceac5219a106288739b222c60bac77d36ab",
+    "node": "v24.12.0",
+    "platform": "darwin",
+    "arch": "arm64",
+    "cpuModel": "Apple M1 Pro",
+    "logicalCpuCount": 10,
+    "totalMemoryBytes": 17179869184
+  },
+  "measurements": [
+    {
+      "key": "runner/configured-fallow-bin",
+      "category": "runner",
+      "scenario": "configured-fallow-bin",
+      "cold": {
+        "wallMs": 34.87,
+        "parentCpuUserMs": 0.98,
+        "parentCpuSystemMs": 0.43,
+        "internalElapsedMs": 1,
+        "wrapperOverheadMs": 33.87,
+        "binary": "/Users/revaz/Work/fallow-pi/benchmarks/bin/fallow-fixture.mjs"
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 34.87,
+          "median": 34.87,
+          "p95": 34.87,
+          "max": 34.87,
+          "mean": 34.87
+        },
+        "parentCpuUserMs": {
+          "min": 0.98,
+          "median": 0.98,
+          "p95": 0.98,
+          "max": 0.98,
+          "mean": 0.98
+        },
+        "parentCpuSystemMs": {
+          "min": 0.43,
+          "median": 0.43,
+          "p95": 0.43,
+          "max": 0.43,
+          "mean": 0.43
+        },
+        "internalElapsedMs": {
+          "min": 1,
+          "median": 1,
+          "p95": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "wrapperOverheadMs": {
+          "min": 33.87,
+          "median": 33.87,
+          "p95": 33.87,
+          "max": 33.87,
+          "mean": 33.87
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 32.28,
+          "median": 36.56,
+          "p95": 43.51,
+          "max": 43.51,
+          "mean": 36.79
+        },
+        "parentCpuUserMs": {
+          "min": 0.51,
+          "median": 0.64,
+          "p95": 6.15,
+          "max": 6.15,
+          "mean": 0.99
+        },
+        "parentCpuSystemMs": {
+          "min": 0.42,
+          "median": 0.46,
+          "p95": 2.75,
+          "max": 2.75,
+          "mean": 0.62
+        },
+        "internalElapsedMs": {
+          "min": 1,
+          "median": 1,
+          "p95": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "wrapperOverheadMs": {
+          "min": 31.28,
+          "median": 35.56,
+          "p95": 42.51,
+          "max": 42.51,
+          "mean": 35.79
+        }
+      }
+    },
+    {
+      "key": "runner/path-fallow",
+      "category": "runner",
+      "scenario": "path-fallow",
+      "cold": {
+        "wallMs": 401.57,
+        "parentCpuUserMs": 0.57,
+        "parentCpuSystemMs": 0.42,
+        "internalElapsedMs": 1,
+        "wrapperOverheadMs": 400.57,
+        "binary": "fallow"
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 401.57,
+          "median": 401.57,
+          "p95": 401.57,
+          "max": 401.57,
+          "mean": 401.57
+        },
+        "parentCpuUserMs": {
+          "min": 0.57,
+          "median": 0.57,
+          "p95": 0.57,
+          "max": 0.57,
+          "mean": 0.57
+        },
+        "parentCpuSystemMs": {
+          "min": 0.42,
+          "median": 0.42,
+          "p95": 0.42,
+          "max": 0.42,
+          "mean": 0.42
+        },
+        "internalElapsedMs": {
+          "min": 1,
+          "median": 1,
+          "p95": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "wrapperOverheadMs": {
+          "min": 400.57,
+          "median": 400.57,
+          "p95": 400.57,
+          "max": 400.57,
+          "mean": 400.57
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 29.14,
+          "median": 29.92,
+          "p95": 30.52,
+          "max": 30.52,
+          "mean": 29.9
+        },
+        "parentCpuUserMs": {
+          "min": 0.4,
+          "median": 0.53,
+          "p95": 1.14,
+          "max": 1.14,
+          "mean": 0.6
+        },
+        "parentCpuSystemMs": {
+          "min": 0.36,
+          "median": 0.39,
+          "p95": 0.94,
+          "max": 0.94,
+          "mean": 0.43
+        },
+        "internalElapsedMs": {
+          "min": 1,
+          "median": 1,
+          "p95": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "wrapperOverheadMs": {
+          "min": 28.14,
+          "median": 28.92,
+          "p95": 29.52,
+          "max": 29.52,
+          "mean": 28.9
+        }
+      }
+    },
+    {
+      "key": "runner/npx-fallback-fixture",
+      "category": "runner",
+      "scenario": "npx-fallback-fixture",
+      "cold": {
+        "wallMs": 259.89,
+        "parentCpuUserMs": 0.83,
+        "parentCpuSystemMs": 0.63,
+        "internalElapsedMs": 1,
+        "wrapperOverheadMs": 258.89,
+        "binary": "npx"
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 259.89,
+          "median": 259.89,
+          "p95": 259.89,
+          "max": 259.89,
+          "mean": 259.89
+        },
+        "parentCpuUserMs": {
+          "min": 0.83,
+          "median": 0.83,
+          "p95": 0.83,
+          "max": 0.83,
+          "mean": 0.83
+        },
+        "parentCpuSystemMs": {
+          "min": 0.63,
+          "median": 0.63,
+          "p95": 0.63,
+          "max": 0.63,
+          "mean": 0.63
+        },
+        "internalElapsedMs": {
+          "min": 1,
+          "median": 1,
+          "p95": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "wrapperOverheadMs": {
+          "min": 258.89,
+          "median": 258.89,
+          "p95": 258.89,
+          "max": 258.89,
+          "mean": 258.89
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 29.49,
+          "median": 31.02,
+          "p95": 39.83,
+          "max": 39.83,
+          "mean": 32.01
+        },
+        "parentCpuUserMs": {
+          "min": 0.62,
+          "median": 0.67,
+          "p95": 1.76,
+          "max": 1.76,
+          "mean": 0.81
+        },
+        "parentCpuSystemMs": {
+          "min": 0.57,
+          "median": 0.66,
+          "p95": 0.82,
+          "max": 0.82,
+          "mean": 0.65
+        },
+        "internalElapsedMs": {
+          "min": 1,
+          "median": 1,
+          "p95": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "wrapperOverheadMs": {
+          "min": 28.49,
+          "median": 30.02,
+          "p95": 38.83,
+          "max": 38.83,
+          "mean": 31.01
+        }
+      }
+    },
+    {
+      "key": "runner/system-direct-fallow",
+      "category": "runner",
+      "scenario": "system-direct-fallow",
+      "cold": {
+        "wallMs": 148.18,
+        "parentCpuUserMs": 0.58,
+        "parentCpuSystemMs": 0.55,
+        "internalElapsedMs": 14,
+        "wrapperOverheadMs": 134.18,
+        "binary": "/Users/revaz/.npm/_npx/e6d07818f0a04ee4/node_modules/.bin/fallow",
+        "fallowVersion": "3.6.0"
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 148.18,
+          "median": 148.18,
+          "p95": 148.18,
+          "max": 148.18,
+          "mean": 148.18
+        },
+        "parentCpuUserMs": {
+          "min": 0.58,
+          "median": 0.58,
+          "p95": 0.58,
+          "max": 0.58,
+          "mean": 0.58
+        },
+        "parentCpuSystemMs": {
+          "min": 0.55,
+          "median": 0.55,
+          "p95": 0.55,
+          "max": 0.55,
+          "mean": 0.55
+        },
+        "internalElapsedMs": {
+          "min": 14,
+          "median": 14,
+          "p95": 14,
+          "max": 14,
+          "mean": 14
+        },
+        "wrapperOverheadMs": {
+          "min": 134.18,
+          "median": 134.18,
+          "p95": 134.18,
+          "max": 134.18,
+          "mean": 134.18
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 119.84,
+          "median": 124.72,
+          "p95": 125.27,
+          "max": 125.27,
+          "mean": 123.25
+        },
+        "parentCpuUserMs": {
+          "min": 0.48,
+          "median": 0.72,
+          "p95": 0.97,
+          "max": 0.97,
+          "mean": 0.75
+        },
+        "parentCpuSystemMs": {
+          "min": 0.4,
+          "median": 0.41,
+          "p95": 0.46,
+          "max": 0.46,
+          "mean": 0.42
+        },
+        "internalElapsedMs": {
+          "min": 11,
+          "median": 12,
+          "p95": 13,
+          "max": 13,
+          "mean": 11.8
+        },
+        "wrapperOverheadMs": {
+          "min": 107.84,
+          "median": 112.27,
+          "p95": 114.24,
+          "max": 114.24,
+          "mean": 111.45
+        }
+      },
+      "resolvedBinary": "/Users/revaz/.npm/_npx/e6d07818f0a04ee4/node_modules/.bin/fallow",
+      "fallowVersion": "3.6.0"
+    },
+    {
+      "key": "runner/system-resolution",
+      "category": "runner",
+      "scenario": "system-resolution",
+      "cold": {
+        "wallMs": 852.07,
+        "parentCpuUserMs": 1.33,
+        "parentCpuSystemMs": 2.9,
+        "internalElapsedMs": 10,
+        "wrapperOverheadMs": 842.07,
+        "binary": "npx",
+        "fallowVersion": "3.6.0"
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 852.07,
+          "median": 852.07,
+          "p95": 852.07,
+          "max": 852.07,
+          "mean": 852.07
+        },
+        "parentCpuUserMs": {
+          "min": 1.33,
+          "median": 1.33,
+          "p95": 1.33,
+          "max": 1.33,
+          "mean": 1.33
+        },
+        "parentCpuSystemMs": {
+          "min": 2.9,
+          "median": 2.9,
+          "p95": 2.9,
+          "max": 2.9,
+          "mean": 2.9
+        },
+        "internalElapsedMs": {
+          "min": 10,
+          "median": 10,
+          "p95": 10,
+          "max": 10,
+          "mean": 10
+        },
+        "wrapperOverheadMs": {
+          "min": 842.07,
+          "median": 842.07,
+          "p95": 842.07,
+          "max": 842.07,
+          "mean": 842.07
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 803.34,
+          "median": 819.42,
+          "p95": 845.81,
+          "max": 845.81,
+          "mean": 819.36
+        },
+        "parentCpuUserMs": {
+          "min": 0.76,
+          "median": 0.88,
+          "p95": 43.79,
+          "max": 43.79,
+          "mean": 16.75
+        },
+        "parentCpuSystemMs": {
+          "min": 2.67,
+          "median": 2.73,
+          "p95": 14.05,
+          "max": 14.05,
+          "mean": 5.38
+        },
+        "internalElapsedMs": {
+          "min": 11,
+          "median": 12,
+          "p95": 13,
+          "max": 13,
+          "mean": 12
+        },
+        "wrapperOverheadMs": {
+          "min": 791.34,
+          "median": 807.94,
+          "p95": 833.81,
+          "max": 833.81,
+          "mean": 807.36
+        }
+      },
+      "resolvedBinary": "npx",
+      "fallowVersion": "3.6.0"
+    },
+    {
+      "key": "processing/no-findings",
+      "category": "processing",
+      "scenario": "no-findings",
+      "cold": {
+        "wallMs": 1.61,
+        "parentCpuUserMs": 1.56,
+        "parentCpuSystemMs": 0.15,
+        "outputBytes": 1012
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 1.61,
+          "median": 1.61,
+          "p95": 1.61,
+          "max": 1.61,
+          "mean": 1.61
+        },
+        "parentCpuUserMs": {
+          "min": 1.56,
+          "median": 1.56,
+          "p95": 1.56,
+          "max": 1.56,
+          "mean": 1.56
+        },
+        "parentCpuSystemMs": {
+          "min": 0.15,
+          "median": 0.15,
+          "p95": 0.15,
+          "max": 0.15,
+          "mean": 0.15
+        },
+        "outputBytes": {
+          "min": 1012,
+          "median": 1012,
+          "p95": 1012,
+          "max": 1012,
+          "mean": 1012
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 0.1,
+          "median": 0.16,
+          "p95": 0.43,
+          "max": 0.43,
+          "mean": 0.18
+        },
+        "parentCpuUserMs": {
+          "min": 0.07,
+          "median": 0.11,
+          "p95": 0.51,
+          "max": 0.51,
+          "mean": 0.16
+        },
+        "parentCpuSystemMs": {
+          "min": 0.05,
+          "median": 0.06,
+          "p95": 0.13,
+          "max": 0.13,
+          "mean": 0.07
+        },
+        "outputBytes": {
+          "min": 1012,
+          "median": 1012,
+          "p95": 1012,
+          "max": 1012,
+          "mean": 1012
+        }
+      }
+    },
+    {
+      "key": "processing/small-findings",
+      "category": "processing",
+      "scenario": "small-findings",
+      "cold": {
+        "wallMs": 0.43,
+        "parentCpuUserMs": 0.42,
+        "parentCpuSystemMs": 0.07,
+        "outputBytes": 4118
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 0.43,
+          "median": 0.43,
+          "p95": 0.43,
+          "max": 0.43,
+          "mean": 0.43
+        },
+        "parentCpuUserMs": {
+          "min": 0.42,
+          "median": 0.42,
+          "p95": 0.42,
+          "max": 0.42,
+          "mean": 0.42
+        },
+        "parentCpuSystemMs": {
+          "min": 0.07,
+          "median": 0.07,
+          "p95": 0.07,
+          "max": 0.07,
+          "mean": 0.07
+        },
+        "outputBytes": {
+          "min": 4118,
+          "median": 4118,
+          "p95": 4118,
+          "max": 4118,
+          "mean": 4118
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 0.12,
+          "median": 0.14,
+          "p95": 0.3,
+          "max": 0.3,
+          "mean": 0.16
+        },
+        "parentCpuUserMs": {
+          "min": 0.08,
+          "median": 0.11,
+          "p95": 0.46,
+          "max": 0.46,
+          "mean": 0.16
+        },
+        "parentCpuSystemMs": {
+          "min": 0.04,
+          "median": 0.05,
+          "p95": 0.08,
+          "max": 0.08,
+          "mean": 0.05
+        },
+        "outputBytes": {
+          "min": 4118,
+          "median": 4118,
+          "p95": 4118,
+          "max": 4118,
+          "mean": 4118
+        }
+      }
+    },
+    {
+      "key": "processing/medium-findings",
+      "category": "processing",
+      "scenario": "medium-findings",
+      "cold": {
+        "wallMs": 0.31,
+        "parentCpuUserMs": 0.26,
+        "parentCpuSystemMs": 0.06,
+        "outputBytes": 26482
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 0.31,
+          "median": 0.31,
+          "p95": 0.31,
+          "max": 0.31,
+          "mean": 0.31
+        },
+        "parentCpuUserMs": {
+          "min": 0.26,
+          "median": 0.26,
+          "p95": 0.26,
+          "max": 0.26,
+          "mean": 0.26
+        },
+        "parentCpuSystemMs": {
+          "min": 0.06,
+          "median": 0.06,
+          "p95": 0.06,
+          "max": 0.06,
+          "mean": 0.06
+        },
+        "outputBytes": {
+          "min": 26482,
+          "median": 26482,
+          "p95": 26482,
+          "max": 26482,
+          "mean": 26482
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 0.19,
+          "median": 0.26,
+          "p95": 0.38,
+          "max": 0.38,
+          "mean": 0.28
+        },
+        "parentCpuUserMs": {
+          "min": 0.15,
+          "median": 0.24,
+          "p95": 1.03,
+          "max": 1.03,
+          "mean": 0.33
+        },
+        "parentCpuSystemMs": {
+          "min": 0.05,
+          "median": 0.07,
+          "p95": 0.14,
+          "max": 0.14,
+          "mean": 0.08
+        },
+        "outputBytes": {
+          "min": 26482,
+          "median": 26482,
+          "p95": 26482,
+          "max": 26482,
+          "mean": 26482
+        }
+      }
+    },
+    {
+      "key": "processing/large-findings",
+      "category": "processing",
+      "scenario": "large-findings",
+      "cold": {
+        "wallMs": 2.64,
+        "parentCpuUserMs": 2.02,
+        "parentCpuSystemMs": 0.55,
+        "outputBytes": 51781
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 2.64,
+          "median": 2.64,
+          "p95": 2.64,
+          "max": 2.64,
+          "mean": 2.64
+        },
+        "parentCpuUserMs": {
+          "min": 2.02,
+          "median": 2.02,
+          "p95": 2.02,
+          "max": 2.02,
+          "mean": 2.02
+        },
+        "parentCpuSystemMs": {
+          "min": 0.55,
+          "median": 0.55,
+          "p95": 0.55,
+          "max": 0.55,
+          "mean": 0.55
+        },
+        "outputBytes": {
+          "min": 51781,
+          "median": 51781,
+          "p95": 51781,
+          "max": 51781,
+          "mean": 51781
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 1.16,
+          "median": 1.45,
+          "p95": 2.14,
+          "max": 2.14,
+          "mean": 1.51
+        },
+        "parentCpuUserMs": {
+          "min": 0.89,
+          "median": 1.02,
+          "p95": 2.08,
+          "max": 2.08,
+          "mean": 1.13
+        },
+        "parentCpuSystemMs": {
+          "min": 0.3,
+          "median": 0.4,
+          "p95": 0.6,
+          "max": 0.6,
+          "mean": 0.41
+        },
+        "outputBytes": {
+          "min": 51781,
+          "median": 51781,
+          "p95": 51781,
+          "max": 51781,
+          "mean": 51781
+        }
+      }
+    },
+    {
+      "key": "processing/schema",
+      "category": "processing",
+      "scenario": "schema",
+      "cold": {
+        "wallMs": 3.64,
+        "parentCpuUserMs": 2.64,
+        "parentCpuSystemMs": 0.66,
+        "outputBytes": 51608
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 3.64,
+          "median": 3.64,
+          "p95": 3.64,
+          "max": 3.64,
+          "mean": 3.64
+        },
+        "parentCpuUserMs": {
+          "min": 2.64,
+          "median": 2.64,
+          "p95": 2.64,
+          "max": 2.64,
+          "mean": 2.64
+        },
+        "parentCpuSystemMs": {
+          "min": 0.66,
+          "median": 0.66,
+          "p95": 0.66,
+          "max": 0.66,
+          "mean": 0.66
+        },
+        "outputBytes": {
+          "min": 51608,
+          "median": 51608,
+          "p95": 51608,
+          "max": 51608,
+          "mean": 51608
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 2.74,
+          "median": 2.93,
+          "p95": 3.9,
+          "max": 3.9,
+          "mean": 3.12
+        },
+        "parentCpuUserMs": {
+          "min": 2.41,
+          "median": 2.63,
+          "p95": 16.98,
+          "max": 16.98,
+          "mean": 3.91
+        },
+        "parentCpuSystemMs": {
+          "min": 0.36,
+          "median": 0.45,
+          "p95": 1.03,
+          "max": 1.03,
+          "mean": 0.53
+        },
+        "outputBytes": {
+          "min": 51608,
+          "median": 51608,
+          "p95": 51608,
+          "max": 51608,
+          "mean": 51608
+        }
+      }
+    },
+    {
+      "key": "git/autocomplete-refs",
+      "category": "git",
+      "scenario": "autocomplete-refs",
+      "cold": {
+        "wallMs": 14.13,
+        "parentCpuUserMs": 1.19,
+        "parentCpuSystemMs": 1.08
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 12.12,
+          "median": 12.88,
+          "p95": 16.28,
+          "max": 16.28,
+          "mean": 13.59
+        },
+        "parentCpuUserMs": {
+          "min": 0.35,
+          "median": 0.42,
+          "p95": 1.19,
+          "max": 1.19,
+          "mean": 0.52
+        },
+        "parentCpuSystemMs": {
+          "min": 0.96,
+          "median": 1.06,
+          "p95": 1.2,
+          "max": 1.2,
+          "mean": 1.07
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 0.01,
+          "median": 0.01,
+          "p95": 0.06,
+          "max": 0.06,
+          "mean": 0.01
+        },
+        "parentCpuUserMs": {
+          "min": 0.01,
+          "median": 0.01,
+          "p95": 0.15,
+          "max": 0.15,
+          "mean": 0.02
+        },
+        "parentCpuSystemMs": {
+          "min": 0,
+          "median": 0,
+          "p95": 0.02,
+          "max": 0.02,
+          "mean": 0
+        }
+      },
+      "eventLoopBlockedMs": {
+        "min": 12.12,
+        "median": 12.88,
+        "p95": 16.28,
+        "max": 16.28,
+        "mean": 13.59
+      },
+      "subprocessesPerColdInvocation": 1
+    },
+    {
+      "key": "git/base-detection",
+      "category": "git",
+      "scenario": "base-detection",
+      "cold": {
+        "wallMs": 37.03,
+        "parentCpuUserMs": 2.64,
+        "parentCpuSystemMs": 3.37
+      },
+      "coldStats": {
+        "wallMs": {
+          "min": 37.03,
+          "median": 37.03,
+          "p95": 37.03,
+          "max": 37.03,
+          "mean": 37.03
+        },
+        "parentCpuUserMs": {
+          "min": 2.64,
+          "median": 2.64,
+          "p95": 2.64,
+          "max": 2.64,
+          "mean": 2.64
+        },
+        "parentCpuSystemMs": {
+          "min": 3.37,
+          "median": 3.37,
+          "p95": 3.37,
+          "max": 3.37,
+          "mean": 3.37
+        }
+      },
+      "warm": {
+        "wallMs": {
+          "min": 33.02,
+          "median": 34.46,
+          "p95": 36.11,
+          "max": 36.11,
+          "mean": 34.46
+        },
+        "parentCpuUserMs": {
+          "min": 1.21,
+          "median": 1.38,
+          "p95": 1.77,
+          "max": 1.77,
+          "mean": 1.43
+        },
+        "parentCpuSystemMs": {
+          "min": 2.81,
+          "median": 2.98,
+          "p95": 3.13,
+          "max": 3.13,
+          "mean": 2.98
+        }
+      },
+      "subprocessesPerInvocation": 3
+    },
+    {
+      "key": "memory/small-findings",
+      "category": "memory",
+      "scenario": "small-findings",
+      "fixtureBytes": 3719,
+      "retained": {
+        "rssBytes": {
+          "min": 49152,
+          "median": 65536,
+          "p95": 98304,
+          "max": 98304,
+          "mean": 70997.33
+        },
+        "heapUsedBytes": {
+          "min": 89688,
+          "median": 89688,
+          "p95": 89688,
+          "max": 89688,
+          "mean": 89688
+        },
+        "externalBytes": {
+          "min": 240,
+          "median": 240,
+          "p95": 240,
+          "max": 240,
+          "mean": 240
+        },
+        "arrayBuffersBytes": {
+          "min": 200,
+          "median": 200,
+          "p95": 200,
+          "max": 200,
+          "mean": 200
+        }
+      },
+      "afterRelease": {
+        "rssBytes": {
+          "min": 49152,
+          "median": 98304,
+          "p95": 98304,
+          "max": 98304,
+          "mean": 81920
+        },
+        "heapUsedBytes": {
+          "min": 95416,
+          "median": 95416,
+          "p95": 95416,
+          "max": 95416,
+          "mean": 95416
+        },
+        "externalBytes": {
+          "min": 240,
+          "median": 240,
+          "p95": 240,
+          "max": 240,
+          "mean": 240
+        },
+        "arrayBuffersBytes": {
+          "min": 200,
+          "median": 200,
+          "p95": 200,
+          "max": 200,
+          "mean": 200
+        }
+      },
+      "maxRssBytes": {
+        "min": 196083712,
+        "median": 198344704,
+        "p95": 199442432,
+        "max": 199442432,
+        "mean": 197956949.33
+      },
+      "retainedHeapAmplification": 24.12
+    },
+    {
+      "key": "memory/medium-findings",
+      "category": "memory",
+      "scenario": "medium-findings",
+      "fixtureBytes": 26081,
+      "retained": {
+        "rssBytes": {
+          "min": 114688,
+          "median": 180224,
+          "p95": 196608,
+          "max": 196608,
+          "mean": 163840
+        },
+        "heapUsedBytes": {
+          "min": 157192,
+          "median": 157192,
+          "p95": 157192,
+          "max": 157192,
+          "mean": 157192
+        },
+        "externalBytes": {
+          "min": 240,
+          "median": 240,
+          "p95": 240,
+          "max": 240,
+          "mean": 240
+        },
+        "arrayBuffersBytes": {
+          "min": 200,
+          "median": 200,
+          "p95": 200,
+          "max": 200,
+          "mean": 200
+        }
+      },
+      "afterRelease": {
+        "rssBytes": {
+          "min": 131072,
+          "median": 180224,
+          "p95": 212992,
+          "max": 212992,
+          "mean": 174762.67
+        },
+        "heapUsedBytes": {
+          "min": 157488,
+          "median": 157488,
+          "p95": 157488,
+          "max": 157488,
+          "mean": 157488
+        },
+        "externalBytes": {
+          "min": 240,
+          "median": 240,
+          "p95": 240,
+          "max": 240,
+          "mean": 240
+        },
+        "arrayBuffersBytes": {
+          "min": 200,
+          "median": 200,
+          "p95": 200,
+          "max": 200,
+          "mean": 200
+        }
+      },
+      "maxRssBytes": {
+        "min": 197902336,
+        "median": 197935104,
+        "p95": 199213056,
+        "max": 199213056,
+        "mean": 198350165.33
+      },
+      "retainedHeapAmplification": 6.03
+    },
+    {
+      "key": "memory/large-findings",
+      "category": "memory",
+      "scenario": "large-findings",
+      "fixtureBytes": 144414,
+      "retained": {
+        "rssBytes": {
+          "min": 114688,
+          "median": 245760,
+          "p95": 311296,
+          "max": 311296,
+          "mean": 223914.67
+        },
+        "heapUsedBytes": {
+          "min": 350392,
+          "median": 350392,
+          "p95": 350408,
+          "max": 350408,
+          "mean": 350397.33
+        },
+        "externalBytes": {
+          "min": 40,
+          "median": 40,
+          "p95": 40,
+          "max": 40,
+          "mean": 40
+        },
+        "arrayBuffersBytes": {
+          "min": 0,
+          "median": 0,
+          "p95": 0,
+          "max": 0,
+          "mean": 0
+        }
+      },
+      "afterRelease": {
+        "rssBytes": {
+          "min": 114688,
+          "median": 245760,
+          "p95": 311296,
+          "max": 311296,
+          "mean": 223914.67
+        },
+        "heapUsedBytes": {
+          "min": 350672,
+          "median": 350672,
+          "p95": 350688,
+          "max": 350688,
+          "mean": 350677.33
+        },
+        "externalBytes": {
+          "min": 40,
+          "median": 40,
+          "p95": 40,
+          "max": 40,
+          "mean": 40
+        },
+        "arrayBuffersBytes": {
+          "min": 0,
+          "median": 0,
+          "p95": 0,
+          "max": 0,
+          "mean": 0
+        }
+      },
+      "maxRssBytes": {
+        "min": 197640192,
+        "median": 198770688,
+        "p95": 198934528,
+        "max": 198934528,
+        "mean": 198448469.33
+      },
+      "retainedHeapAmplification": 2.43
+    },
+    {
+      "key": "memory/schema",
+      "category": "memory",
+      "scenario": "schema",
+      "fixtureBytes": 181574,
+      "retained": {
+        "rssBytes": {
+          "min": 262144,
+          "median": 294912,
+          "p95": 344064,
+          "max": 344064,
+          "mean": 300373.33
+        },
+        "heapUsedBytes": {
+          "min": 445056,
+          "median": 445056,
+          "p95": 445056,
+          "max": 445056,
+          "mean": 445056
+        },
+        "externalBytes": {
+          "min": 40,
+          "median": 40,
+          "p95": 40,
+          "max": 40,
+          "mean": 40
+        },
+        "arrayBuffersBytes": {
+          "min": 0,
+          "median": 0,
+          "p95": 0,
+          "max": 0,
+          "mean": 0
+        }
+      },
+      "afterRelease": {
+        "rssBytes": {
+          "min": 262144,
+          "median": 311296,
+          "p95": 360448,
+          "max": 360448,
+          "mean": 311296
+        },
+        "heapUsedBytes": {
+          "min": 445336,
+          "median": 445336,
+          "p95": 445336,
+          "max": 445336,
+          "mean": 445336
+        },
+        "externalBytes": {
+          "min": 40,
+          "median": 40,
+          "p95": 40,
+          "max": 40,
+          "mean": 40
+        },
+        "arrayBuffersBytes": {
+          "min": 0,
+          "median": 0,
+          "p95": 0,
+          "max": 0,
+          "mean": 0
+        }
+      },
+      "maxRssBytes": {
+        "min": 199639040,
+        "median": 199737344,
+        "p95": 200589312,
+        "max": 200589312,
+        "mean": 199988565.33
+      },
+      "retainedHeapAmplification": 2.45
+    }
+  ],
+  "findings": {
+    "runner": {
+      "fixtureDirectWarmMedianMs": 36.56,
+      "deterministicFallbackWarmMedianMs": 31.02,
+      "fallowVersion": "3.6.0",
+      "directFallowWarmMedianMs": 124.72,
+      "npxFallbackWarmMedianMs": 819.42,
+      "npxWrapperOverheadMedianMs": 694.7,
+      "npxToDirectRatio": 6.57
+    },
+    "processing": {
+      "no-findings": {
+        "warmMedianMs": 0.16,
+        "warmP95Ms": 0.43
+      },
+      "small-findings": {
+        "warmMedianMs": 0.14,
+        "warmP95Ms": 0.3
+      },
+      "medium-findings": {
+        "warmMedianMs": 0.26,
+        "warmP95Ms": 0.38
+      },
+      "large-findings": {
+        "warmMedianMs": 1.45,
+        "warmP95Ms": 2.14
+      },
+      "schema": {
+        "warmMedianMs": 2.93,
+        "warmP95Ms": 3.9
+      }
+    },
+    "git": {
+      "autocompleteColdMedianBlockedMs": 12.88,
+      "autocompleteWarmMedianMs": 0.01,
+      "autocompleteGitProcesses": 1,
+      "baseDetectionWarmMedianMs": 34.46,
+      "baseDetectionGitProcesses": 3
+    },
+    "memory": {
+      "small-findings": {
+        "retainedHeapMedianBytes": 89688,
+        "retainedHeapAmplification": 24.12,
+        "maxRssMedianBytes": 198344704
+      },
+      "medium-findings": {
+        "retainedHeapMedianBytes": 157192,
+        "retainedHeapAmplification": 6.03,
+        "maxRssMedianBytes": 197935104
+      },
+      "large-findings": {
+        "retainedHeapMedianBytes": 350392,
+        "retainedHeapAmplification": 2.43,
+        "maxRssMedianBytes": 198770688
+      },
+      "schema": {
+        "retainedHeapMedianBytes": 445056,
+        "retainedHeapAmplification": 2.45,
+        "maxRssMedianBytes": 199737344
+      }
+    }
+  }
+}

--- a/benchmarks/bin/fallow-fixture.mjs
+++ b/benchmarks/bin/fallow-fixture.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+process.stdout.write(JSON.stringify({
+	kind: "dead-code",
+	schema_version: 7,
+	version: "benchmark",
+	elapsed_ms: 1,
+	total_issues: 0,
+	summary: { total_issues: 0 },
+	unused_files: [],
+	unused_exports: [],
+}));

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "coverage": "node -e \"require('node:fs').mkdirSync('coverage',{recursive:true})\" && node --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info",
     "bench:tokens": "node scripts/token-benchmark.mjs",
     "bench:tokens:compare": "node scripts/token-benchmark-compare.mjs",
+    "bench:performance": "node scripts/performance-benchmark.mjs",
+    "bench:performance:compare": "node scripts/performance-benchmark-compare.mjs",
     "smoke:fallow": "node scripts/fallow-smoke.mjs",
     "pack:check": "npm pack --dry-run",
     "publish:public": "npm publish --access public"

--- a/scripts/benchmark-utils.mjs
+++ b/scripts/benchmark-utils.mjs
@@ -1,0 +1,55 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export async function writeJsonArtifact(artifact, outputPath) {
+	if (!outputPath) return;
+	const absolutePath = resolve(outputPath);
+	await mkdir(dirname(absolutePath), { recursive: true });
+	await writeFile(absolutePath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+}
+
+export async function readArtifactPair(args, usage) {
+	const [beforePath, afterPath] = args;
+	if (!beforePath || !afterPath) throw new Error(usage);
+	return Promise.all([readJson(beforePath), readJson(afterPath)]);
+}
+
+async function readJson(path) {
+	return JSON.parse(await readFile(resolve(path), "utf8"));
+}
+
+export function indexMeasurements(before, after) {
+	return {
+		beforeByKey: new Map(before.measurements.map((measurement) => [measurement.key, measurement])),
+		afterByKey: new Map(after.measurements.map((measurement) => [measurement.key, measurement])),
+	};
+}
+
+export async function createFallowBenchmarkProject(prefix) {
+	const cwd = await mkdtemp(join(tmpdir(), prefix));
+	await populateFallowProject(cwd);
+	return cwd;
+}
+
+export async function populateFallowProject(cwd) {
+	await mkdir(join(cwd, ".fallow"), { recursive: true });
+	await writeFile(join(cwd, ".fallowrc.json"), "{}\n", "utf8");
+	await writeFile(join(cwd, ".fallow", "cache.bin"), "benchmark", "utf8");
+}
+
+export function runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd }) {
+	return fallowEngine.runFallowWithExecutor({
+		pi: {},
+		cwd,
+		args: scenario.args,
+		signal: undefined,
+		timeoutSecs: 120,
+		throwOnExecutionError: false,
+		executor: async (_pi, args) => ({
+			binary: "fallow",
+			args,
+			result: { stdout: fixtureText, stderr: "", code: scenario.exitCode, killed: false },
+		}),
+	});
+}

--- a/scripts/performance-benchmark-compare.mjs
+++ b/scripts/performance-benchmark-compare.mjs
@@ -1,0 +1,86 @@
+import { indexMeasurements, readArtifactPair } from "./benchmark-utils.mjs";
+
+const [before, after] = await readArtifactPair(
+	process.argv.slice(2),
+	"Usage: node scripts/performance-benchmark-compare.mjs <before.json> <after.json>",
+);
+validateComparable(before, after);
+warnForEnvironmentChanges(before.environment, after.environment);
+
+const { beforeByKey, afterByKey } = indexMeasurements(before, after);
+const timingRows = [];
+const memoryRows = [];
+
+for (const key of [...beforeByKey.keys()].sort()) {
+	const left = beforeByKey.get(key);
+	const right = afterByKey.get(key);
+	if (!right) continue;
+	if (left.category === "memory") memoryRows.push(compareMemory(key, left, right));
+	else timingRows.push(compareTiming(key, left, right));
+}
+
+console.log(`Pi Fallow performance comparison`);
+console.log(`Before: ${before.label} (${before.environment.gitSha})`);
+console.log(`After:  ${after.label} (${after.environment.gitSha})`);
+console.log("Warm timing (lower is better):");
+console.table(timingRows);
+console.log("Retained heap (lower is better):");
+console.table(memoryRows);
+
+function compareTiming(key, beforeValue, afterValue) {
+	const beforeMedian = beforeValue.warm.wallMs.median;
+	const afterMedian = afterValue.warm.wallMs.median;
+	return {
+		key,
+		beforeMedianMs: beforeMedian,
+		afterMedianMs: afterMedian,
+		deltaMs: signed(round(afterMedian - beforeMedian)),
+		reduction: formatPercent(reductionPct(beforeMedian, afterMedian)),
+		beforeP95Ms: beforeValue.warm.wallMs.p95,
+		afterP95Ms: afterValue.warm.wallMs.p95,
+	};
+}
+
+function compareMemory(key, beforeValue, afterValue) {
+	const beforeHeap = beforeValue.retained.heapUsedBytes.median;
+	const afterHeap = afterValue.retained.heapUsedBytes.median;
+	return {
+		key,
+		beforeHeapKB: round(beforeHeap / 1024),
+		afterHeapKB: round(afterHeap / 1024),
+		deltaKB: signed(round((afterHeap - beforeHeap) / 1024)),
+		reduction: formatPercent(reductionPct(beforeHeap, afterHeap)),
+		beforeAmplification: beforeValue.retainedHeapAmplification,
+		afterAmplification: afterValue.retainedHeapAmplification,
+	};
+}
+
+function validateComparable(left, right) {
+	const mismatches = [
+		["benchmarkVersion", left.benchmarkVersion, right.benchmarkVersion],
+		["config", JSON.stringify(left.config), JSON.stringify(right.config)],
+	].filter(([, beforeValue, afterValue]) => beforeValue !== afterValue);
+	if (mismatches.length) throw new Error(`Incompatible performance artifacts: ${mismatches.map(([name]) => name).join(", ")}`);
+}
+
+function warnForEnvironmentChanges(left, right) {
+	const fields = ["node", "platform", "arch", "cpuModel", "logicalCpuCount"];
+	const changes = fields.filter((field) => left[field] !== right[field]);
+	if (changes.length) console.warn(`Warning: environment differs for ${changes.join(", ")}; timing comparisons may be noisy.`);
+}
+
+function reductionPct(beforeValue, afterValue) {
+	return beforeValue ? (beforeValue - afterValue) / beforeValue * 100 : 0;
+}
+
+function formatPercent(value) {
+	return `${value.toFixed(2)}%`;
+}
+
+function signed(value) {
+	return value > 0 ? `+${value}` : String(value);
+}
+
+function round(value) {
+	return Math.round(value * 100) / 100;
+}

--- a/scripts/performance-benchmark.mjs
+++ b/scripts/performance-benchmark.mjs
@@ -1,0 +1,549 @@
+import { execFile, execFileSync } from "node:child_process";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { cpus, tmpdir, totalmem } from "node:os";
+import { delimiter, dirname, join, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { createJiti } from "jiti";
+import { populateFallowProject, runFixtureEngine, writeJsonArtifact } from "./benchmark-utils.mjs";
+
+const execFileAsync = promisify(execFile);
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const FIXTURE_BIN = join(ROOT, "benchmarks", "bin", "fallow-fixture.mjs");
+const MEMORY_WORKER = join(ROOT, "scripts", "performance-memory-worker.mjs");
+const DEFAULT_CONFIG = { warmups: 3, iterations: 15, gitColdIterations: 8, memoryIterations: 3, systemRunnerIterations: 5 };
+const PROCESSING_SCENARIOS = ["no-findings", "small-findings", "medium-findings", "large-findings", "schema"];
+const MEMORY_SCENARIOS = ["small-findings", "medium-findings", "large-findings", "schema"];
+const CLI_OPTION_SETTERS = {
+	"--label": (options, value) => { options.label = value; },
+	"--output": (options, value) => { options.output = value; },
+	"--iterations": (options, value) => { options.config.iterations = parsePositiveInteger(value, "--iterations"); },
+	"--warmups": (options, value) => { options.config.warmups = parsePositiveInteger(value, "--warmups", true); },
+	"--memory-iterations": (options, value) => { options.config.memoryIterations = parsePositiveInteger(value, "--memory-iterations"); },
+};
+const jiti = createJiti(import.meta.url);
+
+const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
+const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
+const { fallowCompletions } = await jiti.import("../extensions/fallow/autocomplete.ts");
+const { detectFallowGitState } = await jiti.import("../extensions/fallow/project/git.ts");
+
+const cli = parseCli(process.argv.slice(2));
+const packageJson = JSON.parse(await readFile(join(ROOT, "package.json"), "utf8"));
+const corpus = JSON.parse(await readFile(join(ROOT, "benchmarks", "corpus.json"), "utf8"));
+const fixtureById = new Map(corpus.scenarios.map((scenario) => [scenario.id, scenario]));
+const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-performance-"));
+const measurements = [];
+
+try {
+	measurements.push(...await benchmarkRunners(workspace, cli.config));
+	measurements.push(...await benchmarkProcessing(workspace, cli.config));
+	measurements.push(...await benchmarkGit(workspace, cli.config));
+	measurements.push(...await benchmarkMemory(cli.config));
+} finally {
+	process.chdir(ROOT);
+	await rm(workspace, { recursive: true, force: true });
+}
+
+const artifact = {
+	benchmarkVersion: 1,
+	label: cli.label,
+	generatedAt: new Date().toISOString(),
+	config: cli.config,
+	environment: buildEnvironment(packageJson),
+	measurements,
+	findings: buildPerformanceFindings(measurements),
+};
+
+await writeJsonArtifact(artifact, cli.output);
+printSummary(artifact, cli.output);
+
+function parseCli(args) {
+	const options = { label: "working-tree", output: undefined, config: { ...DEFAULT_CONFIG } };
+	for (let index = 0; index < args.length; index += 2) {
+		const flag = args[index];
+		const setter = CLI_OPTION_SETTERS[flag];
+		if (!setter) throw new Error(`Unknown argument: ${flag}`);
+		setter(options, requireValue(args, index + 1, flag));
+	}
+	return options;
+}
+
+function requireValue(args, index, flag) {
+	const value = args[index];
+	if (!value) throw new Error(`${flag} requires a value.`);
+	return value;
+}
+
+function parsePositiveInteger(rawValue, flag, allowZero = false) {
+	const value = Number(rawValue);
+	const minimum = allowZero ? 0 : 1;
+	if (!Number.isInteger(value) || value < minimum) throw new Error(`${flag} must be an integer >= ${minimum}.`);
+	return value;
+}
+
+async function benchmarkRunners(workspacePath, config) {
+	const runnerDir = join(workspacePath, "runner-bin");
+	await mkdir(runnerDir, { recursive: true });
+	const pathFallow = join(runnerDir, "fallow");
+	const pathNpx = join(runnerDir, "npx");
+	await copyExecutable(FIXTURE_BIN, pathFallow);
+	await copyExecutable(FIXTURE_BIN, pathNpx);
+	const originalPath = process.env.PATH;
+	const nodePath = dirname(process.execPath);
+	const fixturePath = [runnerDir, nodePath, "/usr/bin", "/bin"].join(delimiter);
+	await execFileAsync(FIXTURE_BIN, ["dead-code", "--format", "json", "--quiet"]);
+
+	const configured = await withEnvironment({ FALLOW_BIN: FIXTURE_BIN, PATH: originalPath }, () => benchmarkOperation(
+		"runner",
+		"configured-fallow-bin",
+		() => runFallowFixture(),
+		config,
+	));
+	const pathResolved = await withEnvironment({ FALLOW_BIN: undefined, PATH: fixturePath }, () => benchmarkOperation(
+		"runner",
+		"path-fallow",
+		() => runFallowFixture(),
+		config,
+	));
+	const deterministicFallback = await benchmarkNpxFallback(workspacePath, pathNpx, nodePath, config);
+	const systemFallowBinary = resolveSystemFallowBinary(originalPath);
+	const systemDirect = await benchmarkSystemDirect(systemFallowBinary, originalPath, config);
+	const systemResolution = await benchmarkSystemResolution(originalPath, config);
+	return [configured, pathResolved, deterministicFallback, systemDirect, systemResolution];
+}
+
+async function benchmarkNpxFallback(workspacePath, npxFixture, nodePath, config) {
+	const npxOnlyDir = join(workspacePath, "npx-only-bin");
+	await mkdir(npxOnlyDir, { recursive: true });
+	await copyExecutable(npxFixture, join(npxOnlyDir, "npx"));
+	const fallbackPath = [npxOnlyDir, nodePath, "/usr/bin", "/bin"].join(delimiter);
+	return withEnvironment({ FALLOW_BIN: undefined, PATH: fallbackPath }, () => benchmarkOperation(
+		"runner",
+		"npx-fallback-fixture",
+		() => runFallowFixture(),
+		config,
+	));
+}
+
+function resolveSystemFallowBinary(pathValue) {
+	return execFileSync("npm", ["exec", "--yes", "--package=fallow", "--", "which", "fallow"], {
+		cwd: ROOT,
+		env: { ...process.env, PATH: pathValue },
+		encoding: "utf8",
+	}).trim();
+}
+
+async function benchmarkSystemDirect(fallowBinary, pathValue, config) {
+	const systemConfig = { ...config, warmups: 1, iterations: config.systemRunnerIterations };
+	const measurement = await withEnvironment({ FALLOW_BIN: fallowBinary, PATH: pathValue }, () => benchmarkOperation(
+		"runner",
+		"system-direct-fallow",
+		() => runSystemFallow(),
+		systemConfig,
+	));
+	measurement.resolvedBinary = measurement.cold.binary;
+	measurement.fallowVersion = measurement.cold.fallowVersion;
+	return measurement;
+}
+
+async function benchmarkSystemResolution(pathValue, config) {
+	const systemConfig = { ...config, warmups: 1, iterations: config.systemRunnerIterations };
+	const measurement = await withEnvironment({ FALLOW_BIN: undefined, PATH: pathValue }, () => benchmarkOperation(
+		"runner",
+		"system-resolution",
+		() => runSystemFallow(),
+		systemConfig,
+	));
+	measurement.resolvedBinary = measurement.cold.binary;
+	measurement.fallowVersion = measurement.cold.fallowVersion;
+	return measurement;
+}
+
+async function runSystemFallow() {
+	const { result, binary } = await fallowCli.execFallow({}, ["dupes", "--format", "json", "--quiet"], ROOT, undefined, 120);
+	const parsed = JSON.parse(result.stdout);
+	return { internalElapsedMs: parsed.elapsed_ms, binary, fallowVersion: parsed.version };
+}
+
+async function copyExecutable(source, target) {
+	await copyFile(source, target);
+	await chmod(target, 0o755);
+}
+
+async function runFallowFixture() {
+	const { result, binary } = await fallowCli.execFallow({}, ["dead-code", "--format", "json", "--quiet"], ROOT, undefined, 120);
+	const parsed = JSON.parse(result.stdout);
+	return { internalElapsedMs: parsed.elapsed_ms, binary };
+}
+
+async function benchmarkProcessing(workspacePath, config) {
+	const projectDir = join(workspacePath, "processing-project");
+	await populateFallowProject(projectDir);
+	const results = [];
+	for (const scenarioId of PROCESSING_SCENARIOS) {
+		const scenario = fixtureById.get(scenarioId);
+		const fixtureText = await readFile(join(ROOT, "benchmarks", scenario.fixture), "utf8");
+		results.push(await benchmarkOperation(
+			"processing",
+			scenarioId,
+			() => processFixture(scenario, fixtureText, projectDir),
+			config,
+		));
+	}
+	return results;
+}
+
+async function processFixture(scenario, fixtureText, cwd) {
+	const result = await runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd });
+	const fullOutputPath = result.formatted.fullOutputPath;
+	return {
+		outputBytes: Buffer.byteLength(result.content),
+		cleanup: fullOutputPath ? () => rm(dirname(fullOutputPath), { recursive: true, force: true }) : undefined,
+	};
+}
+
+async function benchmarkGit(workspacePath, config) {
+	const sourceRepo = join(workspacePath, "git-source");
+	await createGitRepository(sourceRepo);
+	const autocomplete = await benchmarkAutocomplete(workspacePath, sourceRepo, config);
+	const detection = await benchmarkOperation(
+		"git",
+		"base-detection",
+		() => detectFallowGitState(sourceRepo),
+		config,
+	);
+	const counts = await countGitSubprocesses(workspacePath, sourceRepo);
+	autocomplete.subprocessesPerColdInvocation = counts.autocomplete;
+	detection.subprocessesPerInvocation = counts.baseDetection;
+	return [autocomplete, detection];
+}
+
+async function createGitRepository(cwd) {
+	await mkdir(cwd, { recursive: true });
+	git(cwd, ["init", "-q"]);
+	git(cwd, ["config", "user.email", "benchmark@example.invalid"]);
+	git(cwd, ["config", "user.name", "Pi Fallow Benchmark"]);
+	await writeFile(join(cwd, "index.ts"), "export const benchmark = true;\n", "utf8");
+	git(cwd, ["add", "index.ts"]);
+	git(cwd, ["commit", "-qm", "benchmark"]);
+	git(cwd, ["branch", "-M", "main"]);
+	git(cwd, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+}
+
+function git(cwd, args) {
+	return execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+async function benchmarkAutocomplete(workspacePath, sourceRepo, config) {
+	const repos = [];
+	for (let index = 0; index < config.gitColdIterations; index++) {
+		const target = join(workspacePath, `autocomplete-${index}`);
+		execFileSync("git", ["clone", "-q", "--shared", sourceRepo, target]);
+		repos.push(target);
+	}
+	const originalCwd = process.cwd();
+	const coldSamples = [];
+	try {
+		for (const repo of repos) {
+			process.chdir(repo);
+			coldSamples.push(await measureInvocation(() => completeBaseRef()));
+		}
+		process.chdir(repos[0]);
+		completeBaseRef();
+		const warmSamples = [];
+		for (let index = 0; index < config.iterations; index++) warmSamples.push(await measureInvocation(() => completeBaseRef()));
+		return buildMeasurement("git", "autocomplete-refs", coldSamples[0], coldSamples, warmSamples, {
+			eventLoopBlockedMs: summarize(coldSamples, "wallMs"),
+		});
+	} finally {
+		process.chdir(originalCwd);
+	}
+}
+
+function completeBaseRef() {
+	return fallowCompletions.getFallowArgumentCompletions("audit --base ");
+}
+
+async function countGitSubprocesses(workspacePath, sourceRepo) {
+	const traceDir = join(workspacePath, "git-trace");
+	const logPath = join(traceDir, "calls.log");
+	const wrapperPath = join(traceDir, "git");
+	const actualGit = execFileSync("which", ["git"], { encoding: "utf8" }).trim();
+	await mkdir(traceDir, { recursive: true });
+	await writeFile(wrapperPath, "#!/bin/sh\necho call >> \"$PI_FALLOW_GIT_LOG\"\nexec \"$PI_FALLOW_REAL_GIT\" \"$@\"\n", { mode: 0o755 });
+	const tracedRepo = join(workspacePath, "git-traced-repo");
+	execFileSync(actualGit, ["clone", "-q", "--shared", sourceRepo, tracedRepo]);
+	const tracedPath = [traceDir, process.env.PATH].join(delimiter);
+	return withEnvironment({ PATH: tracedPath, PI_FALLOW_GIT_LOG: logPath, PI_FALLOW_REAL_GIT: actualGit }, async () => {
+		const originalCwd = process.cwd();
+		try {
+			process.chdir(tracedRepo);
+			completeBaseRef();
+			const autocomplete = await countLogLines(logPath);
+			await detectFallowGitState(tracedRepo);
+			const total = await countLogLines(logPath);
+			return { autocomplete, baseDetection: total - autocomplete };
+		} finally {
+			process.chdir(originalCwd);
+		}
+	});
+}
+
+async function countLogLines(path) {
+	try {
+		const text = await readFile(path, "utf8");
+		return text.trim() ? text.trim().split(/\r?\n/).length : 0;
+	} catch {
+		return 0;
+	}
+}
+
+async function benchmarkMemory(config) {
+	const results = [];
+	for (const scenarioId of MEMORY_SCENARIOS) {
+		const scenario = fixtureById.get(scenarioId);
+		const fixturePath = join(ROOT, "benchmarks", scenario.fixture);
+		const samples = [];
+		for (let index = 0; index < config.memoryIterations; index++) samples.push(await runMemoryWorker(fixturePath));
+		results.push(buildMemoryMeasurement(scenarioId, samples));
+	}
+	return results;
+}
+
+async function runMemoryWorker(fixturePath) {
+	const { stdout } = await execFileAsync(process.execPath, ["--expose-gc", MEMORY_WORKER, fixturePath], {
+		cwd: ROOT,
+		maxBuffer: 10 * 1024 * 1024,
+	});
+	return JSON.parse(stdout);
+}
+
+function buildMemoryMeasurement(scenario, samples) {
+	const fixtureBytes = samples[0].fixtureBytes;
+	const retainedHeap = samples.map((sample) => sample.deltaWhileRetained.heapUsedBytes);
+	return {
+		key: `memory/${scenario}`,
+		category: "memory",
+		scenario,
+		fixtureBytes,
+		retained: memoryStats(samples, "deltaWhileRetained"),
+		afterRelease: memoryStats(samples, "deltaAfterRelease"),
+		maxRssBytes: aggregate(samples.map((sample) => sample.maxRssBytes)),
+		retainedHeapAmplification: round(aggregate(retainedHeap).median / fixtureBytes),
+	};
+}
+
+function memoryStats(samples, field) {
+	const keys = ["rssBytes", "heapUsedBytes", "externalBytes", "arrayBuffersBytes"];
+	return Object.fromEntries(keys.map((key) => [key, aggregate(samples.map((sample) => sample[field][key]))]));
+}
+
+async function benchmarkOperation(category, scenario, operation, config) {
+	const cold = await measureInvocation(operation);
+	for (let index = 0; index < config.warmups; index++) await measureInvocation(operation);
+	const warmSamples = [];
+	for (let index = 0; index < config.iterations; index++) warmSamples.push(await measureInvocation(operation));
+	return buildMeasurement(category, scenario, cold, [cold], warmSamples);
+}
+
+async function measureInvocation(operation) {
+	const cpuStart = process.cpuUsage();
+	const wallStart = performance.now();
+	const observation = asObservation(await operation());
+	const wallMs = performance.now() - wallStart;
+	const cpu = process.cpuUsage(cpuStart);
+	await cleanupObservation(observation);
+	return buildInvocationResult(observation, wallMs, cpu);
+}
+
+function asObservation(value) {
+	return value && typeof value === "object" ? value : {};
+}
+
+async function cleanupObservation(observation) {
+	if (typeof observation.cleanup === "function") await observation.cleanup();
+}
+
+function buildInvocationResult(observation, wallMs, cpu) {
+	return {
+		wallMs: round(wallMs),
+		parentCpuUserMs: round(cpu.user / 1000),
+		parentCpuSystemMs: round(cpu.system / 1000),
+		internalElapsedMs: observation.internalElapsedMs,
+		wrapperOverheadMs: wrapperOverhead(wallMs, observation.internalElapsedMs),
+		outputBytes: observation.outputBytes,
+		binary: observation.binary,
+		fallowVersion: observation.fallowVersion,
+	};
+}
+
+function wrapperOverhead(wallMs, internalElapsedMs) {
+	return internalElapsedMs === undefined ? undefined : round(wallMs - internalElapsedMs);
+}
+
+function buildMeasurement(category, scenario, cold, coldSamples, warmSamples, extra = {}) {
+	return {
+		key: `${category}/${scenario}`,
+		category,
+		scenario,
+		cold,
+		coldStats: summarizeSamples(coldSamples),
+		warm: summarizeSamples(warmSamples),
+		...extra,
+	};
+}
+
+function summarizeSamples(samples) {
+	const fields = ["wallMs", "parentCpuUserMs", "parentCpuSystemMs", "internalElapsedMs", "wrapperOverheadMs", "outputBytes"];
+	return Object.fromEntries(fields.flatMap((field) => {
+		const values = samples.map((sample) => sample[field]).filter((value) => value !== undefined);
+		return values.length ? [[field, aggregate(values)]] : [];
+	}));
+}
+
+function summarize(samples, field) {
+	return aggregate(samples.map((sample) => sample[field]));
+}
+
+function aggregate(values) {
+	const sorted = [...values].sort((left, right) => left - right);
+	return {
+		min: round(sorted[0] ?? 0),
+		median: round(percentile(sorted, 0.5)),
+		p95: round(percentile(sorted, 0.95)),
+		max: round(sorted.at(-1) ?? 0),
+		mean: round(sorted.reduce((sum, value) => sum + value, 0) / Math.max(1, sorted.length)),
+	};
+}
+
+function percentile(sorted, value) {
+	if (!sorted.length) return 0;
+	return sorted[Math.min(sorted.length - 1, Math.ceil(sorted.length * value) - 1)];
+}
+
+async function withEnvironment(values, operation) {
+	const previous = Object.fromEntries(Object.keys(values).map((key) => [key, process.env[key]]));
+	applyEnvironment(values);
+	try {
+		return await operation();
+	} finally {
+		applyEnvironment(previous);
+	}
+}
+
+function applyEnvironment(values) {
+	for (const [key, value] of Object.entries(values)) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+}
+
+function buildEnvironment(manifest) {
+	const cpu = cpus()[0];
+	return {
+		piFallowVersion: manifest.version,
+		gitSha: readGitSha(),
+		node: process.version,
+		platform: process.platform,
+		arch: process.arch,
+		cpuModel: cpu?.model ?? "unknown",
+		logicalCpuCount: cpus().length,
+		totalMemoryBytes: totalmem(),
+	};
+}
+
+function readGitSha() {
+	try {
+		return execFileSync("git", ["rev-parse", "HEAD"], { cwd: ROOT, encoding: "utf8" }).trim();
+	} catch {
+		return "unknown";
+	}
+}
+
+function buildPerformanceFindings(items) {
+	const byKey = new Map(items.map((item) => [item.key, item]));
+	return {
+		runner: runnerFinding(byKey),
+		processing: processingFinding(byKey),
+		git: gitFinding(byKey),
+		memory: memoryFinding(byKey),
+	};
+}
+
+function runnerFinding(byKey) {
+	const fixtureDirect = byKey.get("runner/configured-fallow-bin");
+	const deterministicFallback = byKey.get("runner/npx-fallback-fixture");
+	const systemDirect = byKey.get("runner/system-direct-fallow");
+	const systemResolution = byKey.get("runner/system-resolution");
+	return {
+		fixtureDirectWarmMedianMs: fixtureDirect.warm.wallMs.median,
+		deterministicFallbackWarmMedianMs: deterministicFallback.warm.wallMs.median,
+		fallowVersion: systemResolution.fallowVersion,
+		directFallowWarmMedianMs: systemDirect.warm.wallMs.median,
+		npxFallbackWarmMedianMs: systemResolution.warm.wallMs.median,
+		npxWrapperOverheadMedianMs: round(systemResolution.warm.wallMs.median - systemDirect.warm.wallMs.median),
+		npxToDirectRatio: round(systemResolution.warm.wallMs.median / systemDirect.warm.wallMs.median),
+	};
+}
+
+function processingFinding(byKey) {
+	return Object.fromEntries(PROCESSING_SCENARIOS.map((scenario) => {
+		const item = byKey.get(`processing/${scenario}`);
+		return [scenario, { warmMedianMs: item.warm.wallMs.median, warmP95Ms: item.warm.wallMs.p95 }];
+	}));
+}
+
+function gitFinding(byKey) {
+	const autocomplete = byKey.get("git/autocomplete-refs");
+	const detection = byKey.get("git/base-detection");
+	return {
+		autocompleteColdMedianBlockedMs: autocomplete.eventLoopBlockedMs.median,
+		autocompleteWarmMedianMs: autocomplete.warm.wallMs.median,
+		autocompleteGitProcesses: autocomplete.subprocessesPerColdInvocation,
+		baseDetectionWarmMedianMs: detection.warm.wallMs.median,
+		baseDetectionGitProcesses: detection.subprocessesPerInvocation,
+	};
+}
+
+function memoryFinding(byKey) {
+	return Object.fromEntries(MEMORY_SCENARIOS.map((scenario) => {
+		const item = byKey.get(`memory/${scenario}`);
+		return [scenario, {
+			retainedHeapMedianBytes: item.retained.heapUsedBytes.median,
+			retainedHeapAmplification: item.retainedHeapAmplification,
+			maxRssMedianBytes: item.maxRssBytes.median,
+		}];
+	}));
+}
+
+function printSummary(artifactValue, outputPath) {
+	const timingRows = artifactValue.measurements
+		.filter((item) => item.category !== "memory")
+		.map((item) => ({
+			key: item.key,
+			coldMs: item.coldStats.wallMs.median,
+			warmMedianMs: item.warm.wallMs.median,
+			warmP95Ms: item.warm.wallMs.p95,
+			processes: item.subprocessesPerInvocation ?? item.subprocessesPerColdInvocation ?? "",
+		}));
+	const memoryRows = artifactValue.measurements
+		.filter((item) => item.category === "memory")
+		.map((item) => ({
+			key: item.key,
+			fixtureKB: round(item.fixtureBytes / 1024),
+			retainedHeapKB: round(item.retained.heapUsedBytes.median / 1024),
+			amplification: item.retainedHeapAmplification,
+			maxRssMB: round(item.maxRssBytes.median / 1024 / 1024),
+		}));
+	console.log(`Pi Fallow performance benchmark: ${artifactValue.label}`);
+	console.log(`${artifactValue.environment.platform}/${artifactValue.environment.arch} · ${artifactValue.environment.cpuModel}`);
+	console.table(timingRows);
+	console.table(memoryRows);
+	if (outputPath) console.log(`Wrote ${resolve(outputPath)}`);
+}
+
+function round(value) {
+	return Math.round(value * 100) / 100;
+}

--- a/scripts/performance-memory-worker.mjs
+++ b/scripts/performance-memory-worker.mjs
@@ -1,0 +1,62 @@
+import { readFile, rm } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { createJiti } from "jiti";
+import { createFallowBenchmarkProject, runFixtureEngine } from "./benchmark-utils.mjs";
+
+const fixtureArg = process.argv[2];
+if (!fixtureArg) throw new Error("A fixture path is required.");
+const fixturePath = resolve(fixtureArg);
+if (typeof global.gc !== "function") throw new Error("Run the memory worker with --expose-gc.");
+
+const jiti = createJiti(import.meta.url);
+const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
+const fixtureText = await readFile(fixturePath, "utf8");
+const projectDir = await createFallowBenchmarkProject("pi-fallow-memory-");
+forceGc();
+const before = memorySnapshot();
+let result = await runFixture(fixtureText, projectDir);
+forceGc();
+const retained = memorySnapshot();
+const fullOutputPath = result.formatted.fullOutputPath;
+result = undefined;
+forceGc();
+const released = memorySnapshot();
+
+await cleanup(projectDir, fullOutputPath);
+process.stdout.write(JSON.stringify({
+	fixtureBytes: Buffer.byteLength(fixtureText),
+	before,
+	retained,
+	released,
+	deltaWhileRetained: memoryDelta(before, retained),
+	deltaAfterRelease: memoryDelta(before, released),
+	maxRssBytes: process.resourceUsage().maxRSS * 1024,
+}));
+
+function runFixture(fixtureText, cwd) {
+	const scenario = { args: ["dead-code", "--format", "json", "--quiet"], exitCode: 0 };
+	return runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd });
+}
+
+function forceGc() {
+	for (let iteration = 0; iteration < 3; iteration++) global.gc();
+}
+
+function memorySnapshot() {
+	const usage = process.memoryUsage();
+	return {
+		rssBytes: usage.rss,
+		heapUsedBytes: usage.heapUsed,
+		externalBytes: usage.external,
+		arrayBuffersBytes: usage.arrayBuffers,
+	};
+}
+
+function memoryDelta(beforeValue, afterValue) {
+	return Object.fromEntries(Object.keys(beforeValue).map((key) => [key, afterValue[key] - beforeValue[key]]));
+}
+
+async function cleanup(projectDir, fullOutputPath) {
+	await rm(projectDir, { recursive: true, force: true });
+	if (fullOutputPath) await rm(dirname(fullOutputPath), { recursive: true, force: true });
+}

--- a/scripts/token-benchmark-compare.mjs
+++ b/scripts/token-benchmark-compare.mjs
@@ -1,18 +1,13 @@
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { indexMeasurements, readArtifactPair } from "./benchmark-utils.mjs";
 
-const [beforePath, afterPath] = process.argv.slice(2);
-if (!beforePath || !afterPath) {
-	throw new Error("Usage: node scripts/token-benchmark-compare.mjs <before.json> <after.json>");
-}
-
-const before = JSON.parse(await readFile(resolve(beforePath), "utf8"));
-const after = JSON.parse(await readFile(resolve(afterPath), "utf8"));
+const [before, after] = await readArtifactPair(
+	process.argv.slice(2),
+	"Usage: node scripts/token-benchmark-compare.mjs <before.json> <after.json>",
+);
 validateComparable(before, after);
 
 const encoding = before.primaryEncoding;
-const beforeByKey = new Map(before.measurements.map((measurement) => [measurement.key, measurement]));
-const afterByKey = new Map(after.measurements.map((measurement) => [measurement.key, measurement]));
+const { beforeByKey, afterByKey } = indexMeasurements(before, after);
 const keys = [...new Set([...beforeByKey.keys(), ...afterByKey.keys()])].sort();
 const rows = [];
 const surfaceTotals = new Map();

--- a/scripts/token-benchmark.mjs
+++ b/scripts/token-benchmark.mjs
@@ -1,12 +1,12 @@
 import { createHash } from "node:crypto";
 import { execFileSync } from "node:child_process";
-import { readFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import { createRequire } from "node:module";
-import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { getEncoding } from "js-tiktoken";
 import { createJiti } from "jiti";
+import { createFallowBenchmarkProject, runFixtureEngine, writeJsonArtifact } from "./benchmark-utils.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const require = createRequire(import.meta.url);
@@ -40,7 +40,7 @@ const corpus = JSON.parse(corpusText);
 const corpusHash = await hashCorpus(corpus, corpusText);
 const contractText = captureToolContract(registerPiFallow);
 const contractMeasurement = measureText("tool-contract", "active", contractText, []);
-const projectDir = await createBenchmarkProject();
+const projectDir = await createFallowBenchmarkProject("pi-fallow-token-project-");
 const measurements = [contractMeasurement];
 
 try {
@@ -73,12 +73,7 @@ const artifact = {
 	aggregates: buildAggregates(measurements),
 };
 
-if (cli.output) {
-	const outputPath = resolve(cli.output);
-	await mkdir(dirname(outputPath), { recursive: true });
-	await writeFile(outputPath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
-}
-
+await writeJsonArtifact(artifact, cli.output);
 printSummary(artifact, cli.output);
 
 function parseCli(args) {
@@ -128,32 +123,12 @@ function captureToolContract(registerExtension) {
 	}, null, 2);
 }
 
-async function createBenchmarkProject() {
-	const cwd = await mkdtemp(join(tmpdir(), "pi-fallow-token-project-"));
-	await mkdir(join(cwd, ".fallow"), { recursive: true });
-	await writeFile(join(cwd, ".fallowrc.json"), "{}\n", "utf8");
-	await writeFile(join(cwd, ".fallow", "cache.bin"), "benchmark", "utf8");
-	return cwd;
-}
-
 async function measureScenario(scenario, cwd, contract) {
 	const fixturePath = join(ROOT, "benchmarks", scenario.fixture);
 	const fixtureText = await readFile(fixturePath, "utf8");
 	const fixtureData = JSON.parse(fixtureText);
 	const findings = collectBenchmarkFindings(fixtureData);
-	const commandResult = await fallowEngine.runFallowWithExecutor({
-		pi: {},
-		cwd,
-		args: scenario.args,
-		signal: undefined,
-		timeoutSecs: 120,
-		throwOnExecutionError: false,
-		executor: async (_pi, args) => ({
-			binary: "fallow",
-			args,
-			result: { stdout: fixtureText, stderr: "", code: scenario.exitCode, killed: false },
-		}),
-	});
+	const commandResult = await runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd });
 
 	const fullOutputPath = commandResult.formatted.fullOutputPath;
 	const normalize = (text) => normalizeFullOutputPath(text, fullOutputPath);

--- a/tests/performance-baseline.test.mjs
+++ b/tests/performance-baseline.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const baseline = JSON.parse(await readFile(join(root, "benchmarks", "baselines", "performance-v0.2.0.json"), "utf8"));
+const byKey = new Map(baseline.measurements.map((measurement) => [measurement.key, measurement]));
+
+describe("performance benchmark baseline", () => {
+	it("records runner, processing, Git, memory, and cold/warm metrics", () => {
+		assert.ok(measurement("runner/system-direct-fallow"));
+		assert.ok(measurement("runner/system-resolution"));
+		assert.ok(measurement("processing/schema"));
+		assert.ok(measurement("git/autocomplete-refs"));
+		assert.ok(measurement("git/base-detection"));
+		assert.ok(measurement("memory/large-findings"));
+		assert.ok(measurement("runner/configured-fallow-bin").coldStats.wallMs.median > 0);
+		assert.ok(measurement("runner/configured-fallow-bin").warm.wallMs.median > 0);
+	});
+
+	it("captures the current runner and Git overhead findings", () => {
+		const direct = measurement("runner/system-direct-fallow");
+		const npx = measurement("runner/system-resolution");
+		assert.equal(npx.resolvedBinary, "npx");
+		assert.ok(npx.warm.wallMs.median > direct.warm.wallMs.median);
+		assert.equal(measurement("git/autocomplete-refs").subprocessesPerColdInvocation, 1);
+		assert.equal(measurement("git/base-detection").subprocessesPerInvocation, 3);
+	});
+
+	it("records retained-memory scaling independently from process RSS", () => {
+		const medium = measurement("memory/medium-findings");
+		const large = measurement("memory/large-findings");
+		assert.ok(large.retained.heapUsedBytes.median > medium.retained.heapUsedBytes.median);
+		assert.ok(large.maxRssBytes.median > 0);
+		assert.ok(Number.isFinite(large.retainedHeapAmplification));
+	});
+});
+
+function measurement(key) {
+	const value = byKey.get(key);
+	assert.ok(value, `Missing performance baseline measurement: ${key}`);
+	return value;
+}


### PR DESCRIPTION
## Summary

   Establishes a reproducible performance baseline before optimizing Pi Fallow’s execution path, Git operations, output processing, or memory retention.

   The benchmark measures five areas:

   1. Runner resolution and process-wrapper overhead.
   2. Extension processing time across report sizes.
   3. Git/autocomplete latency and subprocess counts.
   4. Retained heap, memory amplification, and process RSS.
   5. Cold and warm execution using median and p95 measurements.

   ## Why

   Current observations suggest that runner discovery and npx startup cost substantially more than Fallow analysis itself.

   A frozen baseline lets future optimization PRs show measurable improvements without relying on anecdotal timings. It also distinguishes execution time from parsing, Git, and retained-memory costs.

   ## Baseline findings

   Measured on an Apple M1 Pro with Node.js 24.12.0 and Fallow 3.6.0:

   | Measurement | Before |
   |---|---:|
   | Direct Fallow, warm median | 124.72 ms |
   | Cached npx fallback, warm median | 819.42 ms |
   | Estimated npx overhead | 694.70 ms |
   | npx/direct ratio | 6.57× |
   | Cold autocomplete blocking | 12.88 ms |
   | Warm autocomplete | 0.01 ms |
   | Base-ref detection | 34.46 ms |
   | Git processes per base detection | 3 |
   | Large-report retained heap amplification | 2.43× |
   | Schema retained heap amplification | 2.45× |

   Extension processing remains comparatively inexpensive:

   | Fixture | Warm median | Warm p95 |
   |---|---:|---:|
   | No findings | 0.16 ms | 0.43 ms |
   | 5 findings | 0.14 ms | 0.30 ms |
   | 40 findings | 0.26 ms | 0.38 ms |
   | 300 findings | 1.45 ms | 2.14 ms |
   | Fallow schema | 2.93 ms | 3.90 ms |

   Timings are machine-sensitive and should be compared using the same environment. The comparison script warns when environments differ.

   ## Changes

   - Adds a frozen performance baseline artifact.
   - Adds direct Fallow and npx runner measurements.
   - Adds deterministic runner fixtures.
   - Adds small, medium, large, and schema processing benchmarks.
   - Adds Git autocomplete and base-detection measurements.
   - Records Git subprocess counts.
   - Adds isolated `--expose-gc` memory workers.
   - Records retained and released heap, RSS, and amplification.
   - Adds cold/warm median, p95, maximum, mean, and parent CPU metrics.
   - Adds before/after comparison tooling.
   - Adds regression tests for the baseline structure.
   - Shares common infrastructure with the token benchmark.

   ## Usage

   Generate candidate measurements:

   ```bash
   npm run bench:performance -- \
     --label candidate \
     --output /tmp/pi-fallow-performance-candidate.json