### PR TITLE
perf: remove blocking Git work from autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Pi Fallow are documented here.
 ### Changed
 - Raised the minimum Node.js version to 22.19 to match the current Pi peer packages.
 - Pinned Fallow, esbuild, and coverage tooling for reproducible development and CI checks.
+- Made Git ref autocomplete non-blocking and keyed it to Pi's project directory; base-ref detection now runs only for `/fallow pr` without an explicit base and is cached per project.
 
 ### Fixed
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 - **Slash command:** `/fallow ...` runs the Fallow CLI from inside Pi.
 - **PR shortcut:** `/fallow pr` maps to `audit --base <detected-base> --gate new-only`.
 - **Rerun shortcut:** `/fallow rerun` repeats the last `/fallow` command.
-- **Autocomplete:** subcommands, flags, enum values, and branch refs are suggested in the editor.
+- **Non-blocking autocomplete:** subcommands, flags, enum values, static refs, and asynchronously discovered project branch refs are suggested without running Git while you type.
 - **Interactive navigator:** findings open in a bordered TUI view where you can inspect, select, trace, or load issues into the editor.
 - **Run-mode support:** `/fallow` executes in TUI, RPC, JSON, and print modes; terminal loaders and navigator overlays are TUI-only, while non-TUI modes retain full transcript output.
 - **Safe defaults:** JSON and quiet output are added when appropriate; large output is truncated for the transcript and saved to a temp file.

--- a/extensions/fallow.ts
+++ b/extensions/fallow.ts
@@ -10,7 +10,7 @@ import { renderFallowMessageRenderer, renderFallowToolCall, renderFallowToolResu
 import { renderFallowAboutMessage } from "./fallow/update-notice";
 
 export default function (pi: ExtensionAPI) {
-	const commandState: FallowCommandState = { lastArgs: null };
+	const commandState: FallowCommandState = { lastArgs: null, baseRefs: new Map() };
 	registerFallowTool(pi);
 	registerFallowCommand(pi, commandState);
 	registerFallowResultRenderer(pi);

--- a/extensions/fallow/autocomplete.ts
+++ b/extensions/fallow/autocomplete.ts
@@ -1,5 +1,5 @@
-import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AutocompleteItem } from "@earendil-works/pi-tui";
 
 type CompletionSpec = {
@@ -52,15 +52,17 @@ const COMMANDS: CompletionSpec[] = [
 ];
 
 const STATIC_REF_VALUES = ["main", "master", "HEAD~1", "origin/main", "origin/master"];
-const REF_CACHE_TTL_MS = 3_000;
 const MAX_DYNAMIC_REF_VALUES = 40;
+const GIT_REF_TIMEOUT_MS = 1_200;
+const DEFAULT_REF_VALUES = prioritizeRefs(STATIC_REF_VALUES);
 
 interface GitRefCacheEntry {
 	references: string[];
-	expiresAt: number;
+	refresh?: Promise<void>;
 }
 
 const gitRefCache = new Map<string, GitRefCacheEntry>();
+let activeGitCwd: string | undefined;
 
 function uniqueValues(values: string[]): string[] {
 	const seen = new Set<string>();
@@ -85,37 +87,52 @@ function prioritizeRefs(values: string[]): string[] {
 	return [...ordered, ...[...unique].sort((a, b) => a.localeCompare(b))].slice(0, MAX_DYNAMIC_REF_VALUES);
 }
 
-function readGitReferences(cwd: string): string[] {
-	const output = execFileSync("git", ["for-each-ref", "--format=%(refname:short)", "refs/heads", "refs/remotes"], {
-		cwd,
-		timeout: 1200,
-	});
-	const refs = String(output)
+function parseGitReferences(output: string): string[] {
+	return uniqueValues(output
 		.split(/\r?\n/)
 		.map((value) => value.trim())
-		.filter((value) => Boolean(value) && value !== "HEAD" && !value.endsWith("/HEAD"));
-	return uniqueValues(refs);
+		.filter((value) => Boolean(value) && value !== "HEAD" && !value.endsWith("/HEAD")));
 }
 
-function getRefValuesFromGit(): string[] {
-	const cwd = resolve(process.cwd());
-	const now = Date.now();
-	const cached = gitRefCache.get(cwd);
-	if (cached && cached.expiresAt > now) return cached.references;
-	let refs = STATIC_REF_VALUES;
-	try {
-		refs = prioritizeRefs(readGitReferences(cwd));
-	} catch {
-		refs = [...STATIC_REF_VALUES];
-	}
-	const merged = uniqueValues([...refs, ...STATIC_REF_VALUES]);
-	const result = prioritizeRefs(merged);
-	gitRefCache.set(cwd, { references: result, expiresAt: now + REF_CACHE_TTL_MS });
-	return result;
+function mergeGitReferences(references: string[]): string[] {
+	return prioritizeRefs(uniqueValues([...references, ...STATIC_REF_VALUES]));
+}
+
+function refCacheEntry(cwd: string): GitRefCacheEntry {
+	const existing = gitRefCache.get(cwd);
+	if (existing) return existing;
+	const created = { references: DEFAULT_REF_VALUES };
+	gitRefCache.set(cwd, created);
+	return created;
+}
+
+async function readGitReferences(pi: Pick<ExtensionAPI, "exec">, cwd: string): Promise<string[] | undefined> {
+	const result = await pi.exec(
+		"git",
+		["for-each-ref", "--format=%(refname:short)", "refs/heads", "refs/remotes"],
+		{ cwd, timeout: GIT_REF_TIMEOUT_MS },
+	);
+	return result.code === 0 ? parseGitReferences(result.stdout) : undefined;
+}
+
+function preloadGitReferences(pi: Pick<ExtensionAPI, "exec">, cwd: string): Promise<void> {
+	const resolvedCwd = resolve(cwd);
+	activeGitCwd = resolvedCwd;
+	const entry = refCacheEntry(resolvedCwd);
+	if (entry.refresh) return entry.refresh;
+	const refresh = readGitReferences(pi, resolvedCwd)
+		.then((references) => {
+			if (references) entry.references = mergeGitReferences(references);
+		})
+		.catch(() => {})
+		.finally(() => { entry.refresh = undefined; });
+	entry.refresh = refresh;
+	return refresh;
 }
 
 function getRefValues(): string[] {
-	return getRefValuesFromGit();
+	if (!activeGitCwd) return DEFAULT_REF_VALUES;
+	return refCacheEntry(activeGitCwd).references;
 }
 
 const COMMON_FLAGS: FlagSpec[] = [
@@ -337,12 +354,13 @@ function getFallowRootCommandCompletions(): AutocompleteItem[] {
 	}));
 }
 
-const fallbackCompletion = {
+const completionApi = {
 	getFallowRootCommandCompletions,
 	getFallowArgumentCompletions,
+	preloadGitReferences,
 };
 
-export const fallowCompletions = fallbackCompletion;
+export const fallowCompletions = completionApi;
 
 function completeToken(beforeCurrent: string, current: string, specs: CompletionSpec[]): AutocompleteItem[] {
 	return specs

--- a/extensions/fallow/command/args.ts
+++ b/extensions/fallow/command/args.ts
@@ -1,5 +1,12 @@
 type Notify = (message: string, level: "info" | "warning") => void;
 
+export function needsFallowBaseDetection(rawArgs: string[]): boolean {
+	if (rawArgs[0] !== "pr") return false;
+	const prArgs = rawArgs.slice(1);
+	if (prArgs.some((arg) => arg === "--help" || arg === "-h")) return false;
+	return !hasFlag(prArgs, "--base");
+}
+
 export function normalizeFallowArgs(
 	rawArgs: string[],
 	baseRef: string,

--- a/extensions/fallow/command/base.ts
+++ b/extensions/fallow/command/base.ts
@@ -1,0 +1,18 @@
+import { needsFallowBaseDetection } from "./args";
+import type { FallowCommandState } from "./types";
+
+export type FallowBaseRefDetector = (cwd: string) => Promise<string | undefined>;
+
+export async function resolveFallowCommandBaseRef(
+	rawArgs: string[],
+	cwd: string,
+	state: FallowCommandState,
+	detectBaseRef: FallowBaseRefDetector,
+): Promise<string> {
+	if (!needsFallowBaseDetection(rawArgs)) return "main";
+	const cached = state.baseRefs.get(cwd);
+	if (cached) return cached;
+	const detected = await detectBaseRef(cwd) ?? "main";
+	state.baseRefs.set(cwd, detected);
+	return detected;
+}

--- a/extensions/fallow/command/handler.ts
+++ b/extensions/fallow/command/handler.ts
@@ -1,9 +1,10 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { fallowCli } from "../cli";
-import { detectFallowGitState } from "../project/git";
+import { detectFallowBaseRef } from "../project/git";
 import type { FallowNavigatorResult } from "../types";
 import { sendFallowAboutMessage } from "../update-notice";
 import { normalizeFallowArgs } from "./args";
+import { resolveFallowCommandBaseRef } from "./base";
 import { isFallowTuiMode } from "./mode";
 import { executeFallowResult } from "./result-flow";
 import type { FallowCommandContext, FallowCommandState } from "./types";
@@ -34,7 +35,7 @@ async function normalizeFallowHandlerArgs(
 	commandState: FallowCommandState,
 	parsedArgs: string[],
 ): Promise<string[] | null> {
-	const baseRef = (await detectFallowGitState(ctx.cwd)).baseRef ?? "main";
+	const baseRef = await resolveFallowCommandBaseRef(parsedArgs, ctx.cwd, commandState, detectFallowBaseRef);
 	return normalizeFallowArgs(parsedArgs, baseRef, commandState.lastArgs, (message, level) => {
 		if (ctx.hasUI) ctx.ui.notify(message, level);
 	});

--- a/extensions/fallow/command/types.ts
+++ b/extensions/fallow/command/types.ts
@@ -1,6 +1,9 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
-export type FallowCommandState = { lastArgs: string[] | null };
+export type FallowCommandState = {
+	lastArgs: string[] | null;
+	baseRefs: Map<string, string>;
+};
 export type FallowRunMode = ExtensionContext["mode"];
 
 export type FallowCommandContext = {

--- a/extensions/fallow/project/git.ts
+++ b/extensions/fallow/project/git.ts
@@ -1,7 +1,9 @@
 import { execFile } from "node:child_process";
-import type { FallowGitState } from "../types";
 
 const BASE_REF_CANDIDATES = ["origin/main", "main", "origin/master", "master"];
+const BASE_REF_NAMES = BASE_REF_CANDIDATES.map((candidate) => candidate.startsWith("origin/")
+	? `refs/remotes/${candidate}`
+	: `refs/heads/${candidate}`);
 
 async function git(cwd: string, args: string[]): Promise<string | undefined> {
 	return new Promise((resolve) => {
@@ -12,29 +14,10 @@ async function git(cwd: string, args: string[]): Promise<string | undefined> {
 	});
 }
 
-export async function detectFallowGitState(cwd: string): Promise<FallowGitState> {
-	const isGitRepo = await git(cwd, ["rev-parse", "--is-inside-work-tree"]);
-	if (isGitRepo !== "true") return { isGitRepo: false };
-	const branchName = await git(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
-	const detached = isDetachedBranch(branchName);
-	const baseRef = await resolveBaseRef(cwd);
-	return {
-		isGitRepo: true,
-		detached,
-		branch: detached ? undefined : branchName,
-		baseRef,
-	};
-}
-
-function isDetachedBranch(branchName: string | undefined): boolean {
-	return !branchName || branchName === "HEAD";
-}
-
-async function resolveBaseRef(cwd: string): Promise<string | undefined> {
-	for (const candidate of BASE_REF_CANDIDATES) {
-		const resolved = await git(cwd, ["rev-parse", "--verify", candidate]);
-		if (resolved) return candidate;
-	}
-	return undefined;
+export async function detectFallowBaseRef(cwd: string): Promise<string | undefined> {
+	const output = await git(cwd, ["for-each-ref", "--format=%(refname:short)", ...BASE_REF_NAMES]);
+	if (!output) return undefined;
+	const available = new Set(output.split(/\r?\n/));
+	return BASE_REF_CANDIDATES.find((candidate) => available.has(candidate));
 }
 

--- a/extensions/fallow/session.ts
+++ b/extensions/fallow/session.ts
@@ -4,7 +4,8 @@ import { scheduleFallowUpdateNotice } from "./update-notice";
 
 export function registerFallowSessionStart(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
-		if (!ctx.hasUI) return;
+		if (ctx.mode !== "tui") return;
+		void fallowCompletions.preloadGitReferences(pi, ctx.cwd);
 		scheduleFallowUpdateNotice(pi, ctx);
 		ctx.ui.addAutocompleteProvider((current) => ({
 			async getSuggestions(lines, cursorLine, cursorCol, options) {

--- a/extensions/fallow/types.ts
+++ b/extensions/fallow/types.ts
@@ -5,13 +5,6 @@ export interface FallowProjectState {
 	cacheFiles: string[];
 }
 
-export interface FallowGitState {
-	isGitRepo: boolean;
-	branch?: string;
-	detached?: boolean;
-	baseRef?: string;
-}
-
 export interface FallowPrSummary {
 	baseRef?: string;
 	gate: string;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dupes": "fallow dupes --format json --quiet",
     "dead-code": "fallow dead-code --format json --quiet",
     "test": "node --test",
-    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=46 --statements=46 --functions=67 --branches=77 node --test",
+    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=58 --statements=58 --functions=67 --branches=79 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",

--- a/scripts/performance-benchmark.mjs
+++ b/scripts/performance-benchmark.mjs
@@ -27,7 +27,7 @@ const jiti = createJiti(import.meta.url);
 const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
 const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
 const { fallowCompletions } = await jiti.import("../extensions/fallow/autocomplete.ts");
-const { detectFallowGitState } = await jiti.import("../extensions/fallow/project/git.ts");
+const { detectFallowBaseRef } = await jiti.import("../extensions/fallow/project/git.ts");
 
 const cli = parseCli(process.argv.slice(2));
 const packageJson = JSON.parse(await readFile(join(ROOT, "package.json"), "utf8"));
@@ -218,7 +218,7 @@ async function benchmarkGit(workspacePath, config) {
 	const detection = await benchmarkOperation(
 		"git",
 		"base-detection",
-		() => detectFallowGitState(sourceRepo),
+		() => detectFallowBaseRef(sourceRepo),
 		config,
 	);
 	const counts = await countGitSubprocesses(workspacePath, sourceRepo);
@@ -289,7 +289,7 @@ async function countGitSubprocesses(workspacePath, sourceRepo) {
 			process.chdir(tracedRepo);
 			completeBaseRef();
 			const autocomplete = await countLogLines(logPath);
-			await detectFallowGitState(tracedRepo);
+			await detectFallowBaseRef(tracedRepo);
 			const total = await countLogLines(logPath);
 			return { autocomplete, baseDetection: total - autocomplete };
 		} finally {

--- a/tests/autocomplete.test.mjs
+++ b/tests/autocomplete.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const jiti = createJiti(import.meta.url);
+const { fallowCompletions } = await jiti.import("../extensions/fallow/autocomplete.ts");
+const { needsFallowBaseDetection, normalizeFallowArgs } = await jiti.import("../extensions/fallow/command/args.ts");
+const { resolveFallowCommandBaseRef } = await jiti.import("../extensions/fallow/command/base.ts");
+const { detectFallowBaseRef } = await jiti.import("../extensions/fallow/project/git.ts");
+const { registerFallowSessionStart } = await jiti.import("../extensions/fallow/session.ts");
+
+function labels(items) {
+	return items?.map((item) => item.label) ?? [];
+}
+
+function completionLabels(input) {
+	return labels(fallowCompletions.getFallowArgumentCompletions(input));
+}
+
+function gitResult(stdout, code = 0) {
+	return { stdout, stderr: "", code, killed: false };
+}
+
+function commandState() {
+	return { lastArgs: null, baseRefs: new Map() };
+}
+
+function git(cwd, args) {
+	return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+describe("Fallow autocomplete", () => {
+	it("returns command, flag, and fixed-value completions", () => {
+		assert.ok(labels(fallowCompletions.getFallowRootCommandCompletions()).includes("health"));
+		assert.ok(completionLabels("").includes("audit PR (main)"));
+		assert.ok(completionLabels("health --").includes("--group-by"));
+		assert.deepEqual(completionLabels("health --group-by o"), ["owner"]);
+		assert.ok(completionLabels("health --group-by=o").includes("--group-by=owner"));
+		assert.deepEqual(completionLabels("coverage "), ["analyze"]);
+		assert.equal(fallowCompletions.getFallowArgumentCompletions("rerun "), null);
+	});
+
+	it("returns static refs immediately while asynchronously loading project refs", async () => {
+		let finishGit;
+		const calls = [];
+		const pi = {
+			exec(command, args, options) {
+				calls.push({ command, args, options });
+				return new Promise((resolvePromise) => { finishGit = resolvePromise; });
+			},
+		};
+		const cwd = resolve(root, ".tmp-autocomplete-project-a");
+		const refresh = fallowCompletions.preloadGitReferences(pi, cwd);
+		const immediate = completionLabels("audit --base ");
+		assert.ok(immediate.includes("origin/main"));
+		assert.equal(immediate.includes("feature/async-refs"), false);
+		assert.deepEqual(calls, [{
+			command: "git",
+			args: ["for-each-ref", "--format=%(refname:short)", "refs/heads", "refs/remotes"],
+			options: { cwd, timeout: 1200 },
+		}]);
+
+		finishGit(gitResult("feature/async-refs\norigin/main\norigin/HEAD\nHEAD\n"));
+		await refresh;
+		const refreshed = completionLabels("audit --base ");
+		assert.ok(refreshed.includes("feature/async-refs"));
+		assert.equal(refreshed.includes("origin/HEAD"), false);
+		assert.equal(refreshed.includes("HEAD"), false);
+	});
+
+	it("keys cached refs by Pi's cwd and preserves them after refresh failures", async () => {
+		const firstCwd = resolve(root, ".tmp-autocomplete-project-b");
+		await fallowCompletions.preloadGitReferences({ exec: async () => gitResult("feature/first\n") }, firstCwd);
+		assert.ok(completionLabels("audit --base ").includes("feature/first"));
+
+		const secondCwd = resolve(root, ".tmp-autocomplete-project-c");
+		let finishSecond;
+		const secondRefresh = fallowCompletions.preloadGitReferences({
+			exec: () => new Promise((resolvePromise) => { finishSecond = resolvePromise; }),
+		}, secondCwd);
+		assert.equal(completionLabels("audit --base ").includes("feature/first"), false);
+		finishSecond(gitResult("feature/second\n"));
+		await secondRefresh;
+		assert.ok(completionLabels("audit --base ").includes("feature/second"));
+
+		await fallowCompletions.preloadGitReferences({ exec: async () => gitResult("", 1) }, secondCwd);
+		assert.ok(completionLabels("audit --base ").includes("feature/second"));
+	});
+
+	it("preloads refs from Pi's TUI session cwd only", () => {
+		let sessionStart;
+		const calls = [];
+		let providers = 0;
+		const pi = {
+			on(event, handler) { if (event === "session_start") sessionStart = handler; },
+			exec(command, args, options) {
+				calls.push({ command, args, options });
+				return Promise.resolve(gitResult("feature/session\n"));
+			},
+		};
+		const previous = process.env.PI_FALLOW_DISABLE_UPDATE_NOTICE;
+		process.env.PI_FALLOW_DISABLE_UPDATE_NOTICE = "1";
+		try {
+			registerFallowSessionStart(pi);
+			sessionStart({}, { mode: "rpc", cwd: "/rpc-project", ui: { addAutocompleteProvider() { providers++; } } });
+			sessionStart({}, { mode: "tui", cwd: "/tui-project", ui: { addAutocompleteProvider() { providers++; } } });
+		} finally {
+			if (previous === undefined) delete process.env.PI_FALLOW_DISABLE_UPDATE_NOTICE;
+			else process.env.PI_FALLOW_DISABLE_UPDATE_NOTICE = previous;
+		}
+		assert.equal(calls.length, 1);
+		assert.equal(calls[0].options.cwd, resolve("/tui-project"));
+		assert.equal(providers, 1);
+	});
+
+	it("contains no synchronous Git or process.cwd call in the completion path", async () => {
+		const source = await readFile(resolve(root, "extensions/fallow/autocomplete.ts"), "utf8");
+		assert.doesNotMatch(source, /execFileSync/);
+		assert.doesNotMatch(source, /process\.cwd\(\)/);
+	});
+});
+
+describe("Fallow command base detection", () => {
+	it("only detects a base for pr without an explicit base", () => {
+		assert.equal(needsFallowBaseDetection(["health"]), false);
+		assert.equal(needsFallowBaseDetection(["pr", "--help"]), false);
+		assert.equal(needsFallowBaseDetection(["pr", "--base", "main"]), false);
+		assert.equal(needsFallowBaseDetection(["pr", "--base=main"]), false);
+		assert.equal(needsFallowBaseDetection(["pr"]), true);
+	});
+
+	it("skips Git for ordinary commands and explicit PR bases", async () => {
+		const state = commandState();
+		let detections = 0;
+		const detector = async () => { detections++; return "origin/main"; };
+		assert.equal(await resolveFallowCommandBaseRef(["health"], "/project", state, detector), "main");
+		assert.equal(await resolveFallowCommandBaseRef(["pr", "--base", "release"], "/project", state, detector), "main");
+		assert.equal(detections, 0);
+	});
+
+	it("caches the detected PR base per project", async () => {
+		const state = commandState();
+		let detections = 0;
+		const detector = async (cwd) => { detections++; return cwd.endsWith("one") ? "origin/main" : undefined; };
+		assert.equal(await resolveFallowCommandBaseRef(["pr"], "/project/one", state, detector), "origin/main");
+		assert.equal(await resolveFallowCommandBaseRef(["pr"], "/project/one", state, detector), "origin/main");
+		assert.equal(await resolveFallowCommandBaseRef(["pr"], "/project/two", state, detector), "main");
+		assert.equal(await resolveFallowCommandBaseRef(["pr"], "/project/two", state, detector), "main");
+		assert.equal(detections, 2);
+	});
+
+	it("detects the first available base ref without probing unrelated Git state", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-base-"));
+		try {
+			git(workspace, ["init", "-q"]);
+			git(workspace, ["config", "user.email", "test@example.invalid"]);
+			git(workspace, ["config", "user.name", "Pi Fallow Test"]);
+			await writeFile(join(workspace, "index.ts"), "export const value = true;\n", "utf8");
+			git(workspace, ["add", "index.ts"]);
+			git(workspace, ["commit", "-qm", "initial"]);
+			git(workspace, ["branch", "-M", "main"]);
+			git(workspace, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+			assert.equal(await detectFallowBaseRef(workspace), "origin/main");
+		} finally {
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps normalization behavior for detected and explicit bases", () => {
+		const notify = () => {};
+		assert.deepEqual(normalizeFallowArgs(["pr"], "origin/main", null, notify), [
+			"audit", "--base", "origin/main", "--gate", "new-only",
+		]);
+		assert.deepEqual(normalizeFallowArgs(["pr", "--base", "release"], "main", null, notify), [
+			"audit", "--base", "release", "--gate", "new-only",
+		]);
+	});
+});


### PR DESCRIPTION
   ## Summary

   Removes synchronous Git subprocesses from editor autocomplete and avoids unnecessary base-ref detection for ordinary `/fallow` commands.

   This PR:

   - removes `execFileSync()` from autocomplete
   - removes autocomplete’s dependency on `process.cwd()`
   - returns static ref suggestions immediately
   - asynchronously loads project refs during TUI `session_start`
   - uses `pi.exec()` with `ctx.cwd` and a bounded timeout
   - caches refs per project and preserves cached values when refresh fails
   - detects a base only for `/fallow pr` without an explicit `--base`
   - caches the detected PR base per project/session
   - reduces base detection to one Git subprocess
   - removes unused full Git-state probing and types

   ## Autocomplete behavior

   Autocomplete now returns these static refs immediately:

   ```text
   origin/main
   origin/master
   main
   master
   HEAD~1
 ```

 Project branches are loaded asynchronously with:

 ```text
   git for-each-ref --format=%(refname:short) refs/heads refs/remotes
 ```

 The completion callback performs no Git or filesystem work. Once the background refresh completes, subsequent completion requests include discovered branches.

 Symbolic refs such as HEAD and origin/HEAD remain excluded.

 Base detection

 Previously every /fallow command performed three Git subprocesses for repository, branch, and base detection.

 Now:

 - /fallow health, dupes, dead-code, rerun, and other ordinary commands perform no base lookup
 - /fallow pr --base <ref> performs no lookup
 - /fallow pr --help performs no lookup
 - /fallow pr performs one lookup
 - subsequent /fallow pr commands reuse the cached project base

 Performance
 Base detection is approximately 65.7% faster, and autocomplete no longer starts a subprocess while typing.

 Manual command validation confirmed:

 ```text
   /fallow health: 0 Git processes
   /fallow pr:     1 Git process
 ```

 Tests

 Added coverage for:

 - command, flag, fixed-value, and ref completions
 - immediate static refs while refresh is pending
 - asynchronous project-ref loading
 - ctx.cwd propagation
 - per-project ref caches
 - failed refresh cache preservation
 - TUI-only preload behavior
 - absence of execFileSync and process.cwd() in autocomplete
 - conditional base detection
 - explicit-base and help bypasses
 - per-project base caching
 - actual base-ref detection against a temporary Git repository

 Coverage

 All-source coverage is now:

 - Lines/statements: 62.58%
 - Functions: 67.87%
 - Branches: 80.41%

 Coverage gates were raised to:

 - Lines/statements: 58%
 - Functions: 67%
 - Branches: 79%

 Validation

 - [x] 66 tests pass on Node.js 22.19
 - [x] 66 tests pass on Node.js 24
 - [x] Coverage thresholds pass
 - [x] Bundle validation passes
 - [x] Full publish validation passes
 - [x] Fallow health reports no findings
 - [x] Changed-file audit passes
 - [x] Dead-code check reports zero issues
 - [x] Duplication check reports zero clone groups
 - [x] Dependency audits pass
 - [x] Package installation smoke test passes
 - [x] Token benchmark reports no changes
 - [x] Retained-memory measurements are unchanged

 Stacking

 This PR is currently based on fix/run-mode-compatibility.
