### PR TITLE
perf: reduce retained Fallow result memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to Pi Fallow are documented here.
 - Pinned Fallow, esbuild, and coverage tooling for reproducible development and CI checks.
 - Made Git ref autocomplete non-blocking and keyed it to Pi's project directory; base-ref detection now runs only for `/fallow pr` without an explicit base and is cached per project.
 - Cached Fallow runner resolution per project/session, including direct reuse of the npx-installed executable, environment-aware refresh, and one safe retry when an automatically discovered executable disappears.
+- Slimmed completed engine results to bounded execution and formatting metadata, releasing raw stdout, stderr, and parsed report roots before navigator or transcript retention.
 
 ### Fixed
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 - **Non-blocking autocomplete:** subcommands, flags, enum values, static refs, and asynchronously discovered project branch refs are suggested without running Git while you type.
 - **Interactive navigator:** findings open in a bordered TUI view where you can inspect, select, trace, or load issues into the editor.
 - **Run-mode support:** `/fallow` executes in TUI, RPC, JSON, and print modes; terminal loaders and navigator overlays are TUI-only, while non-TUI modes retain full transcript output.
-- **Safe defaults:** JSON and quiet output are added when appropriate; large output is truncated for the transcript and saved to a temp file.
+- **Safe defaults:** JSON and quiet output are added when appropriate; large output is truncated for the transcript, saved to a temp file, and released from retained engine state after formatting.
 - **Cached CLI lookup:** resolves `FALLOW_BIN`, `fallow` from `PATH`, or a package-local installation once per project/session before falling back to `npx -y fallow`.
 
 ## Installation

--- a/extensions/fallow/command/result-flow.ts
+++ b/extensions/fallow/command/result-flow.ts
@@ -34,9 +34,9 @@ async function runFallowResultFlow(
 	const commandResult = await runFallowWithLoaderIfUi(ctx, executeCommand, finalArgs);
 	if (!commandResult) return handleMissingFallowResult(ctx);
 
-	const { binary, args: executedArgs, result, projectState, prSummary } = commandResult;
+	const { binary, args: executedArgs, execution, projectState, prSummary } = commandResult;
 	const resultPrefix = buildFallowResultPrefix(projectState, prSummary);
-	notifyFallowCompletion(ctx, result, binary, executedArgs);
+	notifyFallowCompletion(ctx, execution, binary, executedArgs);
 	renderFallowResultMessage(pi, ctx, commandResult, resultPrefix);
 	return openFallowNavigator(ctx, commandResult, binary, executedArgs, projectState, prSummary);
 }
@@ -52,9 +52,9 @@ function buildFallowResultPrefix(projectState: FallowProjectState | undefined, p
 	return [prSummaryText, projectStateText].filter(Boolean).join("\n");
 }
 
-function notifyFallowCompletion(ctx: FallowCommandContext, result: FallowCommandResult["result"], binary: string, args: string[]): void {
+function notifyFallowCompletion(ctx: FallowCommandContext, execution: FallowCommandResult["execution"], binary: string, args: string[]): void {
 	if (!ctx.hasUI) return;
-	ctx.ui.notify(buildFallowCompletionMessage(result.code, result.killed, binary, args), shouldNotifyAsError(result) ? "error" : "info");
+	ctx.ui.notify(buildFallowCompletionMessage(execution.code, execution.killed, binary, args), shouldNotifyAsError(execution) ? "error" : "info");
 }
 
 function buildFallowCompletionMessage(code: number, killed: boolean, binary: string, args: string[]): string {

--- a/extensions/fallow/engine.ts
+++ b/extensions/fallow/engine.ts
@@ -27,9 +27,8 @@ interface FallowCommandInput {
 interface ExecutedFallowCommand {
 	binary: string;
 	args: string[];
-	result: ExecResult;
 	stdout: string;
-	stderr: string;	
+	stderr: string;
 	code: number;
 	killed: boolean;
 	elapsedMs: number;
@@ -38,15 +37,16 @@ interface ExecutedFallowCommand {
 interface FallowCommandResult {
 	binary: string;
 	args: string[];
-	result: ExecResult;
+	execution: {
+		code: number;
+		killed: boolean;
+	};
 	formatted: {
-		text: string;
 		summary: string;
 		overview?: FallowOverview;
 		fullOutputPath?: string;
 		truncated?: boolean;
 	};
-	parsed: { parsed: boolean; data?: unknown; raw: string };
 	projectState: FallowProjectState;
 	prSummary?: FallowPrSummary;
 	details: FallowDetails;
@@ -60,23 +60,24 @@ function formatCommandLine(binary: string, args: string[]): string {
 
 async function runFallowWithExecutor(input: FallowCommandInput): Promise<FallowCommandResult> {
 	const execution = await executeCommand(input);
-	const projectState = await detectFallowProjectState(input.cwd, execution.args);
+	const projectStatePromise = detectFallowProjectState(input.cwd, execution.args);
 	const parsed = parseJson(execution.stdout, execution.stderr);
-	const formatted = await formatToolOutput(parsed, input.cwd, execution.code);
+	const formattedPromise = formatToolOutput(parsed, input.cwd, execution.code);
 	const prSummary = buildFallowPrSummary(parsed.data, execution.args, execution.code);
+	const [projectState, formattedOutput] = await Promise.all([projectStatePromise, formattedPromise]);
 	if (shouldThrowExecutionError(execution, input.throwOnExecutionError ?? true)) {
-		throwExecutionError(execution, formatted.text);
+		throwExecutionError(execution, formattedOutput.text);
 	}
+	const formatted = retainFormattedMetadata(formattedOutput);
 	return {
 		binary: execution.binary,
 		args: execution.args,
-		result: execution.result,
+		execution: { code: execution.code, killed: execution.killed },
 		formatted,
-		parsed,
 		projectState,
 		prSummary,
 		details: buildFallowDetails(execution, parsed.parsed, input.cwd, formatted, projectState, prSummary),
-		content: buildFallowResultContent(formatted, projectState, prSummary),
+		content: buildFallowResultContent(formattedOutput.text, projectState, prSummary),
 	};
 }
 
@@ -87,7 +88,6 @@ async function executeCommand(input: FallowCommandInput): Promise<ExecutedFallow
 	return {
 		binary,
 		args: executedArgs,
-		result,
 		stdout: result.stdout,
 		stderr: result.stderr,
 		code: result.code,
@@ -137,15 +137,29 @@ function buildFallowDetails(
 	};
 }
 
+function retainFormattedMetadata(formatted: {
+	summary: string;
+	overview?: FallowOverview;
+	fullOutputPath?: string;
+	truncated?: boolean;
+}): FallowCommandResult["formatted"] {
+	return {
+		summary: formatted.summary,
+		overview: formatted.overview,
+		fullOutputPath: formatted.fullOutputPath,
+		truncated: formatted.truncated,
+	};
+}
+
 function buildFallowResultContent(
-	formatted: { text: string },
+	formattedText: string,
 	projectState: FallowProjectState,
 	prSummary: FallowPrSummary | undefined,
 ): string {
 	const prSummaryText = formatFallowPrSummaryText(prSummary);
 	const projectStateText = formatFallowProjectStateText(projectState);
 	const contentPrefix = [prSummaryText, projectStateText].filter(Boolean).join("\n");
-	return contentPrefix ? `${contentPrefix}\n\n${formatted.text}` : formatted.text;
+	return contentPrefix ? `${contentPrefix}\n\n${formattedText}` : formattedText;
 }
 
 export const fallowEngine = {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dupes": "fallow dupes --format json --quiet",
     "dead-code": "fallow dead-code --format json --quiet",
     "test": "node --test",
-    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=64 --statements=64 --functions=70 --branches=80 node --test",
+    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=66 --statements=66 --functions=71 --branches=81 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",

--- a/tests/engine.test.mjs
+++ b/tests/engine.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
+
+function runFixture(cwd, data, options = {}) {
+	const stdout = typeof data === "string" ? data : JSON.stringify(data);
+	return fallowEngine.runFallowWithExecutor({
+		pi: {},
+		cwd,
+		args: options.args ?? ["dead-code", "--format", "json", "--quiet"],
+		signal: undefined,
+		timeoutSecs: 10,
+		throwOnExecutionError: options.throwOnExecutionError ?? false,
+		executor: async (_pi, args) => ({
+			binary: "fixture-fallow",
+			args,
+			result: {
+				stdout,
+				stderr: options.stderr ?? "",
+				code: options.code ?? 0,
+				killed: options.killed ?? false,
+			},
+		}),
+	});
+}
+
+function largeReport() {
+	const unusedExports = Array.from({ length: 500 }, (_, index) => ({
+		file: `src/generated/file-${index}.ts`,
+		name: `unusedExport${index}`,
+		line: index + 1,
+		reason: `No reachable consumer was found for generated export ${index}.`,
+		actions: [{ type: "remove-export", description: `Remove unusedExport${index}.` }],
+	}));
+	return {
+		kind: "dead-code",
+		schema_version: 7,
+		version: "fixture",
+		elapsed_ms: 1,
+		total_issues: unusedExports.length,
+		summary: { unused_exports: unusedExports.length },
+		unused_files: [],
+		unused_exports: unusedExports,
+	};
+}
+
+describe("Fallow engine result retention", () => {
+	it("returns bounded execution metadata without retaining the executor or parser result", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "pi-fallow-engine-slim-"));
+		try {
+			await writeFile(join(cwd, ".fallowrc.json"), "{}\n", "utf8");
+			const result = await runFixture(cwd, {
+				kind: "dead-code",
+				total_issues: 0,
+				summary: { unused_files: 0 },
+				unused_files: [],
+				unused_exports: [],
+			});
+
+			assert.deepEqual(result.execution, { code: 0, killed: false });
+			assert.equal("result" in result, false);
+			assert.equal("parsed" in result, false);
+			assert.equal("text" in result.formatted, false);
+			assert.equal(result.details.exitCode, 0);
+			assert.match(result.content, /Raw JSON:/);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps truncated full output readable without retaining it in the command result", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "pi-fallow-engine-large-"));
+		let fullOutputPath;
+		try {
+			const report = largeReport();
+			const result = await runFixture(cwd, report);
+			fullOutputPath = result.formatted.fullOutputPath;
+
+			assert.equal(result.formatted.truncated, true);
+			assert.ok(fullOutputPath);
+			assert.match(result.content, /Output truncated/);
+			assert.match(result.content, /unusedExport0/);
+			assert.equal("text" in result.formatted, false);
+			assert.equal(await readFile(fullOutputPath, "utf8"), JSON.stringify(report, null, 2));
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+			if (fullOutputPath) await rm(dirname(fullOutputPath), { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/execution.test.mjs
+++ b/tests/execution.test.mjs
@@ -178,7 +178,7 @@ describe("Fallow process execution", () => {
 				const execution = execute(loaderController.signal);
 				setTimeout(() => loaderController.abort(), 50);
 				const result = await execution;
-				assert.equal(result.result.killed, true);
+				assert.equal(result.execution.killed, true);
 				assert.equal(contextController.signal.aborted, false);
 			});
 		} finally {

--- a/tests/memory.test.mjs
+++ b/tests/memory.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, it } from "node:test";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const execFileAsync = promisify(execFile);
+const MAX_RETAINED_AMPLIFICATION = 2;
+const scenarios = [
+	["large findings", "benchmarks/fixtures/large-findings.json"],
+	["schema", "benchmarks/fixtures/schema.json"],
+];
+
+describe("Fallow retained memory", { concurrency: false }, () => {
+	for (const [name, fixture] of scenarios) {
+		it(`keeps ${name} below two retained full-size copies`, async () => {
+			const { stdout } = await execFileAsync(
+				process.execPath,
+				["--expose-gc", "scripts/performance-memory-worker.mjs", fixture],
+				{ cwd: root, encoding: "utf8", maxBuffer: 1024 * 1024 },
+			);
+			const measurement = JSON.parse(stdout);
+			const retainedBytes = measurement.deltaWhileRetained.heapUsedBytes;
+			const amplification = retainedBytes / measurement.fixtureBytes;
+			assert.ok(
+				amplification <= MAX_RETAINED_AMPLIFICATION,
+				`${name} retained amplification ${amplification.toFixed(2)}x exceeds ${MAX_RETAINED_AMPLIFICATION}x`,
+			);
+		});
+	}
+});

--- a/tests/output.test.mjs
+++ b/tests/output.test.mjs
@@ -54,7 +54,7 @@ describe("formatToolOutput", () => {
 		assert.equal(result.overview?.status, "success");
 		assert.equal(result.truncated, false);
 		assert.match(result.text, /^Fallow summary:\ntotal_issues: 0/m);
-		assert.match(result.text, /Raw JSON:\n{/);
+		assert.match(result.text, /Raw JSON:\n{\n  "kind": "dead-code"/);
 	});
 
 	it("uses raw output when no structured JSON is available", async () => {


### PR DESCRIPTION
## Summary

Reduces retained memory after Fallow output has been parsed and formatted, without changing model-visible reports or navigator finding data.

- replaces the retained full `ExecResult` with `{ code, killed }` execution metadata
- removes parsed report roots and raw stdout/stderr from completed engine results
- retains only summary, overview, truncation, and full-output-path formatting metadata
- avoids retaining formatted payload text twice alongside final command content
- starts project-state detection and output formatting concurrently
- updates slash-command completion notifications to use slim execution metadata
- preserves pretty JSON output, truncation behavior, and readable full-output files

## Memory results

Apple M1 Pro, Node 24, frozen fixture corpus:

| Scenario | Baseline retained heap | Candidate | Reduction | Amplification |
|---|---:|---:|---:|---:|
| Large findings | 342.18 KB | 153.13 KB | **55.25%** | 2.43× → **1.09×** |
| Schema | 434.63 KB | 178.38 KB | **58.96%** | 2.45× → **1.01×** |

Both large-report scenarios are now below the two-full-copy retained-memory budget. A regression test runs isolated `--expose-gc` workers for both fixtures and enforces that limit.

Frozen processing medians also remain improved on this run:

- large findings: 1.71 ms → 1.53 ms
- schema: 3.16 ms → 2.89 ms

## Output compatibility

The token benchmark retains the same tool-result, slash-transcript, and generated-prompt output as `main`:

- large findings: 12,416 tokens, 84/300 findings retained
- schema: 11,497 tokens
- required-field retention unchanged
- full-output path preserved for truncated reports

The only four-token reduction versus the original `0.2.0` baseline is inherited from the previously merged runner-description change.

## Tests

Adds coverage for:

- absence of retained executor and parser results
- bounded execution metadata
- absence of duplicate formatted payload text
- readable pretty-JSON temp output after truncation
- retained-memory amplification below 2× for large findings and schema fixtures
- unchanged pretty JSON presentation

## Coverage

All-production-source coverage is now:

- lines/statements: 67.87%
- functions: 72.19%
- branches: 82.50%

Coverage gates increase to 66% lines/statements, 71% functions, and 81% branches.

## Validation

- [x] 80 tests pass on Node 22.19 and Node 24
- [x] Bundle checks pass on Node 22.19 and Node 24
- [x] Full publish check passes
- [x] Fallow health reports no findings
- [x] Dead-code check reports zero issues
- [x] Duplication check reports zero clone groups
- [x] Changed-file audit passes
- [x] Production and full dependency audits pass
- [x] Package smoke test passes
- [x] Token benchmark reports no output regression
- [x] Performance benchmark records the retained-memory reduction
