### PR TITLE
fix: make Fallow execution cancellation reliable

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -2,6 +2,7 @@
   "entry": [
     "extensions/index.ts",
     "tests/*.test.mjs",
+    "tests/fixtures/*.mjs",
     "scripts/performance-memory-worker.mjs",
     "benchmarks/bin/fallow-fixture.mjs"
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to Pi Fallow are documented here.
 - Raised the minimum Node.js version to 22.19 to match the current Pi peer packages.
 - Pinned Fallow, esbuild, and coverage tooling for reproducible development and CI checks.
 
+### Fixed
+- Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.
+
 ## [0.2.0] - 2026-07-01
 
 ### Added

--- a/extensions/fallow.ts
+++ b/extensions/fallow.ts
@@ -28,7 +28,7 @@ function registerFallowTool(pi: ExtensionAPI): void {
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			onUpdate?.({ content: [{ type: "text", text: `Running fallow ${params.command}...` }] });
 			if (signal?.aborted) return { content: [{ type: "text", text: "Cancelled." }], details: {} };
-			return fallowCli.runFallow(pi, params, ctx);
+			return fallowCli.runFallow(pi, params, ctx, signal);
 		},
 		renderCall(args, theme) {
 			return renderFallowToolCall(args, theme);

--- a/extensions/fallow/cli.ts
+++ b/extensions/fallow/cli.ts
@@ -1,8 +1,8 @@
-import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import type { ExtensionAPI, ExtensionContext, ExecResult } from "@earendil-works/pi-coding-agent";
-import { stripAtPrefix } from "./path";
 import { fallowEngine } from "./engine";
+import { stripAtPrefix } from "./path";
+import { execFallowProcess } from "./process";
 import type { FallowRunParams } from "./schema";
 
 function addValue(args: string[], flag: string, value: unknown): void {
@@ -285,54 +285,15 @@ function buildFallowArgs(params: FallowRunParams): string[] {
 	return args;
 }
 
-async function execCommand(command: string, args: string[], cwd: string, signal: AbortSignal | undefined, timeoutSecs: number): Promise<ExecResult> {
-	return new Promise((resolve) => {
-		const proc = spawn(command, args, { cwd, shell: false, stdio: ["ignore", "pipe", "pipe"], env: process.env });
-		let stdout = "";
-		let stderr = "";
-		let killed = false;
-		let settled = false;
-		let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-		const finish = (result: ExecResult) => {
-			if (settled) return;
-			settled = true;
-			if (timeoutId) clearTimeout(timeoutId);
-			if (signal) signal.removeEventListener("abort", killProcess);
-			resolve(result);
-		};
-
-		const killProcess = () => {
-			if (killed) return;
-			killed = true;
-			proc.kill("SIGTERM");
-			setTimeout(() => {
-				if (!proc.killed) proc.kill("SIGKILL");
-			}, 5000).unref?.();
-		};
-
-		proc.stdout?.on("data", (data) => { stdout += data.toString(); });
-		proc.stderr?.on("data", (data) => { stderr += data.toString(); });
-		proc.on("error", (error: NodeJS.ErrnoException) => {
-			finish({ stdout, stderr: stderr || error.message, code: error.code === "ENOENT" ? 127 : 1, killed });
-		});
-		proc.on("close", (code) => finish({ stdout, stderr, code: code ?? 0, killed }));
-
-		if (signal?.aborted) killProcess();
-		else signal?.addEventListener("abort", killProcess, { once: true });
-		if (timeoutSecs > 0) timeoutId = setTimeout(killProcess, timeoutSecs * 1000);
-	});
-}
-
 async function execFallow(_pi: ExtensionAPI, args: string[], cwd: string, signal: AbortSignal | undefined, timeoutSecs: number): Promise<{ binary: string; args: string[]; result: ExecResult }> {
 	const configuredBin = process.env.FALLOW_BIN;
 	const binary = configuredBin || "fallow";
-	const result = await execCommand(binary, args, cwd, signal, timeoutSecs);
+	const result = await execFallowProcess(binary, args, cwd, signal, timeoutSecs);
 	if (!shouldTryNpxFallback(configuredBin, result)) {
 		return { binary, args, result };
 	}
 	const npxArgs = buildNpxArgs(args);
-	return { binary: "npx", args: npxArgs, result: await execCommand("npx", npxArgs, cwd, signal, timeoutSecs) };
+	return { binary: "npx", args: npxArgs, result: await execFallowProcess("npx", npxArgs, cwd, signal, timeoutSecs) };
 }
 
 function shouldTryNpxFallback(configuredBin: string | undefined, result: ExecResult): boolean {
@@ -353,16 +314,23 @@ function buildNpxArgs(args: string[]): string[] {
 	return ["-y", "fallow", ...args];
 }
 
-async function runFallow(pi: ExtensionAPI, params: FallowRunParams, ctx: ExtensionContext) {
-	const args = buildFallowArgs(params);
-	const cwd = params.root ? resolve(ctx.cwd, stripAtPrefix(params.root)) : ctx.cwd;
-	const timeoutSecs = params.timeoutSecs ?? Number(process.env.FALLOW_TIMEOUT_SECS || 120);
+function resolveFallowRoot(params: FallowRunParams, contextRoot: string): string {
+	if (!params.root) return contextRoot;
+	return resolve(contextRoot, stripAtPrefix(params.root));
+}
+
+function resolveFallowTimeout(params: FallowRunParams): number {
+	if (params.timeoutSecs !== undefined) return params.timeoutSecs;
+	return Number(process.env.FALLOW_TIMEOUT_SECS || 120);
+}
+
+async function runFallow(pi: ExtensionAPI, params: FallowRunParams, ctx: ExtensionContext, signal?: AbortSignal) {
 	const { details, content } = await fallowEngine.runFallowWithExecutor({
 		pi,
-		cwd,
-		args,
-		signal: ctx.signal,
-		timeoutSecs,
+		cwd: resolveFallowRoot(params, ctx.cwd),
+		args: buildFallowArgs(params),
+		signal: signal ?? ctx.signal,
+		timeoutSecs: resolveFallowTimeout(params),
 		executor: execFallow,
 	});
 	return { content: [{ type: "text" as const, text: content }], details };
@@ -459,6 +427,7 @@ function flushSplitArg(state: { args: string[]; current: string }): void {
 export const fallowCli = {
 	runFallow,
 	execFallow,
+	execCommand: execFallowProcess,
 	splitArgs,
 	buildFallowArgs,
 };

--- a/extensions/fallow/process.ts
+++ b/extensions/fallow/process.ts
@@ -1,0 +1,130 @@
+import { spawn } from "node:child_process";
+import type { ExecResult } from "@earendil-works/pi-coding-agent";
+
+// Fallow needs process-group ownership so npx descendants cannot survive cancellation.
+// ExtensionAPI.exec returns only the final result, so it cannot provide the PID needed for verified escalation.
+const PROCESS_KILL_GRACE_MS = 1_000;
+type SpawnedProcess = ReturnType<typeof spawn>;
+type ProcessSignal = "SIGTERM" | "SIGKILL";
+
+function signalWindowsTree(proc: SpawnedProcess, force: boolean): void {
+	const taskkillArgs = ["/PID", String(proc.pid), "/T", ...(force ? ["/F"] : [])];
+	const taskkill = spawn("taskkill", taskkillArgs, { stdio: "ignore", windowsHide: true });
+	taskkill.on("error", () => {});
+	taskkill.unref();
+}
+
+function signalChild(proc: SpawnedProcess, signal: ProcessSignal): void {
+	try {
+		proc.kill(signal);
+	} catch {
+		// The process exited between the liveness check and signal delivery.
+	}
+}
+
+function signalUnixTree(proc: SpawnedProcess, signal: ProcessSignal): void {
+	try {
+		process.kill(-proc.pid!, signal);
+	} catch {
+		signalChild(proc, signal);
+	}
+}
+
+function signalProcessTree(proc: SpawnedProcess, force: boolean): void {
+	if (!proc.pid) return;
+	if (process.platform === "win32") return signalWindowsTree(proc, force);
+	signalUnixTree(proc, force ? "SIGKILL" : "SIGTERM");
+}
+
+function isWindowsProcessRunning(proc: SpawnedProcess): boolean {
+	return proc.exitCode === null && proc.signalCode === null;
+}
+
+function isUnixProcessTreeRunning(pid: number): boolean {
+	try {
+		process.kill(-pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function isProcessTreeRunning(proc: SpawnedProcess): boolean {
+	if (!proc.pid) return false;
+	if (process.platform === "win32") return isWindowsProcessRunning(proc);
+	return isUnixProcessTreeRunning(proc.pid);
+}
+
+function clearTimer(timer: ReturnType<typeof setTimeout> | undefined): void {
+	if (timer) clearTimeout(timer);
+}
+
+function forceRemainingProcessTree(proc: SpawnedProcess, killed: boolean): void {
+	if (!killed) return;
+	if (isProcessTreeRunning(proc)) signalProcessTree(proc, true);
+}
+
+function resolveExitCode(code: number | null, killed: boolean): number {
+	if (code !== null) return code;
+	return killed ? 130 : 1;
+}
+
+export async function execFallowProcess(
+	command: string,
+	args: string[],
+	cwd: string,
+	signal: AbortSignal | undefined,
+	timeoutSecs: number,
+): Promise<ExecResult> {
+	if (signal?.aborted) return { stdout: "", stderr: "", code: 130, killed: true };
+	return new Promise((resolve) => {
+		const proc = spawn(command, args, {
+			cwd,
+			detached: process.platform !== "win32",
+			shell: false,
+			stdio: ["ignore", "pipe", "pipe"],
+			env: process.env,
+			windowsHide: true,
+		});
+		let stdout = "";
+		let stderr = "";
+		let killed = false;
+		let settled = false;
+		let timeoutId: ReturnType<typeof setTimeout> | undefined;
+		let forceKillId: ReturnType<typeof setTimeout> | undefined;
+
+		const cleanup = () => {
+			clearTimer(timeoutId);
+			clearTimer(forceKillId);
+			signal?.removeEventListener("abort", killProcess);
+		};
+		const finish = (result: ExecResult) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve(result);
+		};
+		const forceKill = () => {
+			if (!settled) signalProcessTree(proc, true);
+		};
+		const killProcess = () => {
+			if (killed || settled) return;
+			killed = true;
+			signalProcessTree(proc, false);
+			forceKillId = setTimeout(forceKill, PROCESS_KILL_GRACE_MS);
+		};
+
+		proc.stdout?.on("data", (data) => { stdout += data.toString(); });
+		proc.stderr?.on("data", (data) => { stderr += data.toString(); });
+		proc.on("error", (error: NodeJS.ErrnoException) => {
+			finish({ stdout, stderr: stderr || error.message, code: error.code === "ENOENT" ? 127 : 1, killed });
+		});
+		proc.on("close", (code) => {
+			forceRemainingProcessTree(proc, killed);
+			finish({ stdout, stderr, code: resolveExitCode(code, killed), killed });
+		});
+
+		signal?.addEventListener("abort", killProcess, { once: true });
+		if (timeoutSecs > 0) timeoutId = setTimeout(killProcess, timeoutSecs * 1000);
+	});
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dupes": "fallow dupes --format json --quiet",
     "dead-code": "fallow dead-code --format json --quiet",
     "test": "node --test",
-    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=40 --statements=40 --functions=60 --branches=75 node --test",
+    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=45 --statements=45 --functions=65 --branches=75 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",

--- a/tests/execution.test.mjs
+++ b/tests/execution.test.mjs
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const fixture = join(root, "tests", "fixtures", "process-fixture.mjs");
+const jiti = createJiti(import.meta.url);
+const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
+const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
+const { buildFallowExecutor } = await jiti.import("../extensions/fallow/command/loader.ts");
+
+function assignEnvironmentValue(key, value) {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
+function applyEnvironment(values) {
+	const previous = new Map();
+	for (const [key, value] of Object.entries(values)) {
+		previous.set(key, process.env[key]);
+		assignEnvironmentValue(key, value);
+	}
+	return previous;
+}
+
+function restoreEnvironment(previous) {
+	for (const [key, value] of previous) assignEnvironmentValue(key, value);
+}
+
+async function withFixture(mode, callback, extraEnv = {}) {
+	const previous = applyEnvironment({
+		FALLOW_BIN: fixture,
+		PI_FALLOW_PROCESS_FIXTURE_MODE: mode,
+		...extraEnv,
+	});
+	try {
+		return await callback();
+	} finally {
+		restoreEnvironment(previous);
+	}
+}
+
+async function waitForFile(path, timeoutMs = 2_000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			await access(path);
+			return;
+		} catch {
+			await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+		}
+	}
+	throw new Error(`Timed out waiting for ${path}`);
+}
+
+function isProcessRunning(pid) {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		if (error?.code === "ESRCH") return false;
+		throw error;
+	}
+}
+
+async function waitForProcessExit(pid, timeoutMs = 1_000) {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (!isProcessRunning(pid)) return;
+		await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+	}
+	assert.equal(isProcessRunning(pid), false, `process ${pid} should have exited`);
+}
+
+function fakeResult(code, options = {}) {
+	return {
+		stdout: JSON.stringify({ kind: "dead-code", total_issues: code === 1 ? 1 : 0, unused_files: [], unused_exports: [] }),
+		stderr: options.stderr ?? "",
+		code,
+		killed: options.killed ?? false,
+	};
+}
+
+describe("Fallow process execution", () => {
+	it("does not spawn a command for an already-aborted signal", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const result = await fallowCli.execCommand("definitely-not-a-command", [], root, controller.signal, 10);
+		assert.deepEqual(result, { stdout: "", stderr: "", code: 130, killed: true });
+	});
+
+	it("reports a missing executable with the fallback exit code", async () => {
+		const result = await fallowCli.execCommand(join(root, "missing-fallow-binary"), [], root, undefined, 10);
+		assert.equal(result.code, 127);
+		assert.equal(result.killed, false);
+	});
+
+	it("escalates a timeout when the process ignores SIGTERM", async () => {
+		await withFixture("ignore-term", async () => {
+			const started = Date.now();
+			const result = await fallowCli.execCommand(fixture, [], root, undefined, 0.25);
+			assert.equal(result.killed, true);
+			assert.equal(result.code, 130);
+			assert.match(result.stderr, /received SIGTERM/);
+			assert.ok(Date.now() - started < 2_000, "forced termination should settle promptly");
+		});
+	});
+
+	it("kills descendants when cancellation terminates a wrapper process", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-cancel-"));
+		const pidFile = join(workspace, "child.pid");
+		let childPid;
+		try {
+			await withFixture("tree", async () => {
+				const controller = new AbortController();
+				const execution = fallowCli.execCommand(fixture, [], root, controller.signal, 10);
+				await waitForFile(pidFile);
+				childPid = Number(await readFile(pidFile, "utf8"));
+				assert.equal(isProcessRunning(childPid), true);
+				controller.abort();
+				const result = await execution;
+				assert.equal(result.killed, true);
+				await waitForProcessExit(childPid);
+			}, { PI_FALLOW_PROCESS_FIXTURE_PID_FILE: pidFile });
+		} finally {
+			if (childPid && isProcessRunning(childPid)) {
+				try { process.kill(childPid, "SIGKILL"); } catch {}
+			}
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("uses the tool signal instead of an unrelated context signal", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-tool-"));
+		try {
+			await withFixture("wait", async () => {
+				const toolController = new AbortController();
+				const contextController = new AbortController();
+				const execution = fallowCli.runFallow(
+					{},
+					{ command: "health" },
+					{ cwd: workspace, signal: contextController.signal },
+					toolController.signal,
+				);
+				setTimeout(() => toolController.abort(), 50);
+				await assert.rejects(execution, /killed=true/);
+				assert.equal(contextController.signal.aborted, false);
+			});
+		} finally {
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("passes loader cancellation through the slash-command executor", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-command-"));
+		try {
+			await withFixture("wait", async () => {
+				const loaderController = new AbortController();
+				const contextController = new AbortController();
+				const execute = buildFallowExecutor(
+					{},
+					{ cwd: workspace, hasUI: true, signal: contextController.signal, ui: {} },
+					["health", "--format", "json", "--quiet"],
+				);
+				const execution = execute(loaderController.signal);
+				setTimeout(() => loaderController.abort(), 50);
+				const result = await execution;
+				assert.equal(result.result.killed, true);
+				assert.equal(contextController.signal.aborted, false);
+			});
+		} finally {
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("Fallow exit-code semantics", () => {
+	it("keeps exit code 1 as a findings result", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-exit-one-"));
+		try {
+			const result = await fallowEngine.runFallowWithExecutor({
+				pi: {}, cwd: workspace, args: [], signal: undefined, timeoutSecs: 1,
+				executor: async () => ({ binary: "fixture", args: [], result: fakeResult(1) }),
+			});
+			assert.equal(result.details.exitCode, 1);
+		} finally {
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("throws for exit code 2 and killed executions", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-execution-error-"));
+		try {
+			const input = {
+				pi: {}, cwd: workspace, args: [], signal: undefined, timeoutSecs: 1,
+				executor: async () => ({ binary: "fixture", args: [], result: fakeResult(2, { stderr: "bad" }) }),
+			};
+			await assert.rejects(fallowEngine.runFallowWithExecutor(input), /exitCode=2/);
+			await assert.rejects(fallowEngine.runFallowWithExecutor({
+				...input,
+				executor: async () => ({ binary: "fixture", args: [], result: fakeResult(130, { killed: true }) }),
+			}), /killed=true/);
+		} finally {
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/fixtures/process-fixture.mjs
+++ b/tests/fixtures/process-fixture.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const mode = process.env.PI_FALLOW_PROCESS_FIXTURE_MODE ?? "success";
+
+if (mode === "success") {
+	process.stdout.write(JSON.stringify({ kind: "dead-code", schema_version: 7, version: "fixture", elapsed_ms: 1, total_issues: 0, unused_files: [], unused_exports: [] }));
+	process.exit(0);
+}
+
+if (mode === "findings") {
+	process.stdout.write(JSON.stringify({ kind: "dead-code", schema_version: 7, version: "fixture", elapsed_ms: 1, total_issues: 1, unused_files: ["unused.ts"], unused_exports: [] }));
+	process.exit(1);
+}
+
+if (mode === "error") {
+	process.stderr.write("fixture execution error\n");
+	process.exit(2);
+}
+
+if (mode === "ignore-term") {
+	process.on("SIGTERM", () => process.stderr.write("received SIGTERM\n"));
+	setInterval(() => {}, 1_000);
+} else if (mode === "wait") {
+	setInterval(() => {}, 1_000);
+} else if (mode === "tree") {
+	process.on("SIGTERM", () => process.stderr.write("parent received SIGTERM\n"));
+	const child = spawn(process.execPath, [fileURLToPath(import.meta.url)], {
+		env: { ...process.env, PI_FALLOW_PROCESS_FIXTURE_MODE: "ignore-term" },
+		stdio: "ignore",
+	});
+	if (!child.pid) throw new Error("Fixture child did not start.");
+	const pidFile = process.env.PI_FALLOW_PROCESS_FIXTURE_PID_FILE;
+	if (pidFile) writeFileSync(pidFile, String(child.pid));
+	setInterval(() => {}, 1_000);
+} else {
+	process.stderr.write(`unknown fixture mode: ${mode}\n`);
+	process.exit(2);
+}


### PR DESCRIPTION
 ## Summary

   Makes Fallow cancellation and timeout handling reliably terminate the complete process tree.

   This PR:

   - passes the actual `fallow_run.execute()` abort signal through execution
   - propagates slash-command loader cancellation
   - terminates `npx` and other wrapper descendants
   - escalates from `SIGTERM` to `SIGKILL` after one second
   - checks actual process-tree liveness instead of `ChildProcess.killed`
   - avoids spawning commands for already-aborted signals
   - preserves Fallow exit-code semantics
   - adds deterministic cancellation and timeout fixtures

   ## Process lifecycle

   The execution lifecycle now:

   1. Starts Fallow in an isolated process group on Unix.
   2. Sends `SIGTERM` to the complete process group on cancellation or timeout.
   3. Waits one second for graceful shutdown.
   4. Sends `SIGKILL` if the process tree remains alive.
   5. Uses `taskkill /T` on Windows to terminate wrapper descendants.
   6. Removes signal listeners and timers after execution settles.

   This fixes the previous escalation check, which relied on `proc.killed`. Node sets that property when a signal is sent, not when the process exits, so a process that ignored `SIGTERM` could avoid forced termination.

   ## Pi execution API note

   `ExtensionAPI.exec()` was considered, but its public result-only interface does not expose the child PID or process group. Pi Fallow needs that information to verify termination, kill `npx` descendants, and escalate commands that
 ignore `SIGTERM`.

   The process-specific implementation is isolated in `extensions/fallow/process.ts` so it can be replaced if Pi’s execution API later exposes equivalent process-tree guarantees.

   ## Exit-code behavior

   Existing behavior remains enforced:

   - exit code `0`: successful analysis
   - exit code `1`: valid findings result
   - exit code `2+`: execution error
   - cancelled or timed-out execution: killed execution error

   ## Tests

   Added deterministic coverage for:

   - an already-aborted signal
   - a missing executable
   - timeout escalation when a process ignores `SIGTERM`
   - terminating descendants of a wrapper process
   - tool-signal propagation instead of an unrelated context signal
   - slash-command loader cancellation
   - exit code `1` findings behavior
   - exit code `2+` and killed execution errors

   ## Coverage

   All-source coverage increased to:

   - Lines/statements: 46.97%
   - Functions: 67.44%
   - Branches: 77.57%

   Coverage gates were raised to:

   - Lines/statements: 45%
   - Functions: 65%
   - Branches: 75%

   ## Validation

   - [x] 50 tests pass on Node.js 22.19
   - [x] 50 tests pass on Node.js 24
   - [x] Coverage thresholds pass
   - [x] Bundle validation passes
   - [x] Full publish validation passes
   - [x] Fallow health reports no findings
   - [x] Fallow changed-file audit passes
   - [x] Dead-code check reports zero issues
   - [x] Duplication check reports zero clone groups
   - [x] Production and full dependency audits pass
   - [x] Package installation smoke test passes
   - [x] Token benchmark reports no changes
   - [x] Direct Fallow performance remains within machine-level variance