### PR TITLE
perf: cache Fallow runner resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to Pi Fallow are documented here.
 - Raised the minimum Node.js version to 22.19 to match the current Pi peer packages.
 - Pinned Fallow, esbuild, and coverage tooling for reproducible development and CI checks.
 - Made Git ref autocomplete non-blocking and keyed it to Pi's project directory; base-ref detection now runs only for `/fallow pr` without an explicit base and is cached per project.
+- Cached Fallow runner resolution per project/session, including direct reuse of the npx-installed executable, environment-aware refresh, and one safe retry when an automatically discovered executable disappears.
 
 ### Fixed
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 - **Interactive navigator:** findings open in a bordered TUI view where you can inspect, select, trace, or load issues into the editor.
 - **Run-mode support:** `/fallow` executes in TUI, RPC, JSON, and print modes; terminal loaders and navigator overlays are TUI-only, while non-TUI modes retain full transcript output.
 - **Safe defaults:** JSON and quiet output are added when appropriate; large output is truncated for the transcript and saved to a temp file.
-- **Flexible CLI lookup:** uses `FALLOW_BIN` first, then `fallow` from `PATH`, then falls back to `npx -y fallow`.
+- **Cached CLI lookup:** resolves `FALLOW_BIN`, `fallow` from `PATH`, or a package-local installation once per project/session before falling back to `npx -y fallow`.
 
 ## Installation
 
@@ -108,7 +108,10 @@ In the interactive navigator:
 - Fallow available through one of:
   - `FALLOW_BIN=/path/to/fallow`
   - `fallow` on `PATH`
+  - a package-local Fallow installation
   - `npx -y fallow` fallback
+
+Runner resolution is refreshed when `FALLOW_BIN` or `PATH` changes. The npx fallback locates the installed package once and invokes its executable directly for later commands. If an automatically resolved executable disappears, Pi Fallow invalidates it and retries the next route once. An invalid explicit `FALLOW_BIN`, cancellation, timeout, or a command that already started never falls through to another installation.
 
 The Pi package declares Pi libraries as peer dependencies, as recommended for Pi extensions.
 

--- a/extensions/fallow.ts
+++ b/extensions/fallow.ts
@@ -40,7 +40,7 @@ function registerFallowTool(pi: ExtensionAPI): void {
 }
 
 function buildFallowToolDescription(): string {
-	return `Run Fallow codebase intelligence for TypeScript/JavaScript: PR/new-issue audits (audit --base ... --gate new-only), changed-file checks, dead code, duplication, health, inspect/trace evidence, security candidates, decision surfaces, project/config/schema info, feature flags, impact, auto-fix preview/apply, and runtime coverage. JSON output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}; full output is saved to a temp file when truncated. Uses FALLOW_BIN if set, otherwise fallow from PATH, falling back to npx -y fallow.`;
+	return `Run Fallow codebase intelligence for TypeScript/JavaScript: PR/new-issue audits (audit --base ... --gate new-only), changed-file checks, dead code, duplication, health, inspect/trace evidence, security candidates, decision surfaces, project/config/schema info, feature flags, impact, auto-fix preview/apply, and runtime coverage. JSON output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}; full output is saved to a temp file when truncated. Caches FALLOW_BIN, PATH, package-local, or npx runner resolution per session.`;
 }
 
 const fallowToolPromptGuidelines = [

--- a/extensions/fallow/cli.ts
+++ b/extensions/fallow/cli.ts
@@ -1,8 +1,9 @@
 import { resolve } from "node:path";
-import type { ExtensionAPI, ExtensionContext, ExecResult } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { fallowEngine } from "./engine";
 import { stripAtPrefix } from "./path";
 import { execFallowProcess } from "./process";
+import { createFallowRunner } from "./runner";
 import type { FallowRunParams } from "./schema";
 
 function addValue(args: string[], flag: string, value: unknown): void {
@@ -285,33 +286,14 @@ function buildFallowArgs(params: FallowRunParams): string[] {
 	return args;
 }
 
-async function execFallow(_pi: ExtensionAPI, args: string[], cwd: string, signal: AbortSignal | undefined, timeoutSecs: number): Promise<{ binary: string; args: string[]; result: ExecResult }> {
-	const configuredBin = process.env.FALLOW_BIN;
-	const binary = configuredBin || "fallow";
-	const result = await execFallowProcess(binary, args, cwd, signal, timeoutSecs);
-	if (!shouldTryNpxFallback(configuredBin, result)) {
-		return { binary, args, result };
-	}
-	const npxArgs = buildNpxArgs(args);
-	return { binary: "npx", args: npxArgs, result: await execFallowProcess("npx", npxArgs, cwd, signal, timeoutSecs) };
+const fallowRunner = createFallowRunner();
+
+function execFallow(pi: ExtensionAPI, args: string[], cwd: string, signal: AbortSignal | undefined, timeoutSecs: number) {
+	return fallowRunner.execute(pi, args, cwd, signal, timeoutSecs);
 }
 
-function shouldTryNpxFallback(configuredBin: string | undefined, result: ExecResult): boolean {
-	if (configuredBin) return false;
-	if (!isNpxFallbackCode(result.code)) return false;
-	return result.code === 127 || isEmptyFailureOutput(result);
-}
-
-function isNpxFallbackCode(code: number): boolean {
-	return code === 127 || code === 1;
-}
-
-function isEmptyFailureOutput(result: ExecResult): boolean {
-	return !result.stdout.trim() && !result.stderr.trim();
-}
-
-function buildNpxArgs(args: string[]): string[] {
-	return ["-y", "fallow", ...args];
+function clearRunnerCache(pi: ExtensionAPI): void {
+	fallowRunner.clear(pi);
 }
 
 function resolveFallowRoot(params: FallowRunParams, contextRoot: string): string {
@@ -428,6 +410,7 @@ export const fallowCli = {
 	runFallow,
 	execFallow,
 	execCommand: execFallowProcess,
+	clearRunnerCache,
 	splitArgs,
 	buildFallowArgs,
 };

--- a/extensions/fallow/process.ts
+++ b/extensions/fallow/process.ts
@@ -7,6 +7,13 @@ const PROCESS_KILL_GRACE_MS = 1_000;
 type SpawnedProcess = ReturnType<typeof spawn>;
 type ProcessSignal = "SIGTERM" | "SIGKILL";
 
+export interface FallowProcessResult extends ExecResult {
+	launchError?: {
+		code?: string;
+		message: string;
+	};
+}
+
 function signalWindowsTree(proc: SpawnedProcess, force: boolean): void {
 	const taskkillArgs = ["/PID", String(proc.pid), "/T", ...(force ? ["/F"] : [])];
 	const taskkill = spawn("taskkill", taskkillArgs, { stdio: "ignore", windowsHide: true });
@@ -75,7 +82,7 @@ export async function execFallowProcess(
 	cwd: string,
 	signal: AbortSignal | undefined,
 	timeoutSecs: number,
-): Promise<ExecResult> {
+): Promise<FallowProcessResult> {
 	if (signal?.aborted) return { stdout: "", stderr: "", code: 130, killed: true };
 	return new Promise((resolve) => {
 		const proc = spawn(command, args, {
@@ -89,6 +96,7 @@ export async function execFallowProcess(
 		let stdout = "";
 		let stderr = "";
 		let killed = false;
+		let launched = false;
 		let settled = false;
 		let timeoutId: ReturnType<typeof setTimeout> | undefined;
 		let forceKillId: ReturnType<typeof setTimeout> | undefined;
@@ -116,8 +124,15 @@ export async function execFallowProcess(
 
 		proc.stdout?.on("data", (data) => { stdout += data.toString(); });
 		proc.stderr?.on("data", (data) => { stderr += data.toString(); });
+		proc.on("spawn", () => { launched = true; });
 		proc.on("error", (error: NodeJS.ErrnoException) => {
-			finish({ stdout, stderr: stderr || error.message, code: error.code === "ENOENT" ? 127 : 1, killed });
+			finish({
+				stdout,
+				stderr: stderr || error.message,
+				code: error.code === "ENOENT" ? 127 : 1,
+				killed,
+				launchError: launched ? undefined : { code: error.code, message: error.message },
+			});
 		});
 		proc.on("close", (code) => {
 			forceRemainingProcessTree(proc, killed);

--- a/extensions/fallow/runner.ts
+++ b/extensions/fallow/runner.ts
@@ -1,0 +1,445 @@
+import { constants } from "node:fs";
+import { access, stat } from "node:fs/promises";
+import { delimiter, dirname, extname, join, resolve } from "node:path";
+import type { ExecResult, ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { execFallowProcess, type FallowProcessResult } from "./process";
+
+const DEFAULT_FALLBACK_CACHE_TTL_MS = 30_000;
+const PACKAGE_ROOT = resolve(import.meta.dirname, "../..");
+const RECOVERABLE_LAUNCH_ERRORS = new Set(["ENOENT", "EACCES"]);
+const NPX_PACKAGE_LOCATOR_ARGS = [
+	"-y",
+	"--package=fallow",
+	process.execPath,
+	"-e",
+	"process.stdout.write(process.env.PATH || '')",
+];
+
+type RunnerSource = "configured" | "path" | "package" | "npx-package" | "npx";
+type ProcessExecutor = (
+	command: string,
+	args: string[],
+	cwd: string,
+	signal: AbortSignal | undefined,
+	timeoutSecs: number,
+) => Promise<FallowProcessResult>;
+type ExecutableFinder = (name: string, pathValue: string, cwd: string) => Promise<string | undefined>;
+
+interface RunnerRoute {
+	command: string;
+	displayBinary: string;
+	argsPrefix: string[];
+	source: RunnerSource;
+	expiresAt?: number;
+}
+
+interface RunnerEnvironment {
+	configuredBin?: string;
+	pathValue: string;
+}
+
+interface RunnerRequest {
+	cwd: string;
+	signal: AbortSignal | undefined;
+	timeoutSecs: number;
+}
+
+interface RunnerCacheEntry {
+	key: string;
+	environment: RunnerEnvironment;
+	route?: RunnerRoute;
+	resolving?: Promise<RunnerRoute>;
+}
+
+interface RunnerOptions {
+	executeProcess?: ProcessExecutor;
+	findExecutable?: ExecutableFinder;
+	fallbackCacheTtlMs?: number;
+	now?: () => number;
+	packageRoot?: string | null;
+	resolveNpxPackage?: boolean;
+}
+
+interface FallowRunnerExecution {
+	binary: string;
+	args: string[];
+	result: ExecResult;
+}
+
+export function createFallowRunner({
+	executeProcess = execFallowProcess,
+	findExecutable = findExecutableOnPath,
+	fallbackCacheTtlMs = DEFAULT_FALLBACK_CACHE_TTL_MS,
+	now = Date.now,
+	packageRoot = PACKAGE_ROOT,
+	resolveNpxPackage = true,
+}: RunnerOptions = {}) {
+	const sessionCaches = new WeakMap<ExtensionAPI, Map<string, RunnerCacheEntry>>();
+
+	async function execute(
+		pi: ExtensionAPI,
+		args: string[],
+		cwd: string,
+		signal: AbortSignal | undefined,
+		timeoutSecs: number,
+	): Promise<FallowRunnerExecution> {
+		if (signal?.aborted) return unresolvedCancellation(args);
+		const request = { cwd: resolve(cwd), signal, timeoutSecs };
+		const route = await resolveCachedRoute(pi, request);
+		return executeResolvedRoute(pi, args, request, route);
+	}
+
+	async function executeResolvedRoute(
+		pi: ExtensionAPI,
+		args: string[],
+		request: RunnerRequest,
+		route: RunnerRoute,
+	): Promise<FallowRunnerExecution> {
+		if (request.signal?.aborted) return routeCancellation(route, args);
+		const execution = await executeRoute(route, args, request.cwd, request.signal, request.timeoutSecs);
+		return handleExecution(pi, args, request, route, execution);
+	}
+
+	function handleExecution(
+		pi: ExtensionAPI,
+		args: string[],
+		request: RunnerRequest,
+		route: RunnerRoute,
+		execution: FallowRunnerExecution & { result: FallowProcessResult },
+	): Promise<FallowRunnerExecution> | FallowRunnerExecution {
+		if (shouldRetryExecution(route, execution.result)) {
+			return retryExecution(pi, args, request, route, execution);
+		}
+		return completeExecution(pi, request.cwd, route, execution);
+	}
+
+	function completeExecution(
+		pi: ExtensionAPI,
+		cwd: string,
+		route: RunnerRoute,
+		execution: FallowRunnerExecution & { result: FallowProcessResult },
+	): FallowRunnerExecution {
+		if (execution.result.launchError) removeCachedRoute(pi, cwd, route);
+		return finalizeExecution(execution, route.source === "configured");
+	}
+
+	async function retryExecution(
+		pi: ExtensionAPI,
+		args: string[],
+		request: RunnerRequest,
+		failedRoute: RunnerRoute,
+		failedExecution: FallowRunnerExecution & { result: FallowProcessResult },
+	): Promise<FallowRunnerExecution> {
+		removeCachedRoute(pi, request.cwd, failedRoute);
+		const retryRoute = await resolveRetryRoute(pi, request, failedRoute);
+		if (!retryRoute) return finalizeExecution(failedExecution, false);
+		const retry = await executeRoute(retryRoute, args, request.cwd, request.signal, request.timeoutSecs);
+		if (retry.result.launchError) removeCachedRoute(pi, request.cwd, retryRoute);
+		return finalizeExecution(retry, retryRoute.source === "configured");
+	}
+
+	function clear(pi: ExtensionAPI): void {
+		sessionCaches.delete(pi);
+	}
+
+	async function resolveCachedRoute(pi: ExtensionAPI, request: RunnerRequest): Promise<RunnerRoute> {
+		const entry = cacheEntry(pi, request.cwd);
+		const cached = usableCachedRoute(entry.route, now());
+		if (cached) return cached;
+		if (entry.resolving) return entry.resolving;
+		const pending = discoverRoute(entry.environment, request, new Set(), true)
+			.then((route) => resolvedRouteOrFallback(route, now(), fallbackCacheTtlMs));
+		entry.resolving = pending;
+		try {
+			const route = await pending;
+			cacheResolvedRoute(entry, route, request.signal);
+			return route;
+		} finally {
+			entry.resolving = undefined;
+		}
+	}
+
+	async function resolveRetryRoute(pi: ExtensionAPI, request: RunnerRequest, failed: RunnerRoute): Promise<RunnerRoute | undefined> {
+		const entry = cacheEntry(pi, request.cwd);
+		const route = await discoverRoute(entry.environment, request, new Set([failed.command]), failed.source !== "npx");
+		if (route) entry.route = route;
+		return route;
+	}
+
+	async function discoverRoute(
+		environment: RunnerEnvironment,
+		request: RunnerRequest,
+		skippedCommands: Set<string>,
+		allowNpx: boolean,
+	): Promise<RunnerRoute | undefined> {
+		if (environment.configuredBin) return configuredRoute(environment.configuredBin);
+		return discoverAutomaticRoute(environment.pathValue, request, skippedCommands, allowNpx);
+	}
+
+	async function discoverAutomaticRoute(
+		pathValue: string,
+		request: RunnerRequest,
+		skipped: Set<string>,
+		allowNpx: boolean,
+	): Promise<RunnerRoute | undefined> {
+		const pathCandidate = await discoverPathRoute(pathValue, request.cwd, skipped);
+		if (pathCandidate) return pathCandidate;
+		const packageCandidate = await discoverPackageRoute(skipped);
+		if (packageCandidate) return packageCandidate;
+		return discoverFallbackRoute(pathValue, request, skipped, allowNpx);
+	}
+
+	async function discoverFallbackRoute(
+		pathValue: string,
+		request: RunnerRequest,
+		skipped: Set<string>,
+		allowNpx: boolean,
+	): Promise<RunnerRoute | undefined> {
+		if (!allowNpx) return undefined;
+		return discoverNpxRoute(pathValue, request, skipped);
+	}
+
+	async function discoverPathRoute(pathValue: string, cwd: string, skipped: Set<string>): Promise<RunnerRoute | undefined> {
+		const command = await findExecutable("fallow", pathValue, cwd);
+		return availableRoute(command, skipped, pathRoute);
+	}
+
+	async function discoverPackageRoute(skipped: Set<string>): Promise<RunnerRoute | undefined> {
+		if (!packageRoot) return undefined;
+		const command = await findExecutable("fallow", packageBinPath(packageRoot), packageRoot);
+		return availableRoute(command, skipped, packageRoute);
+	}
+
+	async function discoverNpxRoute(
+		pathValue: string,
+		request: RunnerRequest,
+		skipped: Set<string>,
+	): Promise<RunnerRoute | undefined> {
+		const pathNpx = await findExecutable("npx", pathValue, request.cwd);
+		if (!pathNpx) return unresolvedNpxRoute(skipped, now(), fallbackCacheTtlMs);
+		return discoverAvailableNpxRoute(pathNpx, request, skipped);
+	}
+
+	async function discoverAvailableNpxRoute(
+		pathNpx: string,
+		request: RunnerRequest,
+		skipped: Set<string>,
+	): Promise<RunnerRoute | undefined> {
+		if (skipped.has(pathNpx)) return undefined;
+		const fallback = npxRoute(pathNpx, now(), fallbackCacheTtlMs);
+		if (!resolveNpxPackage) return fallback;
+		return discoverNpxPackageRoute(pathNpx, request, skipped, fallback);
+	}
+
+	async function discoverNpxPackageRoute(
+		npxCommand: string,
+		request: RunnerRequest,
+		skipped: Set<string>,
+		fallback: RunnerRoute,
+	): Promise<RunnerRoute> {
+		const command = await locateNpxPackage(npxCommand, request);
+		return availableRoute(command, skipped, npxPackageRoute) ?? fallback;
+	}
+
+	async function locateNpxPackage(npxCommand: string, request: RunnerRequest): Promise<string | undefined> {
+		const result = await executeProcess(
+			npxCommand,
+			NPX_PACKAGE_LOCATOR_ARGS,
+			request.cwd,
+			request.signal,
+			locatorTimeout(request.timeoutSecs),
+		);
+		if (result.code !== 0 || result.killed) return undefined;
+		return findExecutable("fallow", result.stdout, request.cwd);
+	}
+
+	function cacheEntry(pi: ExtensionAPI, cwd: string): RunnerCacheEntry {
+		let projectCaches = sessionCaches.get(pi);
+		if (!projectCaches) {
+			projectCaches = new Map();
+			sessionCaches.set(pi, projectCaches);
+		}
+		const environment = currentEnvironment();
+		const key = environmentKey(environment);
+		const existing = projectCaches.get(cwd);
+		if (existing?.key === key) return existing;
+		const created = { key, environment };
+		projectCaches.set(cwd, created);
+		return created;
+	}
+
+	function removeCachedRoute(pi: ExtensionAPI, cwd: string, route: RunnerRoute): void {
+		const entry = sessionCaches.get(pi)?.get(cwd);
+		if (entry?.route === route) entry.route = undefined;
+	}
+
+	async function executeRoute(
+		route: RunnerRoute,
+		args: string[],
+		cwd: string,
+		signal: AbortSignal | undefined,
+		timeoutSecs: number,
+	): Promise<FallowRunnerExecution & { result: FallowProcessResult }> {
+		const executedArgs = [...route.argsPrefix, ...args];
+		const result = await executeProcess(route.command, executedArgs, cwd, signal, timeoutSecs);
+		return { binary: route.displayBinary, args: executedArgs, result };
+	}
+
+	return { execute, clear };
+}
+
+function packageBinPath(packageRoot: string): string {
+	return [
+		join(packageRoot, "node_modules", ".bin"),
+		join(dirname(packageRoot), ".bin"),
+	].join(delimiter);
+}
+
+function unresolvedCancellation(args: string[]): FallowRunnerExecution {
+	const binary = process.env.FALLOW_BIN || "fallow";
+	return { binary, args, result: cancellationResult() };
+}
+
+function routeCancellation(route: RunnerRoute, args: string[]): FallowRunnerExecution {
+	return {
+		binary: route.displayBinary,
+		args: [...route.argsPrefix, ...args],
+		result: cancellationResult(),
+	};
+}
+
+function cancellationResult(): FallowProcessResult {
+	return { stdout: "", stderr: "", code: 130, killed: true };
+}
+
+function usableCachedRoute(route: RunnerRoute | undefined, now: number): RunnerRoute | undefined {
+	if (!route || isExpired(route, now)) return undefined;
+	return route;
+}
+
+function resolvedRouteOrFallback(route: RunnerRoute | undefined, now: number, ttlMs: number): RunnerRoute {
+	return route ?? npxRoute("npx", now, ttlMs);
+}
+
+function cacheResolvedRoute(entry: RunnerCacheEntry, route: RunnerRoute, signal: AbortSignal | undefined): void {
+	if (signal?.aborted) return;
+	entry.route = route;
+}
+
+function unresolvedNpxRoute(skipped: Set<string>, now: number, ttlMs: number): RunnerRoute | undefined {
+	if (skipped.has("npx")) return undefined;
+	return npxRoute("npx", now, ttlMs);
+}
+
+function availableRoute(
+	command: string | undefined,
+	skipped: Set<string>,
+	build: (command: string) => RunnerRoute,
+): RunnerRoute | undefined {
+	if (!command || skipped.has(command)) return undefined;
+	return build(command);
+}
+
+function shouldRetryExecution(route: RunnerRoute, result: FallowProcessResult): boolean {
+	return route.source !== "configured" && isRecoverableLaunchFailure(result);
+}
+
+function currentEnvironment(): RunnerEnvironment {
+	return {
+		configuredBin: process.env.FALLOW_BIN || undefined,
+		pathValue: process.env.PATH ?? "",
+	};
+}
+
+function environmentKey(environment: RunnerEnvironment): string {
+	return JSON.stringify([environment.configuredBin ?? null, environment.pathValue]);
+}
+
+function configuredRoute(command: string): RunnerRoute {
+	return { command, displayBinary: command, argsPrefix: [], source: "configured" };
+}
+
+function pathRoute(command: string): RunnerRoute {
+	return { command, displayBinary: "fallow", argsPrefix: [], source: "path" };
+}
+
+function packageRoute(command: string): RunnerRoute {
+	return { command, displayBinary: command, argsPrefix: [], source: "package" };
+}
+
+function npxPackageRoute(command: string): RunnerRoute {
+	return { command, displayBinary: command, argsPrefix: [], source: "npx-package" };
+}
+
+function npxRoute(command: string, now: number, ttlMs: number): RunnerRoute {
+	return {
+		command,
+		displayBinary: "npx",
+		argsPrefix: ["-y", "fallow"],
+		source: "npx",
+		expiresAt: now + ttlMs,
+	};
+}
+
+function isExpired(route: RunnerRoute, now: number): boolean {
+	return route.expiresAt !== undefined && route.expiresAt <= now;
+}
+
+function locatorTimeout(commandTimeoutSecs: number): number {
+	if (commandTimeoutSecs <= 0) return 30;
+	return Math.min(commandTimeoutSecs, 30);
+}
+
+function isRecoverableLaunchFailure(result: FallowProcessResult): boolean {
+	return !!result.launchError?.code && RECOVERABLE_LAUNCH_ERRORS.has(result.launchError.code);
+}
+
+function finalizeExecution(
+	execution: FallowRunnerExecution & { result: FallowProcessResult },
+	configured: boolean,
+): FallowRunnerExecution {
+	if (!execution.result.launchError) return execution;
+	const guidance = configured
+		? "Unable to launch FALLOW_BIN. Verify that the configured executable exists and is runnable."
+		: "Unable to launch Fallow. Install fallow on PATH or set FALLOW_BIN to a runnable executable.";
+	return {
+		...execution,
+		result: {
+			...execution.result,
+			stderr: [execution.result.stderr.trim(), guidance].filter(Boolean).join("\n"),
+		},
+	};
+}
+
+async function findExecutableOnPath(name: string, pathValue: string, cwd: string): Promise<string | undefined> {
+	for (const entry of pathValue.split(delimiter)) {
+		const directory = resolvePathEntry(entry, cwd);
+		for (const executableName of executableNames(name)) {
+			const candidate = join(directory, executableName);
+			if (await isExecutableFile(candidate)) return candidate;
+		}
+	}
+	return undefined;
+}
+
+function resolvePathEntry(entry: string, cwd: string): string {
+	const unquoted = entry.replace(/^"|"$/g, "");
+	return resolve(cwd, unquoted || ".");
+}
+
+function executableNames(name: string): string[] {
+	if (process.platform !== "win32" || extname(name)) return [name];
+	const extensions = (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";");
+	return [name, ...extensions.map((extension) => `${name}${extension.toLowerCase()}`)];
+}
+
+async function isExecutableFile(path: string): Promise<boolean> {
+	try {
+		const info = await stat(path);
+		if (!info.isFile()) return false;
+		await access(path, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/extensions/fallow/session.ts
+++ b/extensions/fallow/session.ts
@@ -1,9 +1,11 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { fallowCompletions } from "./autocomplete";
+import { fallowCli } from "./cli";
 import { scheduleFallowUpdateNotice } from "./update-notice";
 
 export function registerFallowSessionStart(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
+		fallowCli.clearRunnerCache(pi);
 		if (ctx.mode !== "tui") return;
 		void fallowCompletions.preloadGitReferences(pi, ctx.cwd);
 		scheduleFallowUpdateNotice(pi, ctx);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dupes": "fallow dupes --format json --quiet",
     "dead-code": "fallow dead-code --format json --quiet",
     "test": "node --test",
-    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=58 --statements=58 --functions=67 --branches=79 node --test",
+    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=64 --statements=64 --functions=70 --branches=80 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",

--- a/scripts/performance-benchmark.mjs
+++ b/scripts/performance-benchmark.mjs
@@ -28,7 +28,10 @@ const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
 const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
 const { fallowCompletions } = await jiti.import("../extensions/fallow/autocomplete.ts");
 const { detectFallowBaseRef } = await jiti.import("../extensions/fallow/project/git.ts");
+const { createFallowRunner } = await jiti.import("../extensions/fallow/runner.ts");
 
+const benchmarkPi = {};
+const benchmarkRunner = createFallowRunner({ packageRoot: null });
 const cli = parseCli(process.argv.slice(2));
 const packageJson = JSON.parse(await readFile(join(ROOT, "package.json"), "utf8"));
 const corpus = JSON.parse(await readFile(join(ROOT, "benchmarks", "corpus.json"), "utf8"));
@@ -169,7 +172,7 @@ async function benchmarkSystemResolution(pathValue, cwd, config) {
 }
 
 async function runSystemFallow(cwd) {
-	const { result, binary } = await fallowCli.execFallow({}, ["dupes", "--format", "json", "--quiet"], cwd, undefined, 120);
+	const { result, binary } = await benchmarkRunner.execute(benchmarkPi, ["dupes", "--format", "json", "--quiet"], cwd, undefined, 120);
 	const parsed = JSON.parse(result.stdout);
 	return { internalElapsedMs: parsed.elapsed_ms, binary, fallowVersion: parsed.version };
 }
@@ -180,7 +183,7 @@ async function copyExecutable(source, target) {
 }
 
 async function runFallowFixture() {
-	const { result, binary } = await fallowCli.execFallow({}, ["dead-code", "--format", "json", "--quiet"], ROOT, undefined, 120);
+	const { result, binary } = await benchmarkRunner.execute(benchmarkPi, ["dead-code", "--format", "json", "--quiet"], ROOT, undefined, 120);
 	const parsed = JSON.parse(result.stdout);
 	return { internalElapsedMs: parsed.elapsed_ms, binary };
 }

--- a/tests/execution.test.mjs
+++ b/tests/execution.test.mjs
@@ -93,10 +93,19 @@ describe("Fallow process execution", () => {
 		assert.deepEqual(result, { stdout: "", stderr: "", code: 130, killed: true });
 	});
 
-	it("reports a missing executable with the fallback exit code", async () => {
+	it("reports a missing executable as a pre-execution launch failure", async () => {
 		const result = await fallowCli.execCommand(join(root, "missing-fallow-binary"), [], root, undefined, 10);
 		assert.equal(result.code, 127);
 		assert.equal(result.killed, false);
+		assert.equal(result.launchError?.code, "ENOENT");
+	});
+
+	it("distinguishes a launched command's exit 127 from a launch failure", async () => {
+		await withFixture("exit-127", async () => {
+			const result = await fallowCli.execCommand(fixture, [], root, undefined, 10);
+			assert.equal(result.code, 127);
+			assert.equal(result.launchError, undefined);
+		});
 	});
 
 	it("escalates a timeout when the process ignores SIGTERM", async () => {

--- a/tests/fixtures/process-fixture.mjs
+++ b/tests/fixtures/process-fixture.mjs
@@ -21,6 +21,11 @@ if (mode === "error") {
 	process.exit(2);
 }
 
+if (mode === "exit-127") {
+	process.stderr.write("fixture returned 127 after launch\n");
+	process.exit(127);
+}
+
 if (mode === "ignore-term") {
 	process.on("SIGTERM", () => process.stderr.write("received SIGTERM\n"));
 	setInterval(() => {}, 1_000);

--- a/tests/runner.test.mjs
+++ b/tests/runner.test.mjs
@@ -1,0 +1,296 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, join } from "node:path";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { createFallowRunner } = await jiti.import("../extensions/fallow/runner.ts");
+
+function executableName(name) {
+	return process.platform === "win32" ? `${name}.cmd` : name;
+}
+
+async function createExecutable(directory, name) {
+	await mkdir(directory, { recursive: true });
+	const path = join(directory, executableName(name));
+	await writeFile(path, process.platform === "win32" ? "@exit /b 0\r\n" : "#!/bin/sh\nexit 0\n", "utf8");
+	await chmod(path, 0o755);
+	return path;
+}
+
+function executionResult(code = 0, extra = {}) {
+	return { stdout: "{}", stderr: "", code, killed: false, ...extra };
+}
+
+function missingResult(command, code = "ENOENT") {
+	return executionResult(code === "ENOENT" ? 127 : 1, {
+		stderr: `${code}: ${command}`,
+		launchError: { code, message: `${code}: ${command}` },
+	});
+}
+
+function setEnvironment(values) {
+	const previous = new Map();
+	for (const [key, value] of Object.entries(values)) {
+		previous.set(key, process.env[key]);
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	return () => {
+		for (const [key, value] of previous) {
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	};
+}
+
+describe("Fallow runner resolution", { concurrency: false }, () => {
+	it("does not resolve or launch after cancellation", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		let lookups = 0;
+		let executions = 0;
+		const runner = createFallowRunner({
+			packageRoot: null,
+			findExecutable: async () => { lookups++; return undefined; },
+			executeProcess: async () => { executions++; return executionResult(); },
+		});
+		const result = await runner.execute({}, ["health"], "/project", controller.signal, 10);
+		assert.equal(result.result.killed, true);
+		assert.equal(lookups, 0);
+		assert.equal(executions, 0);
+	});
+
+	it("treats an explicit FALLOW_BIN launch failure as final", async () => {
+		const restore = setEnvironment({ FALLOW_BIN: "/configured/fallow", PATH: "/unused" });
+		const calls = [];
+		const runner = createFallowRunner({
+			packageRoot: null,
+			executeProcess: async (command, args) => {
+				calls.push({ command, args });
+				return missingResult(command);
+			},
+		});
+		try {
+			const execution = await runner.execute({}, ["health"], "/project", undefined, 10);
+			assert.equal(execution.binary, "/configured/fallow");
+			assert.equal(calls.length, 1);
+			assert.deepEqual(calls[0], { command: "/configured/fallow", args: ["health"] });
+			assert.match(execution.result.stderr, /Unable to launch FALLOW_BIN/);
+		} finally {
+			restore();
+		}
+	});
+
+	it("caches a PATH runner and resolves again when PATH changes", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-runner-path-"));
+		const firstBin = join(workspace, "first");
+		const secondBin = join(workspace, "second");
+		const firstFallow = await createExecutable(firstBin, "fallow");
+		const secondFallow = await createExecutable(secondBin, "fallow");
+		const calls = [];
+		const runner = createFallowRunner({
+			packageRoot: null,
+			executeProcess: async (command) => {
+				calls.push(command);
+				return executionResult();
+			},
+		});
+		const restore = setEnvironment({ FALLOW_BIN: undefined, PATH: firstBin });
+		try {
+			const pi = {};
+			await runner.execute(pi, ["health"], workspace, undefined, 10);
+			await runner.execute(pi, ["dupes"], workspace, undefined, 10);
+			process.env.PATH = secondBin;
+			await runner.execute(pi, ["dead-code"], workspace, undefined, 10);
+			assert.deepEqual(calls, [firstFallow, firstFallow, secondFallow]);
+		} finally {
+			restore();
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("prefers an available package-local runner over npx", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-runner-package-"));
+		const packageRoot = join(workspace, "package");
+		const pathBin = join(workspace, "path");
+		const packageFallow = await createExecutable(join(workspace, ".bin"), "fallow");
+		await createExecutable(pathBin, "npx");
+		const calls = [];
+		const runner = createFallowRunner({
+			packageRoot,
+			executeProcess: async (command, args) => {
+				calls.push({ command, args });
+				return executionResult();
+			},
+		});
+		const restore = setEnvironment({ FALLOW_BIN: undefined, PATH: pathBin });
+		try {
+			const execution = await runner.execute({}, ["health"], workspace, undefined, 10);
+			assert.equal(execution.binary, packageFallow);
+			assert.deepEqual(calls, [{ command: packageFallow, args: ["health"] }]);
+		} finally {
+			restore();
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("invalidates a missing cached runner, retries once, and caches the fallback", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-runner-retry-"));
+		const bin = join(workspace, "bin");
+		const fallow = await createExecutable(bin, "fallow");
+		const npx = await createExecutable(bin, "npx");
+		const calls = [];
+		const runner = createFallowRunner({
+			packageRoot: null,
+			resolveNpxPackage: false,
+			executeProcess: async (command, args) => {
+				calls.push({ command, args });
+				if (command === fallow && calls.filter((call) => call.command === fallow).length > 1) return missingResult(command);
+				return executionResult();
+			},
+		});
+		const restore = setEnvironment({ FALLOW_BIN: undefined, PATH: bin });
+		try {
+			const pi = {};
+			await runner.execute(pi, ["health"], workspace, undefined, 10);
+			await unlink(fallow);
+			const fallback = await runner.execute(pi, ["dupes"], workspace, undefined, 10);
+			await runner.execute(pi, ["dead-code"], workspace, undefined, 10);
+			assert.equal(fallback.binary, "npx");
+			assert.deepEqual(calls, [
+				{ command: fallow, args: ["health"] },
+				{ command: fallow, args: ["dupes"] },
+				{ command: npx, args: ["-y", "fallow", "dupes"] },
+				{ command: npx, args: ["-y", "fallow", "dead-code"] },
+			]);
+		} finally {
+			restore();
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("does not fall back after a runner starts and returns code 127", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-runner-exit-"));
+		const bin = join(workspace, "bin");
+		const fallow = await createExecutable(bin, "fallow");
+		await createExecutable(bin, "npx");
+		const calls = [];
+		const runner = createFallowRunner({
+			packageRoot: null,
+			executeProcess: async (command) => {
+				calls.push(command);
+				return executionResult(127);
+			},
+		});
+		const restore = setEnvironment({ FALLOW_BIN: undefined, PATH: bin });
+		try {
+			const execution = await runner.execute({}, ["fix", "--yes"], workspace, undefined, 10);
+			assert.equal(execution.result.code, 127);
+			assert.deepEqual(calls, [fallow]);
+		} finally {
+			restore();
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("refreshes a cached npx route after the negative-cache TTL", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-runner-ttl-"));
+		const bin = join(workspace, "bin");
+		const npx = await createExecutable(bin, "npx");
+		let currentTime = 0;
+		const calls = [];
+		const runner = createFallowRunner({
+			packageRoot: null,
+			resolveNpxPackage: false,
+			fallbackCacheTtlMs: 100,
+			now: () => currentTime,
+			executeProcess: async (command) => {
+				calls.push(command);
+				return executionResult();
+			},
+		});
+		const restore = setEnvironment({ FALLOW_BIN: undefined, PATH: bin });
+		try {
+			const pi = {};
+			await runner.execute(pi, ["health"], workspace, undefined, 10);
+			const fallow = await createExecutable(bin, "fallow");
+			currentTime = 50;
+			await runner.execute(pi, ["dupes"], workspace, undefined, 10);
+			currentTime = 100;
+			await runner.execute(pi, ["dead-code"], workspace, undefined, 10);
+			assert.deepEqual(calls, [npx, npx, fallow]);
+		} finally {
+			restore();
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves the npx package once and then runs its executable directly", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-runner-npx-package-"));
+		const pathBin = join(workspace, "path");
+		const packageBin = join(workspace, "npx-cache", "node_modules", ".bin");
+		const npx = await createExecutable(pathBin, "npx");
+		const fallow = await createExecutable(packageBin, "fallow");
+		const calls = [];
+		const runner = createFallowRunner({
+			packageRoot: null,
+			executeProcess: async (command, args) => {
+				calls.push({ command, args });
+				if (command === npx) return executionResult(0, { stdout: packageBin });
+				return executionResult();
+			},
+		});
+		const restore = setEnvironment({ FALLOW_BIN: undefined, PATH: pathBin });
+		try {
+			const pi = {};
+			await runner.execute(pi, ["health"], workspace, undefined, 10);
+			await runner.execute(pi, ["dupes"], workspace, undefined, 10);
+			assert.deepEqual(calls, [
+				{ command: npx, args: ["-y", "--package=fallow", process.execPath, "-e", "process.stdout.write(process.env.PATH || '')"] },
+				{ command: fallow, args: ["health"] },
+				{ command: fallow, args: ["dupes"] },
+			]);
+		} finally {
+			restore();
+			await rm(workspace, { recursive: true, force: true });
+		}
+	});
+
+	it("deduplicates concurrent runner resolution and clears session state", async () => {
+		let releaseLookup;
+		let lookupCount = 0;
+		let executionCount = 0;
+		const lookupGate = new Promise((resolve) => { releaseLookup = resolve; });
+		const runner = createFallowRunner({
+			packageRoot: null,
+			findExecutable: async (name) => {
+				if (name !== "fallow") return undefined;
+				lookupCount++;
+				await lookupGate;
+				return "/resolved/fallow";
+			},
+			executeProcess: async () => {
+				executionCount++;
+				return executionResult();
+			},
+		});
+		const restore = setEnvironment({ FALLOW_BIN: undefined, PATH: ["/one", "/two"].join(delimiter) });
+		try {
+			const pi = {};
+			const first = runner.execute(pi, ["health"], "/project", undefined, 10);
+			const second = runner.execute(pi, ["dupes"], "/project", undefined, 10);
+			releaseLookup();
+			await Promise.all([first, second]);
+			assert.equal(lookupCount, 1);
+			assert.equal(executionCount, 2);
+			runner.clear(pi);
+			await runner.execute(pi, ["dead-code"], "/project", undefined, 10);
+			assert.equal(lookupCount, 2);
+		} finally {
+			restore();
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Caches Fallow runner resolution per project/session and removes the repeated npm wrapper cost from warm npx fallback executions.

- resolves `FALLOW_BIN`, `fallow` on `PATH`, package-local/hoisted Fallow, then npx
- uses npx once to locate its installed Fallow package and invokes that executable directly afterward
- keys cached routes by project cwd, `FALLOW_BIN`, and `PATH`
- deduplicates concurrent resolution and clears state on `session_start`
- briefly caches an unresolved npx route so installing Fallow during a session is detected
- invalidates a disappeared or non-executable automatic runner and retries the next route once
- keeps explicit `FALLOW_BIN` strict instead of silently selecting another installation
- never falls back after cancellation, timeout, or a command that successfully launched
- records a distinct pre-execution launch error instead of inferring it from exit code 127

## Safety

Fallback is limited to confirmed `ENOENT`/`EACCES` launch failures. Exit codes `1`, `2+`, and `127` from a process that actually started retain their existing semantics and are never retried. This avoids duplicate execution of commands such as `fix --yes`.

## Performance

Apple M1 Pro, Node 24, Fallow 3.7.0:

| Route | Baseline warm median | Candidate warm median | Change |
|---|---:|---:|---:|
| Direct Fallow | 111.23 ms | 115.60 ms | timing noise |
| System resolution via npx | 804.50 ms | 115.06 ms | **85.70% faster** |

The npx/direct ratio falls from **7.23×** to **1.00×** after resolution. Cold system resolution also falls from 811.56 ms to 441.54 ms on this run.

Retained-memory measurements are unchanged. The frozen token benchmark decreases by four tool-contract tokens.

## Tests

Adds coverage for:

- strict configured-runner failures
- PATH and environment-key refresh
- package-local resolution
- cached-runner disappearance and one-time fallback
- no fallback for a launched exit 127
- cancellation before resolution
- negative npx cache expiry
- direct reuse of the npx-installed executable
- concurrent resolution deduplication
- session cache clearing
- process-level distinction between spawn failure and exit 127

## Validation

- [x] 76 tests pass on Node 22.19 and Node 24
- [x] Bundle checks pass on Node 22.19 and Node 24
- [x] Full publish check passes
- [x] Fallow health reports no findings
- [x] Dead-code check reports zero issues
- [x] Duplication check reports zero clone groups
- [x] Changed-file audit passes
- [x] Production and full dependency audits pass
- [x] Package smoke test passes with tests, scripts, fixtures, and benchmarks excluded
- [x] Token benchmark passes with no regression
- [x] Performance benchmark records the warm npx reduction

## Coverage

All-production-source coverage is now:

- lines/statements: 65.91%
- functions: 71.11%
- branches: 81.06%

Coverage gates increase to 64% lines/statements, 70% functions, and 80% branches.
