### PR TITLE
perf: shrink Fallow tool contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to Pi Fallow are documented here.
 - Cached Fallow runner resolution per project/session, including direct reuse of the npx-installed executable, environment-aware refresh, and one safe retry when an automatically discovered executable disappears.
 - Slimmed completed engine results to bounded execution and formatting metadata, releasing raw stdout, stderr, and parsed report roots before navigator or transcript retention.
 - Replaced overlapping embedded-JSON parse retries with a balanced linear scanner that handles nesting, quoted delimiters, escapes, malformed candidates, and split stdout/stderr output.
+- Reduced the `fallow_run` contract to command, CLI-token args, root, timeout, and output detail while translating wide-schema calls stored by older Pi sessions before validation.
 
 ### Fixed
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 
 ## Highlights
 
-- **Agent tool:** `fallow_run` gives Pi structured JSON summaries from Fallow.
+- **Compact agent tool:** `fallow_run` uses a small command-plus-args contract while preserving internal validation and older-session compatibility.
 - **Slash command:** `/fallow ...` runs the Fallow CLI from inside Pi.
 - **PR shortcut:** `/fallow pr` maps to `audit --base <detected-base> --gate new-only`.
 - **Rerun shortcut:** `/fallow rerun` repeats the last `/fallow` command.
@@ -90,6 +90,8 @@ Manual slash command examples:
 ```
 
 `/fallow check-changed` is a Pi Fallow convenience alias for Fallow's combined root analysis with `--changed-since`.
+
+The agent-facing `fallow_run` tool passes command-specific flags as separate `args` tokens. For example, a PR audit uses `{ "command": "audit", "args": ["--base", "main", "--gate", "new-only"] }`. Manual `/fallow` command syntax is unchanged.
 
 `/fallow about` shows the installed Pi Fallow version, latest npm version, update command, and project links. Pi Fallow also checks npm once per TUI session and shows a non-blocking update notice when a newer version is available. Set `PI_FALLOW_DISABLE_UPDATE_NOTICE=1` to disable startup update notices.
 

--- a/extensions/fallow.ts
+++ b/extensions/fallow.ts
@@ -1,10 +1,9 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "@earendil-works/pi-coding-agent";
 import { fallowCompletions } from "./fallow/autocomplete";
 import { fallowCli } from "./fallow/cli";
+import { fallowToolContract } from "./fallow/contract";
 import { runFallowCommandHandler } from "./fallow/command/handler";
 import type { FallowCommandState } from "./fallow/command/types";
-import { fallowRunParams } from "./fallow/schema";
 import { registerFallowSessionStart } from "./fallow/session";
 import { renderFallowMessageRenderer, renderFallowToolCall, renderFallowToolResult } from "./fallow/tool-render";
 import { renderFallowAboutMessage } from "./fallow/update-notice";
@@ -19,12 +18,8 @@ export default function (pi: ExtensionAPI) {
 
 function registerFallowTool(pi: ExtensionAPI): void {
 	pi.registerTool({
-		name: "fallow_run",
-		label: "Fallow",
-		description: buildFallowToolDescription(),
-		promptSnippet: "Run Fallow static/runtime codebase intelligence and return JSON summaries.",
-		promptGuidelines: fallowToolPromptGuidelines,
-		parameters: fallowRunParams,
+		...fallowToolContract,
+		prepareArguments: fallowCli.prepareFallowRunParams,
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
 			onUpdate?.({ content: [{ type: "text", text: `Running fallow ${params.command}...` }] });
 			if (signal?.aborted) return { content: [{ type: "text", text: "Cancelled." }], details: {} };
@@ -38,18 +33,6 @@ function registerFallowTool(pi: ExtensionAPI): void {
 		},
 	});
 }
-
-function buildFallowToolDescription(): string {
-	return `Run Fallow codebase intelligence for TypeScript/JavaScript: PR/new-issue audits (audit --base ... --gate new-only), changed-file checks, dead code, duplication, health, inspect/trace evidence, security candidates, decision surfaces, project/config/schema info, feature flags, impact, auto-fix preview/apply, and runtime coverage. JSON output is truncated to ${DEFAULT_MAX_LINES} lines or ${formatSize(DEFAULT_MAX_BYTES)}; full output is saved to a temp file when truncated. Caches FALLOW_BIN, PATH, package-local, or npx runner resolution per session.`;
-}
-
-const fallowToolPromptGuidelines = [
-	"Use fallow_run after making TypeScript/JavaScript changes when the user asks for cleanup, quality, dead-code, duplication, architecture, complexity, or PR-readiness checks.",
-	"Use fallow_run with command=\"audit\", base=\"main\" or \"origin/main\", and gate=\"new-only\" for PR/new-issue checks; use command=\"check-changed\" with changedSince for changed-file checks.",
-	"Use command=\"all\" for full-repo context; command=\"fix-preview\" before command=\"fix-apply\" unless the user explicitly requested automatic cleanup.",
-	"Use fallow_run command=\"inspect\" with file or symbol before editing unfamiliar code when bundled evidence would reduce risk.",
-	"Use fallow_run trace commands, especially command=\"trace-file\" with file or command=\"trace-symbol\" with symbol/file+exportName, before deleting exports, files, dependencies, or clone groups when confidence is low.",
-];
 
 function registerFallowCommand(pi: ExtensionAPI, commandState: FallowCommandState): void {
 	pi.registerCommand("fallow", {

--- a/extensions/fallow/cli.ts
+++ b/extensions/fallow/cli.ts
@@ -4,7 +4,10 @@ import { fallowEngine } from "./engine";
 import { stripAtPrefix } from "./path";
 import { execFallowProcess } from "./process";
 import { createFallowRunner } from "./runner";
-import type { FallowRunParams } from "./schema";
+import type { FallowRunParams as CompactFallowRunParams } from "./schema";
+
+// Compatibility shape for tool calls stored by Pi before the compact contract.
+type FallowRunParams = CompactFallowRunParams & Record<string, any>;
 
 function addValue(args: string[], flag: string, value: unknown): void {
 	if (value === undefined || value === null || value === "") return;
@@ -20,10 +23,10 @@ function addWorkspace(args: string[], workspace: FallowRunParams["workspace"]): 
 	args.push("--workspace", Array.isArray(workspace) ? workspace.join(",") : workspace);
 }
 
-function rejectFormatOverride(extraArgs?: string[]): void {
-	if (!extraArgs) return;
-	if (extraArgs.some((arg) => arg === "--format" || arg.startsWith("--format=") || arg === "-f")) {
-		throw new Error("extraArgs must not include --format/-f; the Pi extension always requests JSON output.");
+function rejectFormatOverride(args?: string[]): void {
+	if (!args) return;
+	if (args.some((arg) => arg === "--format" || arg.startsWith("--format=") || arg === "-f")) {
+		throw new Error("Fallow args must not include --format/-f; the Pi extension always requests JSON output.");
 	}
 }
 
@@ -276,7 +279,56 @@ const commandBuilders: Record<string, CommandArgsBuilder> = {
 	"coverage-analyze": buildCoverageAnalyzeArgs,
 };
 
-function buildFallowArgs(params: FallowRunParams): string[] {
+const MANAGED_OUTPUT_ARGS = ["--format", "json", "--quiet"];
+const COMMAND_PREFIXES: Record<CompactFallowRunParams["command"], readonly string[]> = {
+	all: [],
+	"dead-code": ["dead-code"],
+	"check-changed": [],
+	dupes: ["dupes"],
+	health: ["health"],
+	audit: ["audit"],
+	"fix-preview": ["fix", "--dry-run"],
+	"fix-apply": ["fix", "--yes"],
+	flags: ["flags"],
+	inspect: ["inspect"],
+	"trace-symbol": ["trace"],
+	security: ["security"],
+	workspaces: ["workspaces"],
+	config: ["config"],
+	schema: ["schema"],
+	"decision-surface": ["decision-surface"],
+	impact: ["impact"],
+	"project-info": ["list"],
+	"list-boundaries": ["list", "--boundaries"],
+	explain: ["explain"],
+	"trace-export": ["dead-code", "--trace"],
+	"trace-file": ["dead-code", "--trace-file"],
+	"trace-dependency": ["dead-code", "--trace-dependency"],
+	"trace-clone": ["dupes", "--trace"],
+	"coverage-analyze": ["coverage", "analyze"],
+};
+const POSITIONAL_TARGET_COMMANDS = new Set<CompactFallowRunParams["command"]>([
+	"trace-symbol", "explain", "trace-export", "trace-file", "trace-dependency", "trace-clone",
+]);
+const PATH_TARGET_COMMANDS = new Set<CompactFallowRunParams["command"]>([
+	"trace-symbol", "trace-export", "trace-file", "trace-clone",
+]);
+const PATH_OPTION_FLAGS = new Set(["--file", "--symbol"]);
+const FORBIDDEN_FIXED_ARGS: Partial<Record<CompactFallowRunParams["command"], Set<string>>> = {
+	"fix-preview": new Set(["--yes"]),
+	"fix-apply": new Set(["--dry-run"]),
+};
+const COMPACT_PARAM_KEYS = new Set(["command", "args", "root", "timeoutSecs", "detail"]);
+const LEGACY_PARAM_KEYS = new Set([
+	"config", "workspace", "production", "changedSince", "base", "noCache", "threads",
+	"includeEntryExports", "file", "exportName", "symbol", "symbolChain", "callers", "callees", "depth", "packageName", "line",
+	"top", "groupBy", "minTokens", "minLines", "threshold", "minOccurrences", "skipLocal", "crossLanguage", "ignoreImports",
+	"fileScores", "hotspots", "targets", "score", "trend", "coverage", "coverageRoot", "runtimeCoverage", "maxCrap",
+	"diffFile", "securityGate", "surface", "minInvocationsHot", "maxDecisions", "gate", "explain", "issueType",
+	"entryPoints", "files", "plugins", "boundaries", "listWorkspaces", "noCreateConfig", "extraArgs",
+]);
+
+function buildLegacyFallowArgs(params: FallowRunParams): string[] {
 	rejectFormatOverride(params.extraArgs);
 	const args: string[] = [];
 	const builder = commandBuilders[params.command];
@@ -284,6 +336,154 @@ function buildFallowArgs(params: FallowRunParams): string[] {
 	builder(args, params);
 	args.push(...(params.extraArgs ?? []));
 	return args;
+}
+
+function buildFallowArgs(params: CompactFallowRunParams): string[] {
+	rejectFormatOverride(params.args);
+	rejectConflictingFixedArgs(params.command, params.args ?? []);
+	const commandArgs = normalizeCompactArgs(params.command, params.args ?? []);
+	const prefix = commandPrefix(params.command);
+	if (POSITIONAL_TARGET_COMMANDS.has(params.command)) {
+		return buildPositionalCommandArgs(params.command, prefix, commandArgs);
+	}
+	return [...prefix, ...MANAGED_OUTPUT_ARGS, ...commandArgs];
+}
+
+function rejectConflictingFixedArgs(command: CompactFallowRunParams["command"], args: string[]): void {
+	const forbidden = FORBIDDEN_FIXED_ARGS[command];
+	const conflict = forbidden && args.find((arg) => forbidden.has(arg));
+	if (conflict) throw new Error(`${command} args must not include ${conflict}.`);
+}
+
+function commandPrefix(command: CompactFallowRunParams["command"]): readonly string[] {
+	const prefix = (COMMAND_PREFIXES as Record<string, readonly string[]>)[command];
+	if (!prefix) throw new Error(`Unsupported fallow command: ${command}`);
+	return prefix;
+}
+
+function normalizeCompactArgs(command: CompactFallowRunParams["command"], args: string[]): string[] {
+	const normalized = command === "check-changed" ? normalizeCheckChangedArgs(args) : [...args];
+	return normalizeAtPrefixedTargets(command, normalized);
+}
+
+function normalizeCheckChangedArgs(args: string[]): string[] {
+	const normalized = args.map((arg) => {
+		if (arg === "--base") return "--changed-since";
+		if (arg.startsWith("--base=")) return `--changed-since=${arg.slice("--base=".length)}`;
+		return arg;
+	});
+	if (!hasFlagValue(normalized, "--changed-since")) {
+		throw new Error("check-changed requires args containing --changed-since or --base.");
+	}
+	return normalized;
+}
+
+function hasFlagValue(args: string[], flag: string): boolean {
+	const exactIndex = args.indexOf(flag);
+	if (exactIndex >= 0 && args[exactIndex + 1] !== undefined) return true;
+	return args.some((arg) => arg.startsWith(`${flag}=`) && arg.length > flag.length + 1);
+}
+
+function normalizeAtPrefixedTargets(command: CompactFallowRunParams["command"], args: string[]): string[] {
+	return args.map((arg, index) => normalizeAtPrefixedTarget(command, args, arg, index));
+}
+
+function normalizeAtPrefixedTarget(
+	command: CompactFallowRunParams["command"],
+	args: string[],
+	arg: string,
+	index: number,
+): string {
+	if (index === 0 && PATH_TARGET_COMMANDS.has(command)) return stripAtPrefix(arg);
+	if (isPathOptionValue(args, index)) return stripAtPrefix(arg);
+	return normalizeInlinePathOption(arg);
+}
+
+function isPathOptionValue(args: string[], index: number): boolean {
+	if (index === 0) return false;
+	return PATH_OPTION_FLAGS.has(args[index - 1]!);
+}
+
+function normalizeInlinePathOption(arg: string): string {
+	if (arg.startsWith("--file=@")) return `--file=${stripAtPrefix(arg.slice("--file=".length))}`;
+	if (arg.startsWith("--symbol=@")) return `--symbol=${stripAtPrefix(arg.slice("--symbol=".length))}`;
+	return arg;
+}
+
+function buildPositionalCommandArgs(
+	command: CompactFallowRunParams["command"],
+	prefix: readonly string[],
+	args: string[],
+): string[] {
+	const [target, ...rest] = args;
+	if (!target || target.startsWith("-")) throw new Error(`${command} requires its target as the first args entry.`);
+	return [...prefix, target, ...MANAGED_OUTPUT_ARGS, ...rest];
+}
+
+function prepareFallowRunParams(value: unknown): unknown {
+	const legacy = asLegacyFallowParams(value);
+	if (!legacy) return value;
+	return compactLegacyFallowParams(legacy);
+}
+
+function asLegacyFallowParams(value: unknown): FallowRunParams | undefined {
+	const record = asLegacyCommandRecord(value);
+	if (!record) return undefined;
+	return hasOnlyLegacyExtraKeys(record) ? record as FallowRunParams : undefined;
+}
+
+function asLegacyCommandRecord(value: unknown): Record<string, any> | undefined {
+	if (!isRecord(value)) return undefined;
+	if (typeof value.command !== "string") return undefined;
+	if (Object.hasOwn(value, "args")) return undefined;
+	return value;
+}
+
+function hasOnlyLegacyExtraKeys(value: Record<string, any>): boolean {
+	const extraKeys = Object.keys(value).filter((key) => !COMPACT_PARAM_KEYS.has(key));
+	if (!extraKeys.length) return false;
+	return extraKeys.every((key) => LEGACY_PARAM_KEYS.has(key));
+}
+
+function compactLegacyFallowParams(value: FallowRunParams): CompactFallowRunParams {
+	const command = value.command as CompactFallowRunParams["command"];
+	const legacyArgs = buildLegacyFallowArgs(value);
+	const args = removeManagedLegacyArgs(command, legacyArgs);
+	const compact: Record<string, unknown> = { command };
+	if (args.length) compact.args = args;
+	copyDefinedOption(compact, value, "root");
+	copyDefinedOption(compact, value, "timeoutSecs");
+	copyDefinedOption(compact, value, "detail");
+	return compact as CompactFallowRunParams;
+}
+
+function copyDefinedOption(target: Record<string, unknown>, source: Record<string, any>, key: string): void {
+	if (source[key] !== undefined) target[key] = source[key];
+}
+
+function removeManagedLegacyArgs(command: CompactFallowRunParams["command"], args: string[]): string[] {
+	const prefixLength = commandPrefix(command).length;
+	const remaining = args.slice(prefixLength);
+	const compact: string[] = [];
+	for (let index = 0; index < remaining.length; index++) {
+		const width = managedOutputArgWidth(remaining, index);
+		if (width) {
+			index += width - 1;
+			continue;
+		}
+		compact.push(remaining[index]!);
+	}
+	return compact;
+}
+
+function managedOutputArgWidth(args: string[], index: number): number {
+	if (args[index] === "--quiet") return 1;
+	if (args[index] !== "--format") return 0;
+	return args[index + 1] === "json" ? 2 : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 const fallowRunner = createFallowRunner();
@@ -296,17 +496,17 @@ function clearRunnerCache(pi: ExtensionAPI): void {
 	fallowRunner.clear(pi);
 }
 
-function resolveFallowRoot(params: FallowRunParams, contextRoot: string): string {
+function resolveFallowRoot(params: CompactFallowRunParams, contextRoot: string): string {
 	if (!params.root) return contextRoot;
 	return resolve(contextRoot, stripAtPrefix(params.root));
 }
 
-function resolveFallowTimeout(params: FallowRunParams): number {
+function resolveFallowTimeout(params: CompactFallowRunParams): number {
 	if (params.timeoutSecs !== undefined) return params.timeoutSecs;
 	return Number(process.env.FALLOW_TIMEOUT_SECS || 120);
 }
 
-async function runFallow(pi: ExtensionAPI, params: FallowRunParams, ctx: ExtensionContext, signal?: AbortSignal) {
+async function runFallow(pi: ExtensionAPI, params: CompactFallowRunParams, ctx: ExtensionContext, signal?: AbortSignal) {
 	const { details, content } = await fallowEngine.runFallowWithExecutor({
 		pi,
 		cwd: resolveFallowRoot(params, ctx.cwd),
@@ -413,5 +613,6 @@ export const fallowCli = {
 	clearRunnerCache,
 	splitArgs,
 	buildFallowArgs,
+	prepareFallowRunParams,
 };
 

--- a/extensions/fallow/contract.ts
+++ b/extensions/fallow/contract.ts
@@ -1,0 +1,8 @@
+import { fallowRunParams } from "./schema";
+
+export const fallowToolContract = {
+	name: "fallow_run",
+	label: "Fallow",
+	description: "Run Fallow audits, dead-code, duplication, health, inspect, trace, security, architecture, and fixes. Pass CLI flags and values as separate args items.",
+	parameters: fallowRunParams,
+} as const;

--- a/extensions/fallow/schema.ts
+++ b/extensions/fallow/schema.ts
@@ -29,78 +29,14 @@ const FallowCommand = StringEnum([
 	"coverage-analyze",
 ] as const);
 
-const GroupBy = StringEnum(["owner", "directory", "package", "section"] as const);
-const AuditGate = StringEnum(["new-only", "all"] as const);
-const SecurityGate = StringEnum(["new", "newly-reachable"] as const);
+const OutputDetail = StringEnum(["summary", "findings", "raw"] as const);
 
 export const fallowRunParams = Type.Object({
 	command: FallowCommand,
-
-	// Common execution/configuration
-	root: Type.Optional(Type.String({ description: "Project root to run fallow in. Defaults to Pi's current working directory." })),
-	config: Type.Optional(Type.String({ description: "Path to .fallowrc.json/.jsonc or fallow.toml." })),
-	workspace: Type.Optional(Type.Union([
-		Type.String({ description: "Workspace name/glob." }),
-		Type.Array(Type.String(), { description: "Workspace names/globs; passed comma-separated." }),
-	])),
-	production: Type.Optional(Type.Boolean({ description: "Exclude test/story/dev-only code paths where supported." })),
-	changedSince: Type.Optional(Type.String({ description: "Git ref for changed-file analysis (check-changed maps to Fallow's root --changed-since; also for dead-code, dupes, or health), e.g. main or origin/main." })),
-	base: Type.Optional(Type.String({ description: "Audit base ref for PR/new-issue gates, e.g. main or origin/main. Alias of changedSince for check-changed." })),
-	noCache: Type.Optional(Type.Boolean({ description: "Pass --no-cache." })),
-	threads: Type.Optional(Type.Number({ description: "Worker thread count." })),
-	timeoutSecs: Type.Optional(Type.Number({ description: "Process timeout in seconds. Defaults to FALLOW_TIMEOUT_SECS or 120." })),
-
-	// Dead-code / traces
-	includeEntryExports: Type.Optional(Type.Boolean({ description: "Also report unused exports in entry files." })),
-	file: Type.Optional(Type.String({ description: "File for inspect, security scoping, trace-file, trace-export, trace-symbol, or trace-clone." })),
-	exportName: Type.Optional(Type.String({ description: "Export name for trace-export, trace-symbol, or inspect symbol queries." })),
-	symbol: Type.Optional(Type.String({ description: "Symbol target for inspect or trace-symbol, formatted as file.ts:exportName." })),
-	symbolChain: Type.Optional(Type.Boolean({ description: "Inspect: include best-effort symbol-level call chain evidence for symbol targets." })),
-	callers: Type.Optional(Type.Boolean({ description: "trace-symbol: walk upward to callers." })),
-	callees: Type.Optional(Type.Boolean({ description: "trace-symbol: walk downward to callees." })),
-	depth: Type.Optional(Type.Number({ description: "trace-symbol: call-chain depth bound." })),
-	packageName: Type.Optional(Type.String({ description: "Package name for trace-dependency." })),
-	line: Type.Optional(Type.Number({ description: "Line number for trace-clone." })),
-
-	// Duplication / health / audit
-	top: Type.Optional(Type.Number({ description: "Limit top findings where supported." })),
-	groupBy: Type.Optional(GroupBy),
-	minTokens: Type.Optional(Type.Number({ description: "Duplication min token threshold." })),
-	minLines: Type.Optional(Type.Number({ description: "Duplication min line threshold." })),
-	threshold: Type.Optional(Type.Number({ description: "Duplication or audit threshold where supported." })),
-	minOccurrences: Type.Optional(Type.Number({ description: "Minimum duplicate occurrences before reporting." })),
-	skipLocal: Type.Optional(Type.Boolean({ description: "Dupes: skip local clones within the same file." })),
-	crossLanguage: Type.Optional(Type.Boolean({ description: "Dupes: enable cross-language clone detection." })),
-	ignoreImports: Type.Optional(Type.Boolean({ description: "Dupes: ignore import declarations." })),
-	fileScores: Type.Optional(Type.Boolean({ description: "Health: include file maintainability scores." })),
-	hotspots: Type.Optional(Type.Boolean({ description: "Health: include churn-backed hotspots." })),
-	targets: Type.Optional(Type.Boolean({ description: "Health: include ranked refactoring targets." })),
-	score: Type.Optional(Type.Boolean({ description: "Health: compute project health score/grade." })),
-	trend: Type.Optional(Type.Boolean({ description: "Health: compare against the latest saved snapshot." })),
-	coverage: Type.Optional(Type.String({ description: "Istanbul coverage-final.json or V8/Istanbul runtime coverage input, depending on command." })),
-	coverageRoot: Type.Optional(Type.String({ description: "Absolute source root prefix to strip from coverage paths." })),
-	runtimeCoverage: Type.Optional(Type.String({ description: "Health/audit runtime coverage input: V8 dir, V8 JSON, or Istanbul JSON." })),
-	maxCrap: Type.Optional(Type.Number({ description: "Maximum CRAP score threshold where supported." })),
-	diffFile: Type.Optional(Type.String({ description: "Audit/security diff file path for line-scoped review/runtime verdicts." })),
-	securityGate: Type.Optional(SecurityGate),
-	surface: Type.Optional(Type.Boolean({ description: "Security: include the agent-facing attack-surface inventory in JSON output." })),
-	minInvocationsHot: Type.Optional(Type.Number({ description: "Runtime coverage hot-path threshold for audit/security sidecar enrichment." })),
-	maxDecisions: Type.Optional(Type.Number({ description: "decision-surface/audit brief: maximum surfaced structural decisions." })),
-
-	// Audit/fix/list/explain
-	gate: Type.Optional(AuditGate),
-	explain: Type.Optional(Type.Boolean({ description: "Audit: include _meta explanations in JSON output." })),
-	issueType: Type.Optional(Type.String({ description: "Issue type/rule id for fallow explain." })),
-	entryPoints: Type.Optional(Type.Boolean({ description: "project-info: include entry points." })),
-	files: Type.Optional(Type.Boolean({ description: "project-info: include discovered files." })),
-	plugins: Type.Optional(Type.Boolean({ description: "project-info: include active framework plugins." })),
-	boundaries: Type.Optional(Type.Boolean({ description: "project-info: include architecture boundary zones/rules." })),
-	listWorkspaces: Type.Optional(Type.Boolean({ description: "project-info: include monorepo workspaces and diagnostics." })),
-	noCreateConfig: Type.Optional(Type.Boolean({ description: "fix: do not create .fallowrc.json for add-to-config actions." })),
-
-	extraArgs: Type.Optional(Type.Array(Type.String(), {
-		description: "Advanced escape hatch for modeled CLI flags not exposed above. Do not include --format/-f; JSON output is required.",
-	})),
-});
+	args: Type.Optional(Type.Array(Type.String())),
+	root: Type.Optional(Type.String()),
+	timeoutSecs: Type.Optional(Type.Number()),
+	detail: Type.Optional(OutputDetail),
+}, { additionalProperties: false });
 
 export type FallowRunParams = Static<typeof fallowRunParams>;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dupes": "fallow dupes --format json --quiet",
     "dead-code": "fallow dead-code --format json --quiet",
     "test": "node --test",
-    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=67 --statements=67 --functions=72 --branches=82 node --test",
+    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=72 --statements=72 --functions=76 --branches=82 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",

--- a/scripts/fallow-smoke.mjs
+++ b/scripts/fallow-smoke.mjs
@@ -49,27 +49,27 @@ function hasGitRef(ref) {
 
 function assertModeledArgs() {
 	assertArgs(
-		{ command: "inspect", file: "extensions/fallow/cli.ts" },
+		{ command: "inspect", args: ["--file", "extensions/fallow/cli.ts"] },
 		["inspect", "--format", "json", "--quiet", "--file", "extensions/fallow/cli.ts"],
 	);
 	assertArgs(
-		{ command: "inspect", symbol: "extensions/fallow/cli.ts:fallowCli", symbolChain: true },
+		{ command: "inspect", args: ["--symbol", "extensions/fallow/cli.ts:fallowCli", "--symbol-chain"] },
 		["inspect", "--format", "json", "--quiet", "--symbol", "extensions/fallow/cli.ts:fallowCli", "--symbol-chain"],
 	);
 	assertArgs(
-		{ command: "trace-symbol", file: "extensions/fallow/cli.ts", exportName: "fallowCli", callers: true, depth: 2 },
+		{ command: "trace-symbol", args: ["extensions/fallow/cli.ts:fallowCli", "--callers", "--depth", "2"] },
 		["trace", "extensions/fallow/cli.ts:fallowCli", "--format", "json", "--quiet", "--callers", "--depth", "2"],
 	);
 	assertArgs(
-		{ command: "security", changedSince: "HEAD~1", securityGate: "new", surface: true },
+		{ command: "security", args: ["--changed-since", "HEAD~1", "--gate", "new", "--surface"] },
 		["security", "--format", "json", "--quiet", "--changed-since", "HEAD~1", "--gate", "new", "--surface"],
 	);
 	assertArgs(
-		{ command: "decision-surface", changedSince: "HEAD~1", maxDecisions: 4 },
+		{ command: "decision-surface", args: ["--changed-since", "HEAD~1", "--max-decisions", "4"] },
 		["decision-surface", "--format", "json", "--quiet", "--changed-since", "HEAD~1", "--max-decisions", "4"],
 	);
 	assertArgs(
-		{ command: "project-info", listWorkspaces: true },
+		{ command: "project-info", args: ["--workspaces"] },
 		["list", "--format", "json", "--quiet", "--workspaces"],
 	);
 	for (const command of ["workspaces", "config", "schema", "impact"]) {

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -9,59 +9,149 @@ function build(params) {
 	return fallowCli.buildFallowArgs(params);
 }
 
+function prepare(params) {
+	return fallowCli.prepareFallowRunParams(params);
+}
+
 describe("fallowCli.buildFallowArgs", () => {
-	it("maps check-changed to root --changed-since analysis", () => {
-		assert.deepEqual(build({ command: "check-changed", changedSince: "main" }), [
+	it("maps compact check-changed args to root --changed-since analysis", () => {
+		assert.deepEqual(build({ command: "check-changed", args: ["--changed-since", "main"] }), [
 			"--format", "json", "--quiet", "--changed-since", "main",
 		]);
-	});
-
-	it("accepts base as check-changed changed-since alias", () => {
-		assert.deepEqual(build({ command: "check-changed", base: "origin/main", includeEntryExports: true }), [
-			"--format", "json", "--quiet", "--changed-since", "origin/main", "--include-entry-exports",
+		assert.deepEqual(build({ command: "check-changed", args: ["--base=origin/main", "--include-entry-exports"] }), [
+			"--format", "json", "--quiet", "--changed-since=origin/main", "--include-entry-exports",
 		]);
 	});
 
 	it("requires a comparison ref for check-changed", () => {
-		assert.throws(() => build({ command: "check-changed" }), /requires changedSince or base/);
+		assert.throws(() => build({ command: "check-changed" }), /requires args containing --changed-since or --base/);
+		assert.throws(() => build({ command: "check-changed", args: ["--changed-since"] }), /requires args containing/);
 	});
 
 	it("builds inspect file and symbol queries", () => {
-		assert.deepEqual(build({ command: "inspect", file: "@extensions/fallow/cli.ts" }), [
+		assert.deepEqual(build({ command: "inspect", args: ["--file", "@extensions/fallow/cli.ts"] }), [
 			"inspect", "--format", "json", "--quiet", "--file", "extensions/fallow/cli.ts",
 		]);
-		assert.deepEqual(build({ command: "inspect", symbol: "@extensions/fallow/cli.ts:fallowCli", symbolChain: true }), [
-			"inspect", "--format", "json", "--quiet", "--symbol", "extensions/fallow/cli.ts:fallowCli", "--symbol-chain",
+		assert.deepEqual(build({ command: "inspect", args: ["--symbol=@extensions/fallow/cli.ts:fallowCli", "--symbol-chain"] }), [
+			"inspect", "--format", "json", "--quiet", "--symbol=extensions/fallow/cli.ts:fallowCli", "--symbol-chain",
 		]);
 	});
 
-	it("builds trace-symbol queries", () => {
-		assert.deepEqual(build({ command: "trace-symbol", file: "extensions/fallow/cli.ts", exportName: "fallowCli", callers: true, depth: 2 }), [
+	it("builds positional trace and explain queries", () => {
+		assert.deepEqual(build({ command: "trace-symbol", args: ["@extensions/fallow/cli.ts:fallowCli", "--callers", "--depth", "2"] }), [
 			"trace", "extensions/fallow/cli.ts:fallowCli", "--format", "json", "--quiet", "--callers", "--depth", "2",
 		]);
+		assert.deepEqual(build({ command: "trace-file", args: ["@extensions/fallow/cli.ts"] }), [
+			"dead-code", "--trace-file", "extensions/fallow/cli.ts", "--format", "json", "--quiet",
+		]);
+		assert.deepEqual(build({ command: "explain", args: ["unused-export"] }), [
+			"explain", "unused-export", "--format", "json", "--quiet",
+		]);
+		assert.throws(() => build({ command: "trace-symbol", args: ["--callers"] }), /requires its target/);
 	});
 
-	it("builds security and decision-surface commands", () => {
-		assert.deepEqual(build({ command: "security", changedSince: "HEAD~1", securityGate: "new", surface: true }), [
+	it("builds command aliases and raw options", () => {
+		assert.deepEqual(build({ command: "security", args: ["--changed-since", "HEAD~1", "--gate", "new", "--surface"] }), [
 			"security", "--format", "json", "--quiet", "--changed-since", "HEAD~1", "--gate", "new", "--surface",
 		]);
-		assert.deepEqual(build({ command: "decision-surface", base: "origin/main", maxDecisions: 4 }), [
+		assert.deepEqual(build({ command: "decision-surface", args: ["--changed-since", "origin/main", "--max-decisions", "4"] }), [
 			"decision-surface", "--format", "json", "--quiet", "--changed-since", "origin/main", "--max-decisions", "4",
+		]);
+		assert.deepEqual(build({ command: "project-info", args: ["--workspaces"] }), [
+			"list", "--format", "json", "--quiet", "--workspaces",
+		]);
+		assert.deepEqual(build({ command: "fix-preview" }), ["fix", "--dry-run", "--format", "json", "--quiet"]);
+		assert.deepEqual(build({ command: "coverage-analyze", detail: "summary" }), [
+			"coverage", "analyze", "--format", "json", "--quiet",
 		]);
 	});
 
 	it("builds project inspection commands", () => {
-		assert.deepEqual(build({ command: "workspaces" }), ["workspaces", "--format", "json", "--quiet"]);
-		assert.deepEqual(build({ command: "config" }), ["config", "--format", "json", "--quiet"]);
-		assert.deepEqual(build({ command: "schema" }), ["schema", "--format", "json", "--quiet"]);
-		assert.deepEqual(build({ command: "impact" }), ["impact", "--format", "json", "--quiet"]);
-		assert.deepEqual(build({ command: "project-info", listWorkspaces: true }), ["list", "--format", "json", "--quiet", "--workspaces"]);
+		for (const command of ["workspaces", "config", "schema", "impact"]) {
+			assert.deepEqual(build({ command }), [command, "--format", "json", "--quiet"]);
+		}
+		assert.deepEqual(build({ command: "list-boundaries" }), ["list", "--boundaries", "--format", "json", "--quiet"]);
 	});
 
-	it("rejects format overrides in extraArgs", () => {
-		assert.throws(() => build({ command: "health", extraArgs: ["--format", "human"] }), /must not include --format/);
-		assert.throws(() => build({ command: "health", extraArgs: ["--format=human"] }), /must not include --format/);
-		assert.throws(() => build({ command: "health", extraArgs: ["-f", "human"] }), /must not include --format/);
+	it("rejects unsupported commands and format overrides in args", () => {
+		assert.throws(() => build({ command: "unknown-command" }), /Unsupported fallow command/);
+		assert.throws(() => build({ command: "health", args: ["--format", "human"] }), /must not include --format/);
+		assert.throws(() => build({ command: "health", args: ["--format=human"] }), /must not include --format/);
+		assert.throws(() => build({ command: "health", args: ["-f", "human"] }), /must not include --format/);
+		assert.throws(() => build({ command: "fix-preview", args: ["--yes"] }), /must not include --yes/);
+		assert.throws(() => build({ command: "fix-apply", args: ["--dry-run"] }), /must not include --dry-run/);
+	});
+});
+
+describe("fallowCli.prepareFallowRunParams", () => {
+	it("leaves compact arguments unchanged", () => {
+		const params = { command: "audit", args: ["--base", "main"], root: "packages/app", detail: "findings" };
+		assert.equal(prepare(params), params);
+	});
+
+	it("translates stored wide-schema arguments into compact CLI tokens", () => {
+		assert.deepEqual(prepare({
+			command: "health",
+			changedSince: "main",
+			fileScores: true,
+			targets: true,
+			score: true,
+			root: "packages/app",
+			timeoutSecs: 30,
+		}), {
+			command: "health",
+			args: ["--changed-since", "main", "--file-scores", "--targets", "--score"],
+			root: "packages/app",
+			timeoutSecs: 30,
+		});
+		assert.deepEqual(prepare({
+			command: "trace-symbol",
+			file: "@extensions/fallow/cli.ts",
+			exportName: "fallowCli",
+			callers: true,
+			depth: 2,
+		}), {
+			command: "trace-symbol",
+			args: ["extensions/fallow/cli.ts:fallowCli", "--callers", "--depth", "2"],
+		});
+	});
+
+	it("preserves every stored wide-schema command translation", () => {
+		const cases = [
+			[{ command: "all", changedSince: "main", score: true }, ["--changed-since", "main", "--score"]],
+			[{ command: "dead-code", changedSince: "main", includeEntryExports: true, groupBy: "owner" }, ["--changed-since", "main", "--include-entry-exports", "--group-by", "owner"]],
+			[{ command: "check-changed", base: "origin/main", includeEntryExports: true }, ["--changed-since", "origin/main", "--include-entry-exports"]],
+			[{ command: "dupes", changedSince: "main", top: 5, minTokens: 10, skipLocal: true }, ["--changed-since", "main", "--top", "5", "--min-tokens", "10", "--skip-local"]],
+			[{ command: "audit", base: "main", gate: "new-only", explain: true }, ["--base", "main", "--gate", "new-only", "--explain"]],
+			[{ command: "fix-preview", includeEntryExports: true, noCreateConfig: true }, ["--include-entry-exports", "--no-create-config"]],
+			[{ command: "fix-apply", includeEntryExports: true }, ["--include-entry-exports"]],
+			[{ command: "flags", top: 3 }, ["--top", "3"]],
+			[{ command: "inspect", file: "@extensions/fallow/cli.ts" }, ["--file", "extensions/fallow/cli.ts"]],
+			[{ command: "security", base: "main", file: "@src/auth.ts", securityGate: "new", surface: true }, ["--changed-since", "main", "--file", "src/auth.ts", "--gate", "new", "--surface"]],
+			[{ command: "workspaces", noCache: true }, ["--no-cache"]],
+			[{ command: "config", noCache: true }, ["--no-cache"]],
+			[{ command: "schema", noCache: true }, ["--no-cache"]],
+			[{ command: "decision-surface", base: "main", maxDecisions: 4 }, ["--changed-since", "main", "--max-decisions", "4"]],
+			[{ command: "impact", noCache: true }, ["--no-cache"]],
+			[{ command: "project-info", entryPoints: true, files: true, plugins: true, boundaries: true, listWorkspaces: true }, ["--entry-points", "--files", "--plugins", "--boundaries", "--workspaces"]],
+			[{ command: "list-boundaries", noCache: true }, ["--no-cache"]],
+			[{ command: "explain", issueType: "unused-export" }, ["unused-export"]],
+			[{ command: "trace-export", file: "@src/a.ts", exportName: "unused" }, ["src/a.ts:unused"]],
+			[{ command: "trace-file", file: "@src/a.ts" }, ["src/a.ts"]],
+			[{ command: "trace-dependency", packageName: "jiti" }, ["jiti"]],
+			[{ command: "trace-clone", file: "@src/a.ts", line: 10, minLines: 3 }, ["src/a.ts:10", "--min-lines", "3"]],
+			[{ command: "coverage-analyze", runtimeCoverage: "coverage.json", top: 5, groupBy: "owner" }, ["--runtime-coverage", "coverage.json", "--top", "5", "--group-by", "owner"]],
+		];
+		for (const [legacy, args] of cases) {
+			assert.deepEqual(prepare(legacy), { command: legacy.command, args });
+		}
+	});
+
+	it("does not silently consume mixed or unknown argument shapes", () => {
+		const mixed = { command: "health", args: ["--score"], score: true };
+		const unknown = { command: "health", futureOption: true };
+		assert.equal(prepare(mixed), mixed);
+		assert.equal(prepare(unknown), unknown);
 	});
 });
 

--- a/tests/tool-contract.test.mjs
+++ b/tests/tool-contract.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { getEncoding } from "js-tiktoken";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { fallowToolContract: tool } = await jiti.import("../extensions/fallow/contract.ts");
+const encoder = getEncoding("o200k_base");
+
+describe("fallow_run compact contract", () => {
+	it("exposes only the compact public parameters", () => {
+		assert.deepEqual(Object.keys(tool.parameters.properties), [
+			"command", "args", "root", "timeoutSecs", "detail",
+		]);
+		assert.equal(tool.parameters.additionalProperties, false);
+		assert.equal(tool.promptSnippet, undefined);
+		assert.equal(tool.promptGuidelines, undefined);
+	});
+
+	it("stays below the fixed contract token budget", () => {
+		const contract = JSON.stringify(tool, null, 2);
+		const tokens = encoder.encode(contract).length;
+		assert.ok(tokens <= 350, `contract uses ${tokens} tokens`);
+	});
+});


### PR DESCRIPTION
## Summary

Shrinks the model-visible `fallow_run` contract from more than 50 individually described fields to five compact parameters:

```ts
{
  command,
  args?,
  root?,
  timeoutSecs?,
  detail?
}
```

- passes command-specific Fallow flags and values as separate `args` tokens
- keeps alias translation for root analysis, fixes, traces, project inspection, boundaries, and coverage
- keeps JSON/quiet output mandatory and rejects `--format` overrides
- validates required comparison refs and positional trace/explain targets
- prevents conflicting `fix-preview --yes` and `fix-apply --dry-run` combinations
- preserves leading-`@` path normalization
- removes the duplicated prompt snippet and prompt-guideline payload
- keeps manual `/fallow` command syntax unchanged

`detail` is reserved in the compact contract for the bounded-digest PR. It is not forwarded to the Fallow CLI, and this PR intentionally leaves output behavior unchanged.

## Stored-session compatibility

Pi calls `prepareArguments()` before validating resumed tool calls. Pi Fallow uses it to translate calls stored with the previous wide schema into compact CLI tokens.

Compatibility coverage includes every modeled command family, common options, workspaces, health/audit options, inspection, every trace alias, fixes, project listing, security, decision surfaces, and runtime coverage. Mixed or unknown shapes are not silently consumed and remain subject to normal schema validation.

## Token results

Frozen `o200k_base` benchmark:

| Surface | Before | After | Reduction |
|---|---:|---:|---:|
| `fallow_run` contract | 2,237 | 331 | **85.20%** |

The serialized contract falls from 9,820 to 1,385 characters. Tool results, slash transcripts, navigator prompts, finding retention, required-field retention, and full-output references are unchanged.

Contract-only next-turn tax becomes:

| Scenario | Before | After |
|---|---:|---:|
| No findings | 2,546 | 640 |
| 5 findings | 3,301 | 1,395 |
| 40 findings | 8,640 | 6,734 |
| 300 findings | 14,653 | 12,747 |
| Schema | 13,734 | 11,828 |

The larger-report tax remains output-dominated and is intentionally deferred to the bounded-digest PR.

## Coverage

All-production-source coverage is now:

- lines/statements: 73.45%
- functions: 77.17%
- branches: 83.52%

Coverage gates increase to 72% lines/statements, 76% functions, and 82% branches. The compact schema and contract modules are fully covered; CLI translation functions reach 100% function coverage.

## Validation

- [x] 92 tests pass on Node 22.19 and Node 24
- [x] Contract regression budget enforces at most 350 tokens
- [x] All legacy command translations are covered
- [x] Bundle checks pass on Node 22.19 and Node 24
- [x] Full publish check passes
- [x] Fallow health reports no findings
- [x] Dead-code check reports zero issues
- [x] Duplication check reports zero clone groups
- [x] Changed-file audit passes
- [x] Production and full dependency audits pass
- [x] Package smoke test passes
- [x] Token benchmark reports no output-quality regression
