### PR TITLE
perf: parse embedded JSON in linear time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Pi Fallow are documented here.
 - Made Git ref autocomplete non-blocking and keyed it to Pi's project directory; base-ref detection now runs only for `/fallow pr` without an explicit base and is cached per project.
 - Cached Fallow runner resolution per project/session, including direct reuse of the npx-installed executable, environment-aware refresh, and one safe retry when an automatically discovered executable disappears.
 - Slimmed completed engine results to bounded execution and formatting metadata, releasing raw stdout, stderr, and parsed report roots before navigator or transcript retention.
+- Replaced overlapping embedded-JSON parse retries with a balanced linear scanner that handles nesting, quoted delimiters, escapes, malformed candidates, and split stdout/stderr output.
 
 ### Fixed
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 - **Non-blocking autocomplete:** subcommands, flags, enum values, static refs, and asynchronously discovered project branch refs are suggested without running Git while you type.
 - **Interactive navigator:** findings open in a bordered TUI view where you can inspect, select, trace, or load issues into the editor.
 - **Run-mode support:** `/fallow` executes in TUI, RPC, JSON, and print modes; terminal loaders and navigator overlays are TUI-only, while non-TUI modes retain full transcript output.
+- **Robust output parsing:** direct or noisy embedded JSON is scanned once with nesting, strings, and escapes handled correctly.
 - **Safe defaults:** JSON and quiet output are added when appropriate; large output is truncated for the transcript, saved to a temp file, and released from retained engine state after formatting.
 - **Cached CLI lookup:** resolves `FALLOW_BIN`, `fallow` from `PATH`, or a package-local installation once per project/session before falling back to `npx -y fallow`.
 

--- a/benchmarks/PERFORMANCE.md
+++ b/benchmarks/PERFORMANCE.md
@@ -5,7 +5,7 @@ This benchmark freezes Pi Fallow's execution and memory behavior before runner, 
 ## The five measured areas
 
 1. **Runner performance** — configured binary, PATH resolution, deterministic fallback, direct real Fallow, and real npx fallback.
-2. **Extension processing** — engine parsing, summaries, overview construction, truncation, and temp output using frozen reports.
+2. **Extension processing** — engine parsing, summaries, overview construction, truncation, temp output using frozen reports, and adversarial noisy embedded-JSON extraction.
 3. **Git and autocomplete** — cold/warm ref completion, event-loop blocking, base detection, and subprocess counts.
 4. **Memory** — retained heap, released heap, RSS, external memory, and fixture-size amplification in isolated workers.
 5. **Cold versus warm execution** — first invocation plus warm median, p95, maximum, mean, and parent-process CPU measurements.
@@ -47,7 +47,9 @@ The deterministic fixture routes show about 31–34 ms of process startup/collec
 | 300 findings | 1.71 ms | 3.45 ms |
 | Fallow schema | 3.16 ms | 3.88 ms |
 
-Current orchestration is inexpensive relative to npx startup for these fixtures. Processing still matters for memory because the command result retains raw output, parsed objects, formatted JSON, and final content together.
+At the frozen baseline, orchestration is inexpensive relative to npx startup, but the command result retains raw output, parsed objects, formatted JSON, and final content together.
+
+Current candidate runs also emit `processing/noisy-json`, a deeply nested noisy-output scenario that exposes overlapping substring and parse retries. The frozen `0.2.0` artifact predates that scenario, so it appears in candidate output but is intentionally absent from baseline comparison tables until the next compatible baseline version.
 
 ### Git and autocomplete
 

--- a/extensions/fallow/engine.ts
+++ b/extensions/fallow/engine.ts
@@ -3,7 +3,8 @@ import { buildFallowPrSummary } from "./pr-summary/build";
 import { formatFallowPrSummaryText } from "./pr-summary/text";
 import { detectFallowProjectState } from "./project/state";
 import { formatFallowProjectStateText } from "./project/text";
-import { formatToolOutput, parseJson } from "./output";
+import { parseJson } from "./json";
+import { formatToolOutput } from "./output";
 import type { FallowDetails, FallowOverview, FallowPrSummary, FallowProjectState } from "./types";
 
 interface FallowExecutor {

--- a/extensions/fallow/json.ts
+++ b/extensions/fallow/json.ts
@@ -1,0 +1,169 @@
+const JSON_VALUE_STARTS = new Set([
+	'"', "{", "[", "-", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "t", "f", "n",
+]);
+const JSON_OBJECT_ROOT_TOKENS = new Set(['"', "}"]);
+
+type ParsedJson = { ok: true; data: unknown; raw: string };
+
+export type ParsedFallowOutput =
+	| { parsed: true; data: unknown; raw: string }
+	| { parsed: false; raw: string };
+
+interface JsonScanState {
+	start?: number;
+	expectedClosers: string[];
+	rootKind?: "object" | "array";
+	awaitingRootToken: boolean;
+	inString: boolean;
+	escaped: boolean;
+}
+
+interface JsonRange {
+	start: number;
+	end: number;
+}
+
+function tryParseJson(raw: string): ParsedJson | { ok: false } {
+	const trimmed = raw.trim();
+	if (!trimmed) return { ok: false };
+	const direct = parseJsonText(trimmed);
+	if (direct) return direct;
+	const embedded = parseEmbeddedJson(trimmed);
+	return embedded ?? { ok: false };
+}
+
+function parseJsonText(raw: string): ParsedJson | undefined {
+	try {
+		return { ok: true, data: JSON.parse(raw), raw };
+	} catch {
+		return undefined;
+	}
+}
+
+function parseEmbeddedJson(raw: string): ParsedJson | undefined {
+	const state = createJsonScanState();
+	let lastParsed: ParsedJson | undefined;
+	for (let index = 0; index < raw.length; index++) {
+		const range = scanJsonCharacter(state, raw[index]!, index);
+		if (!range) continue;
+		const parsed = parseJsonText(raw.slice(range.start, range.end));
+		if (parsed) lastParsed = parsed;
+	}
+	return lastParsed;
+}
+
+function createJsonScanState(): JsonScanState {
+	return { expectedClosers: [], awaitingRootToken: false, inString: false, escaped: false };
+}
+
+function scanJsonCharacter(state: JsonScanState, character: string, index: number): JsonRange | undefined {
+	if (state.start === undefined) return startJsonCandidate(state, character, index);
+	if (state.inString) {
+		consumeJsonStringCharacter(state, character);
+		return undefined;
+	}
+	if (!acceptRootToken(state, character)) return restartJsonCandidate(state, character, index);
+	return scanJsonStructure(state, character, index);
+}
+
+function startJsonCandidate(state: JsonScanState, character: string, index: number): undefined {
+	const closer = expectedJsonCloser(character);
+	if (!closer) return undefined;
+	state.start = index;
+	state.rootKind = character === "{" ? "object" : "array";
+	state.awaitingRootToken = true;
+	state.expectedClosers.push(closer);
+	return undefined;
+}
+
+function acceptRootToken(state: JsonScanState, character: string): boolean {
+	if (!state.awaitingRootToken) return true;
+	if (/\s/.test(character)) return true;
+	state.awaitingRootToken = false;
+	return isRootToken(state.rootKind, character);
+}
+
+function isRootToken(rootKind: JsonScanState["rootKind"], character: string): boolean {
+	if (rootKind === "object") return JSON_OBJECT_ROOT_TOKENS.has(character);
+	return character === "]" || JSON_VALUE_STARTS.has(character);
+}
+
+function restartJsonCandidate(state: JsonScanState, character: string, index: number): undefined {
+	resetJsonScanState(state);
+	return startJsonCandidate(state, character, index);
+}
+
+function scanJsonStructure(state: JsonScanState, character: string, index: number): JsonRange | undefined {
+	if (character === '"') {
+		state.inString = true;
+		return undefined;
+	}
+	const closer = expectedJsonCloser(character);
+	if (closer) {
+		state.expectedClosers.push(closer);
+		return undefined;
+	}
+	return closeJsonStructure(state, character, index);
+}
+
+function closeJsonStructure(state: JsonScanState, character: string, index: number): JsonRange | undefined {
+	if (!isJsonCloser(character)) return undefined;
+	if (state.expectedClosers.at(-1) !== character) {
+		resetJsonScanState(state);
+		return undefined;
+	}
+	state.expectedClosers.pop();
+	if (state.expectedClosers.length) return undefined;
+	const range = { start: state.start!, end: index + 1 };
+	resetJsonScanState(state);
+	return range;
+}
+
+function consumeJsonStringCharacter(state: JsonScanState, character: string): void {
+	if (state.escaped) {
+		state.escaped = false;
+		return;
+	}
+	if (character === "\\") {
+		state.escaped = true;
+		return;
+	}
+	if (character === '"') state.inString = false;
+}
+
+function isJsonCloser(character: string): boolean {
+	return character === "}" || character === "]";
+}
+
+function expectedJsonCloser(character: string): string | undefined {
+	if (character === "{") return "}";
+	if (character === "[") return "]";
+	return undefined;
+}
+
+function resetJsonScanState(state: JsonScanState): void {
+	state.start = undefined;
+	state.expectedClosers.length = 0;
+	state.rootKind = undefined;
+	state.awaitingRootToken = false;
+	state.inString = false;
+	state.escaped = false;
+}
+
+export function parseJson(stdout: string, stderr: string): ParsedFallowOutput {
+	const stdoutParsed = tryParseJson(stdout);
+	if (stdoutParsed.ok) return parsedOutput(stdoutParsed);
+	const stderrParsed = tryParseJson(stderr);
+	if (stderrParsed.ok) return parsedOutput(stderrParsed);
+	const combinedParsed = tryParseJson(`${stdout}\n${stderr}`);
+	if (combinedParsed.ok) return parsedOutput(combinedParsed);
+	return { parsed: false, raw: unparsedOutput(stdout, stderr) };
+}
+
+function unparsedOutput(stdout: string, stderr: string): string {
+	return `${stdout}${stderr ? `\n[stderr]\n${stderr}` : ""}`.trim();
+}
+
+function parsedOutput(parsed: ParsedJson): ParsedFallowOutput {
+	return { parsed: true, data: parsed.data, raw: parsed.raw };
+}

--- a/extensions/fallow/output.ts
+++ b/extensions/fallow/output.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { asRecord } from "./data";
+import type { ParsedFallowOutput } from "./json";
 import { buildFallowOverview } from "./overview";
 import type { FallowOverview } from "./types";
 
@@ -99,55 +100,9 @@ function addNestedSummaries(lines: string[], data: any): void {
 		if (nested && typeof nested === "object") lines.push(...summarizeObject(nested, section));
 	}
 }
-function tryParseJson(raw: string): { ok: true; data: unknown; raw: string } | { ok: false } {
-	const trimmed = raw.trim();
-	if (!trimmed) return { ok: false };
-	const direct = parseJsonText(trimmed);
-	if (direct) return direct;
-	const embedded = parseEmbeddedJson(trimmed);
-	return embedded ?? { ok: false };
-}
-
-function parseJsonText(raw: string): { ok: true; data: unknown; raw: string } | undefined {
-	try {
-		return { ok: true, data: JSON.parse(raw), raw };
-	} catch {
-		return undefined;
-	}
-}
-
-function parseEmbeddedJson(raw: string): { ok: true; data: unknown; raw: string } | undefined {
-	for (const start of findJsonStartCandidates(raw)) {
-		const end = findJsonEndForStart(raw, start);
-		if (end <= start) continue;
-		const parsed = parseJsonText(raw.slice(start, end + 1));
-		if (parsed) return parsed;
-	}
-	return undefined;
-}
-
-function findJsonStartCandidates(raw: string): number[] {
-	const starts: number[] = [];
-	for (let index = 0; index < raw.length; index++) {
-		if (raw[index] === "{" || raw[index] === "[") starts.push(index);
-	}
-	return starts;
-}
-
-function findJsonEndForStart(raw: string, start: number): number {
-	return raw[start] === "{" ? raw.lastIndexOf("}") : raw.lastIndexOf("]");
-}
-
-export function parseJson(stdout: string, stderr: string): { parsed: boolean; data?: unknown; raw: string } {
-	for (const raw of [stdout, stderr, `${stdout}\n${stderr}`]) {
-		const parsed = tryParseJson(raw);
-		if (parsed.ok) return { parsed: true, data: parsed.data, raw: parsed.raw };
-	}
-	return { parsed: false, raw: `${stdout}${stderr ? `\n[stderr]\n${stderr}` : ""}`.trim() };
-}
 
 export async function formatToolOutput(
-	parsed: { parsed: boolean; data?: unknown; raw: string },
+	parsed: ParsedFallowOutput,
 	cwd: string,
 	exitCode = 0,
 ): Promise<{
@@ -167,7 +122,7 @@ export async function formatToolOutput(
 }
 
 function buildToolOutputSummary(
-	parsed: { parsed: boolean; data?: unknown; raw: string },
+	parsed: ParsedFallowOutput,
 	exitCode: number,
 ): { overview: FallowOverview | undefined; summary: string } {
 	const overview = parsed.parsed ? buildFallowOverview(parsed.data, exitCode) : undefined;
@@ -176,7 +131,7 @@ function buildToolOutputSummary(
 	return { overview, summary };
 }
 
-function getFormattedRawText(parsed: { parsed: boolean; data?: unknown; raw: string }): string {
+function getFormattedRawText(parsed: ParsedFallowOutput): string {
 	return parsed.parsed ? JSON.stringify(parsed.data, null, 2) : parsed.raw;
 }
 
@@ -189,7 +144,7 @@ async function writeOutputPathIfTruncated(truncation: ReturnType<typeof truncate
 }
 
 function buildToolOutputText(
-	parsed: { parsed: boolean; data?: unknown; raw: string },
+	parsed: ParsedFallowOutput,
 	summary: string,
 	truncation: ReturnType<typeof truncateHead>,
 	fullOutputPath?: string,
@@ -200,7 +155,7 @@ function buildToolOutputText(
 	return `${header}\n${payloadType}:\n${truncation.content}${truncationSuffix}`;
 }
 
-function buildPayloadType(parsed: { parsed: boolean; data?: unknown; raw: string }, isTruncated: boolean): string {
+function buildPayloadType(parsed: ParsedFallowOutput, isTruncated: boolean): string {
 	const baseType = parsed.parsed ? "Raw JSON" : "Raw output";
 	return `${baseType}${isTruncated ? " (truncated)" : ""}`;
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dupes": "fallow dupes --format json --quiet",
     "dead-code": "fallow dead-code --format json --quiet",
     "test": "node --test",
-    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=66 --statements=66 --functions=71 --branches=81 node --test",
+    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=67 --statements=67 --functions=72 --branches=82 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",

--- a/scripts/performance-benchmark.mjs
+++ b/scripts/performance-benchmark.mjs
@@ -14,7 +14,10 @@ const FIXTURE_BIN = join(ROOT, "benchmarks", "bin", "fallow-fixture.mjs");
 const MEMORY_WORKER = join(ROOT, "scripts", "performance-memory-worker.mjs");
 const DEFAULT_CONFIG = { warmups: 3, iterations: 15, gitColdIterations: 8, memoryIterations: 3, systemRunnerIterations: 5 };
 const PROCESSING_SCENARIOS = ["no-findings", "small-findings", "medium-findings", "large-findings", "schema"];
+const PROCESSING_FINDING_SCENARIOS = [...PROCESSING_SCENARIOS, "noisy-json"];
 const MEMORY_SCENARIOS = ["small-findings", "medium-findings", "large-findings", "schema"];
+const NOISY_JSON_DEPTH = 800;
+const NOISY_JSON_FIXTURE = `prefix ${'{"child":'.repeat(NOISY_JSON_DEPTH)}0${"}".repeat(NOISY_JSON_DEPTH)} suffix {"kind":"health"}`;
 const CLI_OPTION_SETTERS = {
 	"--label": (options, value) => { options.label = value; },
 	"--output": (options, value) => { options.output = value; },
@@ -26,6 +29,7 @@ const jiti = createJiti(import.meta.url);
 
 const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
 const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
+const { parseJson } = await jiti.import("../extensions/fallow/json.ts");
 const { fallowCompletions } = await jiti.import("../extensions/fallow/autocomplete.ts");
 const { detectFallowBaseRef } = await jiti.import("../extensions/fallow/project/git.ts");
 const { createFallowRunner } = await jiti.import("../extensions/fallow/runner.ts");
@@ -42,6 +46,7 @@ const measurements = [];
 try {
 	measurements.push(...await benchmarkRunners(workspace, cli.config));
 	measurements.push(...await benchmarkProcessing(workspace, cli.config));
+	measurements.push(await benchmarkNoisyJson(cli.config));
 	measurements.push(...await benchmarkGit(workspace, cli.config));
 	measurements.push(...await benchmarkMemory(cli.config));
 } finally {
@@ -203,6 +208,14 @@ async function benchmarkProcessing(workspacePath, config) {
 		));
 	}
 	return results;
+}
+
+function benchmarkNoisyJson(config) {
+	return benchmarkOperation("processing", "noisy-json", () => {
+		const parsed = parseJson(NOISY_JSON_FIXTURE, "");
+		if (!parsed.parsed) throw new Error("Noisy JSON benchmark did not find its embedded document.");
+		return { outputBytes: Buffer.byteLength(parsed.raw) };
+	}, config);
 }
 
 async function processFixture(scenario, fixtureText, cwd) {
@@ -499,7 +512,7 @@ function runnerFinding(byKey) {
 }
 
 function processingFinding(byKey) {
-	return Object.fromEntries(PROCESSING_SCENARIOS.map((scenario) => {
+	return Object.fromEntries(PROCESSING_FINDING_SCENARIOS.map((scenario) => {
 		const item = byKey.get(`processing/${scenario}`);
 		return [scenario, { warmMedianMs: item.warm.wallMs.median, warmP95Ms: item.warm.wallMs.p95 }];
 	}));

--- a/tests/output.test.mjs
+++ b/tests/output.test.mjs
@@ -3,7 +3,8 @@ import { describe, it } from "node:test";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
-const { formatToolOutput, parseJson } = await jiti.import("../extensions/fallow/output.ts");
+const { parseJson } = await jiti.import("../extensions/fallow/json.ts");
+const { formatToolOutput } = await jiti.import("../extensions/fallow/output.ts");
 
 describe("parseJson", () => {
 	it("parses direct JSON from stdout", () => {
@@ -19,6 +20,66 @@ describe("parseJson", () => {
 		assert.equal(result.parsed, true);
 		assert.deepEqual(result.data, { kind: "dead-code", summary: { unused_files: 0 } });
 		assert.equal(result.raw, '{"kind":"dead-code","summary":{"unused_files":0}}');
+	});
+
+	it("accepts embedded object and array root values", () => {
+		for (const expected of [{}, [], [true, false, null, -1, 0, "value"], { nested: [1, 2] }]) {
+			const result = parseJson(`prefix ${JSON.stringify(expected)} suffix`, "");
+			assert.equal(result.parsed, true);
+			assert.deepEqual(result.data, expected);
+		}
+	});
+
+	it("handles nested structures, quoted braces, and escaped string characters", () => {
+		const expected = {
+			kind: "inspect",
+			message: 'quoted } ] { [ and " characters with a trailing \\\\',
+			nested: { items: [{ value: 1 }, { value: 2 }] },
+		};
+		const encoded = JSON.stringify(expected);
+		const result = parseJson(`log prefix {not-json}\n${encoded}\nlog suffix`, "");
+
+		assert.equal(result.parsed, true);
+		assert.deepEqual(result.data, expected);
+		assert.equal(result.raw, encoded);
+	});
+
+	it("skips malformed balanced and mismatched candidates before valid JSON", () => {
+		const result = parseJson('log {not-json} mismatch {] then [{"kind":"health","total_issues":0}] done', "");
+
+		assert.equal(result.parsed, true);
+		assert.deepEqual(result.data, [{ kind: "health", total_issues: 0 }]);
+	});
+
+	it("recovers when noisy quoted text contains an unmatched opening brace", () => {
+		const result = parseJson('log "message {not json" then {"kind":"health"} done', "");
+
+		assert.equal(result.parsed, true);
+		assert.deepEqual(result.data, { kind: "health" });
+	});
+
+	it("preserves the last complete embedded document without parsing overlapping suffixes", () => {
+		const second = { kind: "audit", message: "second" };
+		const result = parseJson(`prefix {"kind":"health","message":"first"} middle ${JSON.stringify(second)} suffix`, "");
+
+		assert.deepEqual(result.data, second);
+		assert.equal(result.raw, JSON.stringify(second));
+	});
+
+	it("can recover JSON split across stdout and stderr", () => {
+		const result = parseJson('prefix {"kind":', '"health","total_issues":0} suffix');
+
+		assert.equal(result.parsed, true);
+		assert.deepEqual(result.data, { kind: "health", total_issues: 0 });
+	});
+
+	it("scans deeply nested noisy JSON without retrying overlapping suffixes", () => {
+		const depth = 800;
+		const nested = `${'{"child":'.repeat(depth)}0${"}".repeat(depth)}`;
+		const result = parseJson(`prefix ${nested} suffix {"kind":"health"}`, "");
+
+		assert.equal(result.parsed, true);
+		assert.deepEqual(result.data, { kind: "health" });
 	});
 
 	it("falls back to stderr JSON", () => {


### PR DESCRIPTION
## Summary

Replaces overlapping embedded-JSON substring retries with a dedicated balanced scanner whose scan and parse work stays linear in the size of Fallow output.

- moves parsing into a pure `extensions/fallow/json.ts` module
- keeps direct `JSON.parse()` as the fast path
- scans noisy output once with an expected-closer stack
- tracks quoted strings and backslash escapes so delimiters inside evidence do not affect nesting
- rejects malformed root candidates early and resumes at later documents
- preserves stdout, stderr, and combined stdout/stderr fallback behavior
- preserves the final complete embedded document when output contains multiple documents
- removes the candidate-start array, repeated `lastIndexOf()`, and overlapping `JSON.parse()` slices

## Performance

A new `processing/noisy-json` benchmark uses an 800-level nested document followed by the final Fallow report. The same fixture was rerun against `main` before this change using three warmups and 15 measured iterations:

| Parser | Warm median | Warm p95 |
|---|---:|---:|
| `main` overlapping retries | 42.70 ms | 44.55 ms |
| balanced scanner | 0.19 ms | 0.45 ms |

That is a **99.56% median reduction** and approximately **224.7× faster** for the adversarial case.

The frozen `0.2.0` performance artifact predates this scenario, so candidate artifacts report it separately while baseline comparison continues to compare only compatible keys.

## Compatibility

Tests cover:

- direct JSON
- noisy embedded JSON
- object and array roots
- nested objects and arrays
- delimiters inside strings
- escaped quotes and backslashes
- balanced malformed candidates
- mismatched delimiters
- unmatched braces in quoted log text
- multiple complete documents
- JSON split across stdout and stderr
- deeply nested adversarial output
- raw fallback output

The token benchmark is unchanged for every tool-result, transcript, and generated-prompt scenario. Large-report finding and required-field retention remain unchanged.

## Coverage

All-production-source coverage is now:

- lines/statements: 68.64%
- functions: 72.89%
- branches: 83.36%

The new parser module is covered at 98.81% lines, 97.43% branches, and 100% functions. Coverage gates increase to 67% lines/statements, 72% functions, and 82% branches.

## Validation

- [x] 87 tests pass on Node 22.19 and Node 24
- [x] Bundle checks pass on Node 22.19 and Node 24
- [x] Full publish check passes
- [x] Fallow health reports no findings
- [x] Dead-code check reports zero issues
- [x] Duplication check reports zero clone groups
- [x] Changed-file audit passes
- [x] Production and full dependency audits pass
- [x] Package smoke test passes with the new production module included
- [x] Token benchmark reports no output regression
- [x] Performance benchmark records the noisy parser scenario
- [x] Retained-memory budgets remain below 2× for large and schema reports
