### PR TITLE
fix: respect Pi run modes in Fallow commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Pi Fallow are documented here.
 
 ### Fixed
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.
+- Made `/fallow` execute directly in RPC, JSON, and print modes while reserving loaders and navigator overlays for TUI mode and retaining full non-TUI transcript output.
 
 ## [0.2.0] - 2026-07-01
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 - **Rerun shortcut:** `/fallow rerun` repeats the last `/fallow` command.
 - **Autocomplete:** subcommands, flags, enum values, and branch refs are suggested in the editor.
 - **Interactive navigator:** findings open in a bordered TUI view where you can inspect, select, trace, or load issues into the editor.
+- **Run-mode support:** `/fallow` executes in TUI, RPC, JSON, and print modes; terminal loaders and navigator overlays are TUI-only, while non-TUI modes retain full transcript output.
 - **Safe defaults:** JSON and quiet output are added when appropriate; large output is truncated for the transcript and saved to a temp file.
 - **Flexible CLI lookup:** uses `FALLOW_BIN` first, then `fallow` from `PATH`, then falls back to `npx -y fallow`.
 

--- a/extensions/fallow/command/handler.ts
+++ b/extensions/fallow/command/handler.ts
@@ -4,6 +4,7 @@ import { detectFallowGitState } from "../project/git";
 import type { FallowNavigatorResult } from "../types";
 import { sendFallowAboutMessage } from "../update-notice";
 import { normalizeFallowArgs } from "./args";
+import { isFallowTuiMode } from "./mode";
 import { executeFallowResult } from "./result-flow";
 import type { FallowCommandContext, FallowCommandState } from "./types";
 
@@ -46,7 +47,7 @@ async function executeFallowCommandLoop(
 	initialArgs: string[],
 ): Promise<FallowNavigatorResult | null | undefined> {
 	let result = await runFallowCommandOnce(pi, ctx, commandState, initialArgs, true);
-	while (ctx.hasUI && result?.type === "trace") {
+	while (isFallowTuiMode(ctx.mode) && result?.type === "trace") {
 		result = await runFallowCommandOnce(pi, ctx, commandState, result.commandArgs, false);
 	}
 	return result;
@@ -65,7 +66,7 @@ function runFallowCommandOnce(
 }
 
 function applyFallowPrompt(ctx: FallowCommandContext, result: FallowNavigatorResult | null | undefined): void {
-	if (!ctx.hasUI || result?.type !== "prompt") return;
+	if (!isFallowTuiMode(ctx.mode) || result?.type !== "prompt") return;
 	ctx.ui.setEditorText(result.prompt);
 	ctx.ui.notify(`Loaded ${result.issueCount} Fallow finding(s) into the editor. Add comments, then submit when ready.`, "info");
 }

--- a/extensions/fallow/command/loader.ts
+++ b/extensions/fallow/command/loader.ts
@@ -3,6 +3,7 @@ import { BorderedLoader } from "@earendil-works/pi-coding-agent";
 import { fallowCli } from "../cli";
 import { fallowPurple } from "../colors";
 import { fallowEngine } from "../engine";
+import { isFallowTuiMode } from "./mode";
 import type { FallowCommandContext } from "./types";
 
 export type FallowCommandResult = Awaited<ReturnType<typeof fallowEngine.runFallowWithExecutor>>;
@@ -36,8 +37,12 @@ export async function runFallowWithLoaderIfUi(
 	executeCommand: FallowCommandExecutor,
 	finalArgs: string[],
 ): Promise<NullableFallowCommandResult> {
+	if (isFallowTuiMode(ctx.mode)) {
+		return runFallowWithLoader(ctx, executeCommand, finalArgs).finally(() => clearFallowStatus(ctx));
+	}
 	if (!ctx.hasUI) return executeCommand();
-	return runFallowWithLoader(ctx, executeCommand, finalArgs).finally(() => clearFallowStatus(ctx));
+	ctx.ui.setStatus("fallow", "fallow running…");
+	return executeCommand(ctx.signal).finally(() => clearFallowStatus(ctx));
 }
 
 function clearFallowStatus(ctx: FallowCommandContext): void {

--- a/extensions/fallow/command/mode.ts
+++ b/extensions/fallow/command/mode.ts
@@ -1,0 +1,11 @@
+import type { FallowOverview } from "../types";
+import type { FallowRunMode } from "./types";
+
+export function isFallowTuiMode(mode: FallowRunMode): boolean {
+	return mode === "tui";
+}
+
+export function hasFallowNavigator(mode: FallowRunMode, overview: FallowOverview | undefined): boolean {
+	if (!isFallowTuiMode(mode)) return false;
+	return !!overview?.sections.some((section) => section.items.length > 0);
+}

--- a/extensions/fallow/command/result-flow.ts
+++ b/extensions/fallow/command/result-flow.ts
@@ -5,6 +5,7 @@ import { commandDisplay, fallowExitLabel } from "../tool-render";
 import type { FallowNavigatorResult, FallowPrSummary, FallowProjectState } from "../types";
 import { FallowIssueNavigator } from "../ui";
 import { buildFallowExecutor, buildFallowFinalArgs, runFallowWithLoaderIfUi, type FallowCommandExecutor, type FallowCommandResult } from "./loader";
+import { hasFallowNavigator, isFallowTuiMode } from "./mode";
 import { buildFallowTranscriptContent } from "./transcript";
 import type { FallowCommandContext } from "./types";
 
@@ -73,14 +74,14 @@ function renderFallowResultMessage(
 	resultPrefix: string,
 ): void {
 	const { details: commandDetails, formatted, content } = result;
-	const hasNavigator = formatted.overview?.sections.some((section) => section.items.length > 0);
+	const hasNavigator = hasFallowNavigator(ctx.mode, formatted.overview);
 	pi.sendMessage({
 		customType: "fallow-result",
-		content: buildFallowTranscriptContent(resultPrefix, formatted.summary, content, !!hasNavigator),
+		content: buildFallowTranscriptContent(resultPrefix, formatted.summary, content, hasNavigator),
 		display: true,
 		details: {
 			...commandDetails,
-			compact: !!(ctx.hasUI && hasNavigator),
+			compact: hasNavigator,
 		},
 	});
 }
@@ -94,7 +95,7 @@ function openFallowNavigator(
 	prSummary: FallowPrSummary | undefined,
 ): Promise<FallowNavigatorResult | null> {
 	const { formatted } = result;
-	if (!ctx.hasUI || !formatted.overview) return Promise.resolve(null);
+	if (!isFallowTuiMode(ctx.mode) || !formatted.overview) return Promise.resolve(null);
 	let navigator: FallowIssueNavigator | undefined;
 	return ctx.ui.custom<FallowNavigatorResult | null>((tui, theme, _keybindings, done) => {
 		navigator = new FallowIssueNavigator(

--- a/extensions/fallow/command/types.ts
+++ b/extensions/fallow/command/types.ts
@@ -1,7 +1,11 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
 export type FallowCommandState = { lastArgs: string[] | null };
+export type FallowRunMode = ExtensionContext["mode"];
 
 export type FallowCommandContext = {
 	cwd: string;
+	mode: FallowRunMode;
 	hasUI: boolean;
 	signal?: AbortSignal | undefined;
 	ui: {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dupes": "fallow dupes --format json --quiet",
     "dead-code": "fallow dead-code --format json --quiet",
     "test": "node --test",
-    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=45 --statements=45 --functions=65 --branches=75 node --test",
+    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=46 --statements=46 --functions=67 --branches=77 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",

--- a/tests/execution.test.mjs
+++ b/tests/execution.test.mjs
@@ -102,11 +102,11 @@ describe("Fallow process execution", () => {
 	it("escalates a timeout when the process ignores SIGTERM", async () => {
 		await withFixture("ignore-term", async () => {
 			const started = Date.now();
-			const result = await fallowCli.execCommand(fixture, [], root, undefined, 0.25);
+			const result = await fallowCli.execCommand(fixture, [], root, undefined, 1);
 			assert.equal(result.killed, true);
 			assert.equal(result.code, 130);
 			assert.match(result.stderr, /received SIGTERM/);
-			assert.ok(Date.now() - started < 2_000, "forced termination should settle promptly");
+			assert.ok(Date.now() - started < 3_000, "forced termination should settle promptly");
 		});
 	});
 
@@ -163,7 +163,7 @@ describe("Fallow process execution", () => {
 				const contextController = new AbortController();
 				const execute = buildFallowExecutor(
 					{},
-					{ cwd: workspace, hasUI: true, signal: contextController.signal, ui: {} },
+					{ cwd: workspace, mode: "tui", hasUI: true, signal: contextController.signal, ui: {} },
 					["health", "--format", "json", "--quiet"],
 				);
 				const execution = execute(loaderController.signal);

--- a/tests/run-modes.test.mjs
+++ b/tests/run-modes.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { runFallowWithLoaderIfUi } = await jiti.import("../extensions/fallow/command/loader.ts");
+const { hasFallowNavigator, isFallowTuiMode } = await jiti.import("../extensions/fallow/command/mode.ts");
+const { buildFallowTranscriptContent } = await jiti.import("../extensions/fallow/command/transcript.ts");
+
+const modes = [
+	{ mode: "tui", hasUI: true, usesTui: true },
+	{ mode: "rpc", hasUI: true, usesTui: false },
+	{ mode: "json", hasUI: false, usesTui: false },
+	{ mode: "print", hasUI: false, usesTui: false },
+];
+
+function createContext(mode, hasUI, customResult) {
+	const calls = { custom: 0, statuses: [] };
+	return {
+		calls,
+		context: {
+			cwd: "/workspace",
+			mode,
+			hasUI,
+			ui: {
+				custom() {
+					calls.custom++;
+					if (mode !== "tui") throw new Error(`custom UI used in ${mode} mode`);
+					return Promise.resolve(customResult);
+				},
+				setStatus(key, text) { calls.statuses.push({ key, text }); },
+			},
+		},
+	};
+}
+
+describe("Fallow command run modes", () => {
+	for (const expected of modes) {
+		it(`selects the correct execution path in ${expected.mode} mode`, async () => {
+			const commandResult = { mode: expected.mode };
+			const { calls, context } = createContext(expected.mode, expected.hasUI, commandResult);
+			let executions = 0;
+			const result = await runFallowWithLoaderIfUi(context, async () => {
+				executions++;
+				return commandResult;
+			}, ["health"]);
+
+			assert.equal(isFallowTuiMode(expected.mode), expected.usesTui);
+			assert.equal(result, commandResult);
+			assert.equal(calls.custom, expected.usesTui ? 1 : 0);
+			assert.equal(executions, expected.usesTui ? 0 : 1);
+		});
+	}
+
+	it("uses RPC status methods without opening custom UI", async () => {
+		const commandResult = { mode: "rpc" };
+		const { calls, context } = createContext("rpc", true, commandResult);
+		await runFallowWithLoaderIfUi(context, async () => commandResult, ["health"]);
+		assert.deepEqual(calls.statuses, [
+			{ key: "fallow", text: "fallow running…" },
+			{ key: "fallow", text: undefined },
+		]);
+		assert.equal(calls.custom, 0);
+	});
+
+	it("keeps full transcript output when no TUI navigator can open", () => {
+		const overview = {
+			title: "Dead code",
+			status: "warning",
+			stats: [],
+			sections: [{ title: "Findings", items: [{ label: "unused export" }] }],
+			notes: [],
+		};
+		for (const { mode } of modes) {
+			const hasNavigator = hasFallowNavigator(mode, overview);
+			const content = buildFallowTranscriptContent("project", "summary", "full report", hasNavigator);
+			if (mode === "tui") {
+				assert.match(content, /^Opened Fallow issue navigator\./);
+			} else {
+				assert.equal(content, "full report");
+			}
+		}
+	});
+});


### PR DESCRIPTION
   ## Summary

   Makes `/fallow` work correctly across Pi's TUI, RPC, JSON, and print modes.

   This PR:

   - reserves `BorderedLoader` and navigator overlays for TUI mode
   - executes Fallow directly in RPC, JSON, and print modes
   - prevents RPC `custom()` degradation from being interpreted as cancellation
   - keeps RPC-compatible status and notification events
   - retains full result content when no TUI navigator can open
   - limits navigator trace loops and editor prompt loading to TUI mode
   - derives the internal mode type directly from Pi's `ExtensionContext`

   ## Previous behavior

   RPC mode sets `ctx.hasUI` to `true`, but `ctx.ui.custom()` returns `undefined`.

   Pi Fallow used `ctx.hasUI` to open its loader, causing RPC execution to return immediately without running Fallow and report a false:

   ```text
   fallow cancelled
 ```

 JSON and print result messages could also contain the compact “Opened Fallow issue navigator” transcript despite no navigator being available.

 New behavior

 ### TUI

 - Uses the cancellable bordered loader.
 - Opens the findings navigator when appropriate.
 - Supports trace loops and loading selected findings into the editor.
 - Stores the compact navigator transcript.

 ### RPC

 - Executes Fallow directly.
 - Emits supported setStatus and notify requests.
 - Never calls ctx.ui.custom().
 - Sends the full Fallow result with compact: false.

 ### JSON and print

 - Execute Fallow directly without UI methods.
 - Keep complete result content instead of navigator-only summaries.

 Tests

 Added run-mode coverage for:

 - TUI execution-path selection
 - RPC direct execution
 - JSON direct execution
 - print direct execution
 - RPC status handling without custom UI
 - full transcript retention outside TUI
 - navigator availability only in TUI mode

 The ignored-SIGTERM timeout fixture was also given a longer startup allowance to remain deterministic while test files run concurrently.

 Coverage

 All-source coverage is now:

 - Lines/statements: 47.38%
 - Functions: 68.49%
 - Branches: 78.01%

 Coverage gates were raised to:

 - Lines/statements: 46%
 - Functions: 67%
 - Branches: 77%

 Validation

 - [x] 56 tests pass on Node.js 22.19
 - [x] 56 tests pass on Node.js 24
 - [x] Coverage thresholds pass
 - [x] Bundle validation passes
 - [x] Full publish validation passes
 - [x] Fallow health reports no findings
 - [x] Changed-file audit passes
 - [x] Dead-code check reports zero issues
 - [x] Duplication check reports zero clone groups
 - [x] Production and full dependency audits pass
 - [x] Package installation smoke test passes
 - [x] Token benchmark reports no changes
 - [x] Performance benchmark completes without retained-memory changes
 - [x] Manual Pi validation passes in RPC, JSON, and print modes
