### PR TITLE
feat: add navigator prompt detail toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Pi Fallow are documented here.
 - Reduced the `fallow_run` contract to command, CLI-token args, root, timeout, and output detail while translating wide-schema calls stored by older Pi sessions before validation.
 - Kept every normalized finding available in the TUI navigator and added search, section/severity filters, select-all-visible, and persistent multi-selection across filters.
 - Saved complete JSON whenever navigator normalization omits raw fields; generated report artifacts are never automatically deleted by Pi Fallow.
+- Added a default-off full-details checkbox to the navigator: compact prompts preserve every selected finding's coding essentials, while full mode explicitly embeds complete raw JSON and displays its model-context implication.
 
 ### Fixed
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.

--- a/README.md
+++ b/README.md
@@ -106,9 +106,12 @@ In the interactive navigator:
 - `/` — search section, label, path, severity, details, and suggested action
 - `f` / `v` — cycle section/severity filters
 - `x` — clear filters; `c` — clear explicit selections
+- `d` — toggle full raw finding JSON in the agent prompt; it is deselected by default
 - `e` or `a` — load selected findings into the editor
 - `t` — run a trace for the selected finding when possible
 - `q` / `Esc` — close (`Esc` first cancels an active search)
+
+The navigator defaults to compact prompts. Compact mode includes every selected finding with type, severity, location, subject, concise evidence/details, and suggested action, plus the complete-report path. Selecting the full-details checkbox additionally embeds complete raw JSON for every selected finding; the overlay warns that this can use substantially more model context.
 
 ## Requirements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -337,9 +337,9 @@ Add commands such as:
 
 ### 11. Make prompt generation a pure module
 
-Extract the hardcoded navigator prompt into a pure, independently tested prompt builder. Use normalized findings and a global budget rather than a fixed 3,000-character allowance for every selected raw finding.
+Extract the hardcoded navigator prompt into a pure, independently tested prompt builder. Default to a compact representation containing every selected finding's coding essentials rather than repeating verbose raw JSON scaffolding.
 
-Default to normalized evidence instead of raw JSON. Allow `includeRaw: "never" | "when-needed" | "always"`, but always enforce `maxChars`.
+Expose a default-off checkbox in the navigator for complete raw finding JSON. The overlay must explain that compact mode uses less context while full mode can be substantially larger. Explicit full mode must not silently omit selected findings or truncate their raw JSON; it is a deliberate user choice rather than an automatic budget decision.
 
 ## Phase 5 — Navigator and UI improvements
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -30,12 +30,21 @@ Do not edit a versioned fixture after collecting a baseline. Create a new benchm
 
 ## Commands
 
-Generate a candidate result:
+Generate a candidate result. Navigator prompts use the default compact detail mode:
 
 ```bash
 npm run bench:tokens -- \
   --label candidate \
   --output /tmp/pi-fallow-token-candidate.json
+```
+
+Measure the explicit full-details mode separately with `--prompt-detail full`. Use `--prompt-detail both` for exploratory artifacts containing both modes; do not compare its aggregate prompt total with a single-mode baseline.
+
+```bash
+npm run bench:tokens -- \
+  --label candidate-full \
+  --prompt-detail full \
+  --output /tmp/pi-fallow-token-candidate-full.json
 ```
 
 Compare it with the frozen before state:

--- a/extensions/fallow/command/handler.ts
+++ b/extensions/fallow/command/handler.ts
@@ -69,5 +69,5 @@ function runFallowCommandOnce(
 function applyFallowPrompt(ctx: FallowCommandContext, result: FallowNavigatorResult | null | undefined): void {
 	if (!isFallowTuiMode(ctx.mode) || result?.type !== "prompt") return;
 	ctx.ui.setEditorText(result.prompt);
-	ctx.ui.notify(`Loaded ${result.issueCount} Fallow finding(s) into the editor. Add comments, then submit when ready.`, "info");
+	ctx.ui.notify(`Loaded ${result.issueCount} Fallow finding(s) in ${result.detail} mode. Add comments, then submit when ready.`, "info");
 }

--- a/extensions/fallow/command/result-flow.ts
+++ b/extensions/fallow/command/result-flow.ts
@@ -12,6 +12,9 @@ import type { FallowCommandContext } from "./types";
 const FALLOW_NAVIGATOR_MAX_WIDTH_RATIO = 0.9;
 const FALLBACK_FALLOW_NAVIGATOR_MAX_WIDTH = 100;
 const FALLOW_NAVIGATOR_MIN_WIDTH = 50;
+const FALLOW_NAVIGATOR_STATIC_ROWS = 15;
+const FALLOW_NAVIGATOR_MIN_VISIBLE_ROWS = 3;
+const FALLOW_NAVIGATOR_MAX_VISIBLE_ROWS = 10;
 
 export async function executeFallowResult(
 	pi: ExtensionAPI,
@@ -109,6 +112,7 @@ function openFallowNavigator(
 				truncated: formatted.truncated,
 				projectState,
 				prSummary,
+				visibleRows: resolveFallowNavigatorVisibleRows(tui.terminal.rows),
 			},
 		);
 		return navigator;
@@ -122,6 +126,12 @@ function openFallowNavigator(
 			row: "25%",
 		}),
 	});
+}
+
+function resolveFallowNavigatorVisibleRows(terminalRows: number): number {
+	if (!Number.isFinite(terminalRows) || terminalRows < 1) return FALLOW_NAVIGATOR_MAX_VISIBLE_ROWS;
+	const overlayRows = Math.floor(terminalRows * 0.8);
+	return Math.max(FALLOW_NAVIGATOR_MIN_VISIBLE_ROWS, Math.min(FALLOW_NAVIGATOR_MAX_VISIBLE_ROWS, overlayRows - FALLOW_NAVIGATOR_STATIC_ROWS));
 }
 
 function resolveFallowNavigatorOverlayWidth(navigator: FallowIssueNavigator | undefined): number {

--- a/extensions/fallow/output.ts
+++ b/extensions/fallow/output.ts
@@ -119,7 +119,7 @@ export async function formatToolOutput(
 	const fullOutputPath = await writeOutputPathIfNeeded(
 		truncation,
 		rawText,
-		preserveNavigatorDetails && overviewOmitsRawFindings(overview),
+		preserveNavigatorDetails && overviewHasFindings(overview),
 	);
 	const text = buildToolOutputText(parsed, summary, truncation, fullOutputPath);
 
@@ -140,17 +140,17 @@ function getFormattedRawText(parsed: ParsedFallowOutput): string {
 	return parsed.parsed ? JSON.stringify(parsed.data, null, 2) : parsed.raw;
 }
 
-function overviewOmitsRawFindings(overview: FallowOverview | undefined): boolean {
+function overviewHasFindings(overview: FallowOverview | undefined): boolean {
 	if (!overview) return false;
-	return overview.sections.some((section) => section.items.some((item) => item.raw === undefined));
+	return overview.sections.some((section) => section.items.length > 0);
 }
 
 async function writeOutputPathIfNeeded(
 	truncation: ReturnType<typeof truncateHead>,
 	rawText: string,
-	overviewOmitsRaw: boolean,
+	preserveFullOutput: boolean,
 ): Promise<string | undefined> {
-	if (!truncation.truncated && !overviewOmitsRaw) return undefined;
+	if (!truncation.truncated && !preserveFullOutput) return undefined;
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-fallow-"));
 	const fullOutputPath = join(tempDir, "fallow-output.json");
 	await withFileMutationQueue(fullOutputPath, async () => writeFile(fullOutputPath, rawText, "utf8"));

--- a/extensions/fallow/overview.ts
+++ b/extensions/fallow/overview.ts
@@ -104,18 +104,18 @@ function valueOr<T>(value: T | null | undefined, fallback: T): T {
 	return value ?? fallback;
 }
 
-function sectionFromArray(title: string, array: unknown, kind: string): FallowOverviewSection | undefined {
+function sectionFromArray(title: string, array: unknown, kind: string, includeAllRaw = false): FallowOverviewSection | undefined {
 	const items = asArray(array);
 	if (!items.length) return undefined;
 	return {
 		title,
 		count: items.length,
 		color: "warning",
-		items: items.map((entry, index) => makeIssue(kind, asRecord(entry) ?? { value: entry }, index < INLINE_RAW_DEFAULT)),
+		items: items.map((entry, index) => makeIssue(kind, asRecord(entry) ?? { value: entry }, includeAllRaw || index < INLINE_RAW_DEFAULT)),
 	};
 }
 
-function buildDeadCodeSections(data: Record<string, any>): FallowOverviewSection[] {
+function buildDeadCodeSections(data: Record<string, any>, includeAllRaw = false): FallowOverviewSection[] {
 	const specs: Array<[string, string, string]> = [
 		["Unused files", "unused_files", "unused-file"],
 		["Unused exports", "unused_exports", "unused-export"],
@@ -129,15 +129,15 @@ function buildDeadCodeSections(data: Record<string, any>): FallowOverviewSection
 		["Boundary violations", "boundary_violations", "boundary-violation"],
 		["Stale suppressions", "stale_suppressions", "stale-suppression"],
 	];
-	return specs.map(([title, key, kind]) => sectionFromArray(title, data[key], kind)).filter(Boolean) as FallowOverviewSection[];
+	return specs.map(([title, key, kind]) => sectionFromArray(title, data[key], kind, includeAllRaw)).filter(Boolean) as FallowOverviewSection[];
 }
 
-function buildHealthSections(data: Record<string, any>): FallowOverviewSection[] {
+function buildHealthSections(data: Record<string, any>, includeAllRaw = false): FallowOverviewSection[] {
 	const sections: FallowOverviewSection[] = [];
-	appendHealthSection(sections, "Complexity findings", "error", asArray(data.findings), INLINE_RAW_EXTENDED, buildComplexityIssue);
-	appendHealthSection(sections, "Worst file scores", "accent", asArray(data.file_scores), INLINE_RAW_DEFAULT, buildFileScoreIssue);
-	appendHealthSection(sections, "Refactoring targets", "warning", asArray(data.targets), INLINE_RAW_DEFAULT, buildRefactoringTargetIssue);
-	appendHealthSection(sections, "Hotspots", "warning", asArray(data.hotspots), INLINE_RAW_DEFAULT, buildHotspotIssue);
+	appendHealthSection(sections, "Complexity findings", "error", asArray(data.findings), INLINE_RAW_EXTENDED, includeAllRaw, buildComplexityIssue);
+	appendHealthSection(sections, "Worst file scores", "accent", asArray(data.file_scores), INLINE_RAW_DEFAULT, includeAllRaw, buildFileScoreIssue);
+	appendHealthSection(sections, "Refactoring targets", "warning", asArray(data.targets), INLINE_RAW_DEFAULT, includeAllRaw, buildRefactoringTargetIssue);
+	appendHealthSection(sections, "Hotspots", "warning", asArray(data.hotspots), INLINE_RAW_DEFAULT, includeAllRaw, buildHotspotIssue);
 	return sections;
 }
 
@@ -147,10 +147,11 @@ function appendHealthSection(
 	color: "error" | "accent" | "warning",
 	entries: unknown[],
 	rawLimit: number,
+	includeAllRaw: boolean,
 	buildItem: (entry: unknown, includeRaw: boolean) => FallowIssueLine,
 ): void {
 	if (!entries.length) return;
-	sections.push({ title, count: entries.length, color, items: entries.map((entry, index) => buildItem(entry, index < rawLimit)) });
+	sections.push({ title, count: entries.length, color, items: entries.map((entry, index) => buildItem(entry, includeAllRaw || index < rawLimit)) });
 }
 
 function buildComplexityIssue(entry: unknown, includeRaw = true): FallowIssueLine {
@@ -198,14 +199,14 @@ function buildHotspotTrend(issue: Record<string, any>): string {
 	return issue.trend ?? "";
 }
 
-function buildDupesSections(data: Record<string, any>): FallowOverviewSection[] {
+function buildDupesSections(data: Record<string, any>, includeAllRaw = false): FallowOverviewSection[] {
 	const groups = asArray(data.clone_groups);
 	if (!groups.length) return [];
 	return [{
 		title: "Clone groups",
 		count: groups.length,
 		color: "warning",
-		items: groups.map((entry, index) => makeCloneGroupIssue(entry, index, index < INLINE_RAW_CLONES)),
+		items: groups.map((entry, index) => makeCloneGroupIssue(entry, index, includeAllRaw || index < INLINE_RAW_CLONES)),
 	}];
 }
 
@@ -263,18 +264,18 @@ function addIfDefinedHealthScore(
 	stats.push({ label: "score", value: score });
 }
 
-function addPrimarySections(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }): void {
+function addPrimarySections(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }, includeAllRaw: boolean): void {
 	const specs = buildPrimarySectionSpecs();
 	for (const spec of specs) {
 		if (!spec.isPresent(root)) continue;
-		processPrimarySection(root, sections, title, spec);
+		processPrimarySection(root, sections, title, spec, includeAllRaw);
 	}
 }
 
 function buildPrimarySectionSpecs(): Array<{
 	isPresent: (root: Record<string, any>) => boolean;
 	forceTitle: string;
-	sectionsFor: (data: Record<string, any> | undefined) => FallowOverviewSection[];
+	sectionsFor: (data: Record<string, any> | undefined, includeAllRaw?: boolean) => FallowOverviewSection[];
 	selector: (root: Record<string, any>) => Record<string, any> | undefined;
 	prefix: string;
 }> {
@@ -310,24 +311,25 @@ function processPrimarySection(
 	spec: {
 		isPresent: (root: Record<string, any>) => boolean;
 		forceTitle: string;
-		sectionsFor: (data: Record<string, any> | undefined) => FallowOverviewSection[];
+		sectionsFor: (data: Record<string, any> | undefined, includeAllRaw?: boolean) => FallowOverviewSection[];
 		selector: (root: Record<string, any>) => Record<string, any> | undefined;
 		prefix: string;
 	},
+	includeAllRaw: boolean,
 ): void {
 	if (title.value === "Fallow") title.value = spec.forceTitle;
 	const sectionData = spec.selector(root);
 	if (!sectionData) return;
-	for (const section of spec.sectionsFor(sectionData)) {
+	for (const section of spec.sectionsFor(sectionData, includeAllRaw)) {
 		sections.push({ ...section, title: `${spec.prefix} · ${section.title}` });
 	}
 }
 
-function addFallbackSections(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }): void {
+function addFallbackSections(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }, includeAllRaw: boolean): void {
 	if (sections.length) return;
-	const deadSections = buildDeadCodeSections(root);
-	const healthSections = buildHealthSections(root);
-	const dupeSections = buildDupesSections(root);
+	const deadSections = buildDeadCodeSections(root, includeAllRaw);
+	const healthSections = buildHealthSections(root, includeAllRaw);
+	const dupeSections = buildDupesSections(root, includeAllRaw);
 	appendFallbackSections(sections, deadSections, healthSections, dupeSections);
 	updateFallbackTitle(healthSections, dupeSections, deadSections, title);
 }
@@ -352,7 +354,7 @@ function updateFallbackTitle(
 	else if (deadSections.length) title.value = "Fallow dead code";
 }
 
-function addFeatureFlags(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }): void {
+function addFeatureFlags(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }, includeAllRaw: boolean): void {
 	if (!root.feature_flags) return;
 	title.value = "Fallow feature flags";
 	const flags = asArray(root.feature_flags);
@@ -360,11 +362,11 @@ function addFeatureFlags(root: Record<string, any>, sections: FallowOverviewSect
 		title: "Feature flags",
 		count: flags.length,
 		color: "accent",
-		items: flags.map((entry, index) => makeIssue("flag", asRecord(entry) ?? {}, index < INLINE_RAW_EXTENDED)),
+		items: flags.map((entry, index) => makeIssue("flag", asRecord(entry) ?? {}, includeAllRaw || index < INLINE_RAW_EXTENDED)),
 	});
 }
 
-function addSecurity(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }): void {
+function addSecurity(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }, includeAllRaw: boolean): void {
 	if (!root.security_findings) return;
 	title.value = "Fallow security";
 	const findings = asArray(root.security_findings);
@@ -373,7 +375,7 @@ function addSecurity(root: Record<string, any>, sections: FallowOverviewSection[
 		title: "Security candidates",
 		count: findings.length,
 		color: "warning",
-		items: findings.map((entry, index) => buildSecurityIssue(entry, index < INLINE_RAW_EXTENDED)),
+		items: findings.map((entry, index) => buildSecurityIssue(entry, includeAllRaw || index < INLINE_RAW_EXTENDED)),
 	});
 }
 
@@ -395,7 +397,7 @@ function formatSecurityMeta(issue: Record<string, any>): string | undefined {
 	return parts.length ? parts.join(" · ") : undefined;
 }
 
-function addDecisionSurface(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }): void {
+function addDecisionSurface(root: Record<string, any>, sections: FallowOverviewSection[], title: { value: string }, includeAllRaw: boolean): void {
 	if (!root.decisions) return;
 	title.value = "Fallow decision surface";
 	const decisions = asArray(root.decisions);
@@ -404,7 +406,7 @@ function addDecisionSurface(root: Record<string, any>, sections: FallowOverviewS
 		title: "Structural decisions",
 		count: decisions.length,
 		color: "accent",
-		items: decisions.map((entry, index) => buildDecisionIssue(entry, index < INLINE_RAW_EXTENDED)),
+		items: decisions.map((entry, index) => buildDecisionIssue(entry, includeAllRaw || index < INLINE_RAW_EXTENDED)),
 	});
 }
 
@@ -498,28 +500,30 @@ function addIfDefined(stats: Array<{ label: string; value: string | number }>, l
 	if (value === undefined) return;
 	stats.push({ label, value });
 }
-export function buildFallowOverview(data: unknown, exitCode = 0): FallowOverview | undefined {
+export function buildFallowOverview(
+	data: unknown,
+	exitCode = 0,
+	options: { includeAllRaw?: boolean } = {},
+): FallowOverview | undefined {
 	const root = asRecord(data);
 	if (!root) return undefined;
 	const stats: Array<{ label: string; value: string | number }> = [];
 	const sections: FallowOverviewSection[] = [];
 	const notes: string[] = [];
 	const title = { value: "Fallow" };
+	const includeAllRaw = options.includeAllRaw === true;
 
 	addRootStats(root, stats);
 	addConfigStats(root, stats, title);
-	if (!isConfigOutput(root)) {
-		addPrimarySections(root, sections, title);
-		addFallbackSections(root, sections, title);
-	}
-	addFeatureFlags(root, sections, title);
-	addSecurity(root, sections, title);
-	addDecisionSurface(root, sections, title);
+	addOverviewSections(root, sections, title, includeAllRaw);
+	addFeatureFlags(root, sections, title, includeAllRaw);
+	addSecurity(root, sections, title, includeAllRaw);
+	addDecisionSurface(root, sections, title, includeAllRaw);
 	addInspectionStats(root, stats, title, notes);
 	addWorkspaceStats(root, stats, title, notes);
 	addSchemaStats(root, stats, title);
 	addDefaultNotes(root, sections, stats, notes);
-	if (exitCode === 1) notes.push("Fallow exit 1 means findings/gate failure, not a crashed command.");
+	addExitCodeNote(notes, exitCode);
 
 	return {
 		title: title.value,
@@ -528,6 +532,21 @@ export function buildFallowOverview(data: unknown, exitCode = 0): FallowOverview
 		sections,
 		notes,
 	};
+}
+
+function addOverviewSections(
+	root: Record<string, any>,
+	sections: FallowOverviewSection[],
+	title: { value: string },
+	includeAllRaw: boolean,
+): void {
+	if (isConfigOutput(root)) return;
+	addPrimarySections(root, sections, title, includeAllRaw);
+	addFallbackSections(root, sections, title, includeAllRaw);
+}
+
+function addExitCodeNote(notes: string[], exitCode: number): void {
+	if (exitCode === 1) notes.push("Fallow exit 1 means findings/gate failure, not a crashed command.");
 }
 
 function buildFallowStatus(root: Record<string, any>, sections: FallowOverviewSection[], exitCode: number): "success" | "warning" | "error" {

--- a/extensions/fallow/prompt.ts
+++ b/extensions/fallow/prompt.ts
@@ -1,0 +1,212 @@
+import type { FallowIssueLine } from "./types";
+
+export type FallowPromptDetail = "compact" | "full";
+
+export interface FallowPromptFinding {
+	sectionTitle: string;
+	item: FallowIssueLine;
+}
+
+interface FallowPromptOptions {
+	findings: FallowPromptFinding[];
+	detail: FallowPromptDetail;
+	command?: string;
+	fullOutputPath?: string;
+	hydrationWarning?: string;
+}
+
+const MAX_COMPACT_EVIDENCE_CHARS = 64;
+const MAX_COMPACT_ACTION_CHARS = 64;
+const MAX_COMPACT_DETAILS_CHARS = 160;
+
+export function buildFallowPrompt(options: FallowPromptOptions): string {
+	const header = buildPromptHeader(options);
+	const compactFindings = buildCompactFindings(options.findings);
+	const fullDetails = options.detail === "full" ? buildFullFindingDetails(options.findings) : undefined;
+	return [header, compactFindings, fullDetails].filter(Boolean).join("\n\n");
+}
+
+function buildPromptHeader(options: FallowPromptOptions): string {
+	return [
+		"Please work on the following selected Fallow findings.",
+		"",
+		"Additional instructions from user:",
+		"<!-- Add your comments here before submitting to Pi. -->",
+		"",
+		"Default task: Inspect the referenced code, decide whether to fix, refactor, delete, add tests, or suppress intentionally, then make the appropriate changes. Rerun the relevant Fallow command after changes.",
+		`Prompt detail: ${options.detail}`,
+		options.command ? `Fallow command: ${options.command}` : undefined,
+		options.fullOutputPath ? `Complete Fallow report: ${options.fullOutputPath}` : undefined,
+		options.hydrationWarning ? `Report detail warning: ${options.hydrationWarning}` : undefined,
+	].filter((part) => part !== undefined).join("\n");
+}
+
+function buildCompactFindings(findings: FallowPromptFinding[]): string {
+	const lines = [
+		`Selected findings: ${findings.length}`,
+		"Columns: # | type | severity | location | subject | evidence/details | suggested action",
+	];
+	let currentSection: string | undefined;
+	for (const [index, finding] of findings.entries()) {
+		if (finding.sectionTitle !== currentSection) {
+			currentSection = finding.sectionTitle;
+			lines.push(`## ${escapeCompactCell(currentSection)}`);
+		}
+		lines.push(buildCompactFindingLine(finding, index));
+	}
+	return lines.join("\n");
+}
+
+function buildCompactFindingLine(finding: FallowPromptFinding, index: number): string {
+	const { item } = finding;
+	const raw = asRecord(item.raw);
+	const evidence = compactText(findingEvidence(raw), MAX_COMPACT_EVIDENCE_CHARS);
+	const action = compactText(findingAction(item, raw), MAX_COMPACT_ACTION_CHARS);
+	const details = joinDistinct([
+		compactIdentifier(findingIdentifier(raw), evidence, action),
+		compactText(item.meta, MAX_COMPACT_DETAILS_CHARS),
+		evidence,
+	]);
+	const cells = [
+		String(index + 1),
+		findingType(raw, finding.sectionTitle),
+		findingSeverity(item, raw),
+		findingLocation(item),
+		item.label,
+		textOrDash(details),
+		textOrDash(action),
+	];
+	return cells.map(escapeCompactCell).join(" | ");
+}
+
+function findingLocation(item: FallowIssueLine): string {
+	if (!item.path) return "unknown";
+	return item.line ? `${item.path}:${item.line}` : item.path;
+}
+
+function findingSeverity(item: FallowIssueLine, raw: Record<string, any> | undefined): string {
+	return item.severity ?? stringValue(recordValue(raw, "severity")) ?? "unknown";
+}
+
+function textOrDash(value: string | undefined): string {
+	return value || "-";
+}
+
+function buildFullFindingDetails(findings: FallowPromptFinding[]): string {
+	const blocks = findings.map((finding, index) => {
+		const raw = finding.item.raw ?? normalizedFindingFallback(finding);
+		return [`### ${index + 1}. ${finding.sectionTitle}: ${finding.item.label}`, "```json", safeJson(raw), "```"].join("\n");
+	});
+	return ["## Full raw finding JSON", ...blocks].join("\n\n");
+}
+
+function normalizedFindingFallback(finding: FallowPromptFinding): Record<string, unknown> {
+	return {
+		section: finding.sectionTitle,
+		label: finding.item.label,
+		path: finding.item.path,
+		line: finding.item.line,
+		severity: finding.item.severity,
+		details: finding.item.meta,
+		action: finding.item.action,
+	};
+}
+
+function findingType(raw: Record<string, any> | undefined, fallback: string): string {
+	return firstString(recordValues(raw, ["kind", "type", "issue_type", "rule_id"])) ?? fallback;
+}
+
+function findingIdentifier(raw: Record<string, any> | undefined): string | undefined {
+	return firstString(recordValues(raw, ["benchmark_id", "id", "finding_id"]));
+}
+
+function compactIdentifier(identifier: string | undefined, evidence: string | undefined, action: string | undefined): string | undefined {
+	if (!identifier) return undefined;
+	if (evidence?.includes(identifier) || action?.includes(identifier)) return undefined;
+	return `id ${identifier}`;
+}
+
+function findingEvidence(raw: Record<string, any> | undefined): string | undefined {
+	return firstText(recordValues(raw, ["evidence", "reason", "rationale", "message", "description"]));
+}
+
+function findingAction(item: FallowIssueLine, raw: Record<string, any> | undefined): string | undefined {
+	if (item.action) return item.action;
+	const action = firstRawAction(raw);
+	if (action) return action;
+	return firstText(recordValues(raw, ["recommendation", "suggested_action"]));
+}
+
+function firstRawAction(raw: Record<string, any> | undefined): string | undefined {
+	for (const action of arrayValue(raw, "actions")) {
+		const text = firstText(recordValues(asRecord(action), ["description", "type"]));
+		if (text) return text;
+	}
+	return undefined;
+}
+
+function firstString(values: unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value === "string" && value.trim()) return value;
+	}
+	return undefined;
+}
+
+function firstText(values: unknown[]): string | undefined {
+	for (const value of values) {
+		const text = valueAsText(value);
+		if (text) return text;
+	}
+	return undefined;
+}
+
+function valueAsText(value: unknown): string | undefined {
+	if (!isPresentValue(value)) return undefined;
+	return typeof value === "string" ? value : safeJson(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+	return isPresentValue(value) ? String(value) : undefined;
+}
+
+function isPresentValue(value: unknown): boolean {
+	return value !== undefined && value !== null && value !== "";
+}
+
+function recordValues(raw: Record<string, any> | undefined, keys: string[]): unknown[] {
+	return keys.map((key) => recordValue(raw, key));
+}
+
+function recordValue(raw: Record<string, any> | undefined, key: string): unknown {
+	return raw ? raw[key] : undefined;
+}
+
+function arrayValue(raw: Record<string, any> | undefined, key: string): unknown[] {
+	const value = recordValue(raw, key);
+	return Array.isArray(value) ? value : [];
+}
+
+function compactText(value: string | undefined, maxChars: number): string | undefined {
+	if (!value || value.length <= maxChars) return value;
+	return `${value.slice(0, maxChars - 1)}…`;
+}
+
+function joinDistinct(values: Array<string | undefined>): string {
+	return [...new Set(values.filter(Boolean) as string[])].join("; ");
+}
+
+function escapeCompactCell(value: string): string {
+	return value.replaceAll("\\", "\\\\").replaceAll("|", "\\|").replaceAll("\r", "\\r").replaceAll("\n", "\\n");
+}
+
+function asRecord(value: unknown): Record<string, any> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, any> : undefined;
+}
+
+function safeJson(value: unknown): string {
+	try {
+		return JSON.stringify(value, null, 2) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}

--- a/extensions/fallow/types.ts
+++ b/extensions/fallow/types.ts
@@ -65,5 +65,5 @@ export interface FallowOverview {
 }
 
 export type FallowNavigatorResult =
-	| { type: "prompt"; prompt: string; issueCount: number }
+	| { type: "prompt"; prompt: string; issueCount: number; detail: "compact" | "full" }
 	| { type: "trace"; commandArgs: string[] };

--- a/extensions/fallow/ui/navigator.ts
+++ b/extensions/fallow/ui/navigator.ts
@@ -1,4 +1,7 @@
+import { readFile } from "node:fs/promises";
 import { CURSOR_MARKER, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type Focusable } from "@earendil-works/pi-tui";
+import { buildFallowOverview } from "../overview";
+import { buildFallowPrompt, type FallowPromptDetail, type FallowPromptFinding } from "../prompt";
 import { renderFallowProjectState } from "../project/render";
 import { renderFallowPrSummary } from "../pr-summary/render";
 import type { FallowIssueLine, FallowNavigatorResult, FallowOverview, FallowOverviewSection, FallowPrSummary, FallowProjectState } from "../types";
@@ -15,6 +18,15 @@ function buildHeaderTitle(visibleCount: number, totalCount: number, title: strin
 	const count = visibleCount === totalCount ? `${totalCount}` : `${visibleCount}/${totalCount}`;
 	const findingText = `${count} finding${totalCount === 1 ? "" : "s"}`;
 	return `${purple(" ✦ ")}${theme.fg(statusColor, theme.bold(title))}${theme.fg("dim", " · ")}${pill(findingText, totalCount ? pink : cyan)} `;
+}
+
+interface FallowNavigatorOptions {
+	command?: string;
+	fullOutputPath?: string;
+	truncated?: boolean;
+	projectState?: FallowProjectState;
+	prSummary?: FallowPrSummary;
+	visibleRows?: number;
 }
 
 interface FlatIssue {
@@ -36,6 +48,8 @@ export class FallowIssueNavigator implements Component, Focusable {
 	private editingSearch = false;
 	private sectionFilter?: number;
 	private severityFilter?: string;
+	private includeFullDetails = false;
+	private preparingPrompt = false;
 	private cachedWidth?: number;
 	private cachedLines?: string[];
 
@@ -44,7 +58,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 		private theme: any,
 		private onDone: (result: FallowNavigatorResult | null) => void,
 		private requestRender: () => void,
-		private options: { command?: string; fullOutputPath?: string; truncated?: boolean; projectState?: FallowProjectState; prSummary?: FallowPrSummary } = {},
+		private options: FallowNavigatorOptions = {},
 	) {
 		this.issues = overview.sections
 			.flatMap((section, sectionIndex) => section.items.map((item, itemIndex) => ({ section, item, sectionIndex, itemIndex })))
@@ -58,10 +72,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	handleInput(data: string): void {
-		if (this.editingSearch) {
-			this.handleSearchInput(data);
-			return;
-		}
+		if (this.routeModalInput(data)) return;
 		const bindings: Array<{ matches: (value: string) => boolean; action: () => void }> = [
 			{ matches: (value) => matchesKey(value, "escape") || value === "q", action: () => this.onDone(null) },
 			{ matches: (value) => matchesKey(value, "up") || value === "k", action: () => this.move(-1) },
@@ -75,6 +86,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 			{ matches: (value) => value === "s" || matchesKey(value, "tab"), action: () => this.toggleMarked() },
 			{ matches: (value) => value === "A", action: () => this.toggleAllVisible() },
 			{ matches: (value) => value === "c", action: () => this.clearMarked() },
+			{ matches: (value) => value === "d", action: () => this.togglePromptDetail() },
 			{ matches: (value) => value === "e" || value === "a", action: () => this.finishWithPrompt() },
 			{ matches: (value) => value === "t", action: () => this.finishWithTrace() },
 			{ matches: (value) => matchesKey(value, "enter") || matchesKey(value, "space") || matchesKey(value, "right") || value === "l", action: () => this.toggleExpanded() },
@@ -85,6 +97,13 @@ export class FallowIssueNavigator implements Component, Focusable {
 			binding.action();
 			return;
 		}
+	}
+
+	private routeModalInput(data: string): boolean {
+		if (this.preparingPrompt) return true;
+		if (!this.editingSearch) return false;
+		this.handleSearchInput(data);
+		return true;
 	}
 
 	render(width: number): string[] {
@@ -223,9 +242,10 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private renderIssues(frameWidth: number, innerWidth: number, visible: FlatIssue[], lines: string[]): void {
-		this.ensureVisible(VISIBLE_ISSUE_ROWS, visible.length);
+		const visibleRows = this.visibleRowCount();
+		this.ensureVisible(visibleRows, visible.length);
 		const start = this.scrollStart;
-		const end = Math.min(visible.length, start + VISIBLE_ISSUE_ROWS);
+		const end = Math.min(visible.length, start + visibleRows);
 		if (start > 0) lines.push(this.frame(this.theme.fg("dim", `… ${start} earlier findings`), frameWidth));
 		for (const row of this.renderIssueRows(start, end, innerWidth, visible)) lines.push(this.frame(row, frameWidth));
 		if (end < visible.length) lines.push(this.frame(this.theme.fg("dim", `… ${visible.length - end} later findings`), frameWidth));
@@ -254,6 +274,9 @@ export class FallowIssueNavigator implements Component, Focusable {
 	private renderFooter(frameWidth: number, lines: string[]): void {
 		lines.push(this.separator(frameWidth));
 		lines.push(this.frame(this.footerSelectionLine(), frameWidth));
+		lines.push(this.frame(this.promptDetailLine(), frameWidth));
+		const innerWidth = Math.max(1, frameWidth - FRAME_BORDER_WIDTH);
+		for (const line of wrapTextWithAnsi(this.promptImplicationLine(), innerWidth)) lines.push(this.frame(line, frameWidth));
 		for (const line of this.summaryBlockLines()) lines.push(this.frame(line, frameWidth));
 		for (const line of this.footerMetaLines()) lines.push(this.frame(line, frameWidth));
 	}
@@ -265,6 +288,20 @@ export class FallowIssueNavigator implements Component, Focusable {
 	private selectionStatus(): string {
 		if (this.marked.size) return `${this.marked.size} selected`;
 		return this.currentIssue() ? "current finding" : "0 selected";
+	}
+
+	private promptDetailLine(): string {
+		const checkbox = this.includeFullDetails ? this.theme.fg("success", "☑") : this.theme.fg("dim", "☐");
+		return `${checkbox} ${this.theme.fg("text", "Include full finding JSON in agent prompt")} ${pill("d toggle", violet)}`;
+	}
+
+	private promptImplicationLine(): string {
+		const count = this.selection().length;
+		if (this.preparingPrompt) return this.theme.fg("accent", `Preparing ${this.promptDetail()} prompt for ${count} finding(s)…`);
+		if (this.includeFullDetails) {
+			return this.theme.fg("warning", `Full: embeds raw JSON for ${count} finding(s). Much larger prompt; may consume significant model context.`);
+		}
+		return this.theme.fg("muted", `Compact: sends ${count} finding(s) with type, severity, location, concise evidence, and action. Lower context; complete JSON stays linked.`);
 	}
 
 	private summaryBlockLines(): string[] {
@@ -289,6 +326,8 @@ export class FallowIssueNavigator implements Component, Focusable {
 			...this.preferredHeaderLines(),
 			...this.preferredIssueLines(visible),
 			this.footerSelectionLine(),
+			this.promptDetailLine(),
+			this.promptImplicationLine(),
 			...this.summaryBlockLines(),
 			...this.footerMetaLines(),
 		];
@@ -303,7 +342,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	private preferredIssueLines(visible: FlatIssue[]): string[] {
 		if (!this.issues.length) return [this.theme.fg("success", "No navigable findings in this Fallow report.")];
 		if (!visible.length) return [this.theme.fg("warning", "No findings match the active filters.")];
-		const entries = visible.slice(0, VISIBLE_ISSUE_ROWS);
+		const entries = visible.slice(0, this.visibleRowCount());
 		return entries.flatMap((entry, index) => this.preferredIssueEntryLines(entry, index, entries));
 	}
 
@@ -313,6 +352,10 @@ export class FallowIssueNavigator implements Component, Focusable {
 			this.issueLineRaw(entry, index),
 			...(entry.item.action ? [this.detailActionLine(entry.item)] : []),
 		];
+	}
+
+	private visibleRowCount(): number {
+		return this.options.visibleRows ?? VISIBLE_ISSUE_ROWS;
 	}
 
 	private move(delta: number): void {
@@ -415,10 +458,65 @@ export class FallowIssueNavigator implements Component, Focusable {
 		return current ? [current] : [];
 	}
 
+	private togglePromptDetail(): void {
+		this.includeFullDetails = !this.includeFullDetails;
+		this.changed();
+	}
+
+	private promptDetail(): FallowPromptDetail {
+		return this.includeFullDetails ? "full" : "compact";
+	}
+
 	private finishWithPrompt(): void {
 		const issues = this.selection();
 		if (!issues.length) return;
-		this.onDone({ type: "prompt", issueCount: issues.length, prompt: this.buildPrompt(issues) });
+		if (!issues.some((entry) => entry.item.raw === undefined)) {
+			this.emitPrompt(issues);
+			return;
+		}
+		if (!this.options.fullOutputPath) {
+			this.emitPrompt(issues, "Complete report path is unavailable; using retained finding details.");
+			return;
+		}
+		this.preparingPrompt = true;
+		this.changed();
+		void this.hydrateAndEmitPrompt(issues);
+	}
+
+	private async hydrateAndEmitPrompt(issues: FlatIssue[]): Promise<void> {
+		try {
+			const hydrated = await this.hydrateIssues(issues);
+			this.emitPrompt(hydrated);
+		} catch {
+			this.emitPrompt(issues, "Complete report could not be loaded; using retained finding details.");
+		}
+	}
+
+	private async hydrateIssues(issues: FlatIssue[]): Promise<FlatIssue[]> {
+		const reportText = await readFile(this.options.fullOutputPath!, "utf8");
+		const hydratedOverview = buildFallowOverview(JSON.parse(reportText), 0, { includeAllRaw: true });
+		if (!hydratedOverview) throw new Error("Complete report has no structured overview.");
+		return issues.map((entry) => ({
+			...entry,
+			item: hydratedOverview.sections[entry.sectionIndex]?.items[entry.itemIndex] ?? entry.item,
+		}));
+	}
+
+	private emitPrompt(issues: FlatIssue[], hydrationWarning?: string): void {
+		const detail = this.promptDetail();
+		const findings: FallowPromptFinding[] = issues.map((entry) => ({ sectionTitle: entry.section.title, item: entry.item }));
+		this.onDone({
+			type: "prompt",
+			issueCount: issues.length,
+			detail,
+			prompt: buildFallowPrompt({
+				findings,
+				detail,
+				command: this.options.command,
+				fullOutputPath: this.options.fullOutputPath,
+				hydrationWarning,
+			}),
+		});
 	}
 
 	private finishWithTrace(): void {
@@ -446,45 +544,6 @@ export class FallowIssueNavigator implements Component, Focusable {
 		return path.replace(/[\]\)>,.;:!?]+$/u, "").replace(/:\d+$/, "");
 	}
 
-	private buildPrompt(issues: FlatIssue[]): string {
-		const blocks = issues.map((entry, index) => this.buildIssuePromptBlock(entry, index)).join("\n\n");
-		const sections = [
-			"Please work on the following selected Fallow findings.",
-			"",
-			"Additional instructions from user:",
-			"<!-- Add your comments here before submitting to Pi. -->",
-			"",
-			"Default task: For each finding, inspect the referenced code, decide whether to fix, refactor, delete, add tests, or suppress intentionally, then make the appropriate changes. After changes, rerun the relevant Fallow command to verify.",
-			this.options.command ? `Fallow command: ${this.options.command}` : undefined,
-			this.options.fullOutputPath ? `Complete Fallow report: ${this.options.fullOutputPath}` : undefined,
-			"",
-			blocks,
-		];
-		return sections.filter((part) => part !== undefined).join("\n");
-	}
-
-	private buildIssuePromptBlock(entry: FlatIssue, index: number): string {
-		const item = entry.item;
-		return [
-			`## ${index + 1}. ${entry.section.title}: ${item.label}`,
-			this.buildIssueLocationLine(item),
-			...(item.severity ? [`Severity: ${item.severity}`] : []),
-			...(item.meta ? [`Details: ${item.meta}`] : []),
-			...(item.action ? [`Suggested action: ${item.action}`] : []),
-			...this.buildIssueRawLines(item),
-		].join("\n");
-	}
-
-	private buildIssueLocationLine(item: FallowIssueLine): string {
-		const location = item.path ? `${item.path}${item.line ? `:${item.line}` : ""}` : "unknown location";
-		return `Location: ${location}`;
-	}
-
-	private buildIssueRawLines(item: FallowIssueLine): string[] {
-		if (item.raw === undefined) return [];
-		return ["Raw finding:", "```json", safeJson(item.raw, 3000), "```"];
-	}
-
 	private statLines(width: number): string[] {
 		const statLine = this.statLine();
 		return statLine ? wrapTextWithAnsi(statLine, width) : [];
@@ -510,6 +569,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 			`${key("v")} ${this.theme.fg("muted", "severity")}`,
 			`${key("x")} ${this.theme.fg("muted", "reset filters")}`,
 			`${key("c")} ${this.theme.fg("muted", "clear selected")}`,
+			`${key("d")} ${this.theme.fg("muted", "prompt detail")}`,
 			`${key("e/a")} ${this.theme.fg("muted", "load")}`,
 			`${key("t")} ${this.theme.fg("muted", "trace")}`,
 			`${key("q")} ${this.theme.fg("muted", "close")}`,
@@ -633,16 +693,6 @@ function removeLastCharacter(value: string): string {
 
 function isPrintableCharacter(value: string): boolean {
 	return [...value].length === 1 && value >= " ";
-}
-
-function safeJson(value: unknown, maxChars: number): string {
-	let text: string;
-	try {
-		text = JSON.stringify(value, null, 2);
-	} catch {
-		text = String(value);
-	}
-	return text.length > maxChars ? `${text.slice(0, maxChars)}\n… truncated …` : text;
 }
 
 function pickPathFromText(text: string, pattern: RegExp): string | null {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dupes": "fallow dupes --format json --quiet",
     "dead-code": "fallow dead-code --format json --quiet",
     "test": "node --test",
-    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=72 --statements=72 --functions=76 --branches=82 node --test",
+    "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=75 --statements=75 --functions=79 --branches=83 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",

--- a/scripts/benchmark-utils.mjs
+++ b/scripts/benchmark-utils.mjs
@@ -38,7 +38,7 @@ export async function populateFallowProject(cwd) {
 	await writeFile(join(cwd, ".fallow", "cache.bin"), "benchmark", "utf8");
 }
 
-export function runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd }) {
+export function runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, preserveNavigatorDetails = false }) {
 	return fallowEngine.runFallowWithExecutor({
 		pi: {},
 		cwd,
@@ -46,6 +46,7 @@ export function runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd }) {
 		signal: undefined,
 		timeoutSecs: 120,
 		throwOnExecutionError: false,
+		preserveNavigatorDetails,
 		executor: async (_pi, args) => ({
 			binary: "fallow",
 			args,

--- a/scripts/token-benchmark.mjs
+++ b/scripts/token-benchmark.mjs
@@ -24,6 +24,7 @@ const jiti = createJiti(import.meta.url);
 
 const { default: registerPiFallow } = await jiti.import("../extensions/fallow.ts");
 const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
+const { buildFallowOverview } = await jiti.import("../extensions/fallow/overview.ts");
 const { formatFallowProjectStateText } = await jiti.import("../extensions/fallow/project/text.ts");
 const { formatFallowPrSummaryText } = await jiti.import("../extensions/fallow/pr-summary/text.ts");
 const { buildFallowTranscriptContent } = await jiti.import("../extensions/fallow/command/transcript.ts");
@@ -45,7 +46,7 @@ const measurements = [contractMeasurement];
 
 try {
 	for (const scenario of corpus.scenarios) {
-		measurements.push(...await measureScenario(scenario, projectDir, contractMeasurement));
+		measurements.push(...await measureScenario(scenario, projectDir, contractMeasurement, cli.promptDetail));
 	}
 } finally {
 	await rm(projectDir, { recursive: true, force: true });
@@ -57,6 +58,7 @@ const artifact = {
 	generatedAt: new Date().toISOString(),
 	corpusHash,
 	primaryEncoding: PRIMARY_ENCODING,
+	promptDetail: cli.promptDetail,
 	tokenizers: ENCODING_NAMES.map((encoding) => ({
 		encoding,
 		implementation: "js-tiktoken",
@@ -77,19 +79,29 @@ await writeJsonArtifact(artifact, cli.output);
 printSummary(artifact, cli.output);
 
 function parseCli(args) {
-	const options = { label: "working-tree", output: undefined };
-	for (let index = 0; index < args.length; index++) {
-		const arg = args[index];
-		if (arg === "--label") options.label = requireValue(args, ++index, arg);
-		else if (arg === "--output") options.output = requireValue(args, ++index, arg);
-		else throw new Error(`Unknown argument: ${arg}`);
-	}
+	const options = { label: "working-tree", output: undefined, promptDetail: "compact" };
+	for (let index = 0; index < args.length; index++) index = applyCliOption(options, args, index);
 	return options;
+}
+
+function applyCliOption(options, args, index) {
+	const arg = args[index];
+	if (arg === "--label") options.label = requireValue(args, ++index, arg);
+	else if (arg === "--output") options.output = requireValue(args, ++index, arg);
+	else if (arg === "--prompt-detail") options.promptDetail = requirePromptDetail(args, ++index, arg);
+	else throw new Error(`Unknown argument: ${arg}`);
+	return index;
 }
 
 function requireValue(args, index, flag) {
 	const value = args[index];
 	if (!value) throw new Error(`${flag} requires a value.`);
+	return value;
+}
+
+function requirePromptDetail(args, index, flag) {
+	const value = requireValue(args, index, flag);
+	if (!["compact", "full", "both"].includes(value)) throw new Error(`${flag} must be compact, full, or both.`);
 	return value;
 }
 
@@ -123,12 +135,12 @@ function captureToolContract(registerExtension) {
 	}, null, 2);
 }
 
-async function measureScenario(scenario, cwd, contract) {
+async function measureScenario(scenario, cwd, contract, promptDetail) {
 	const fixturePath = join(ROOT, "benchmarks", scenario.fixture);
 	const fixtureText = await readFile(fixturePath, "utf8");
 	const fixtureData = JSON.parse(fixtureText);
 	const findings = collectBenchmarkFindings(fixtureData);
-	const commandResult = await runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd });
+	const commandResult = await runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, preserveNavigatorDetails: true });
 
 	const fullOutputPath = commandResult.formatted.fullOutputPath;
 	const normalize = (text) => normalizeFullOutputPath(text, fullOutputPath);
@@ -159,11 +171,13 @@ async function measureScenario(scenario, cwd, contract) {
 	];
 
 	if (commandResult.formatted.overview) {
-		output.push(...measurePrompts(
+		const promptOverview = buildFallowOverview(fixtureData, scenario.exitCode, { includeAllRaw: true }) ?? commandResult.formatted.overview;
+		output.push(...await measurePrompts(
 			scenario,
-			commandResult.formatted.overview,
-			commandResult.formatted.fullOutputPath ? FULL_OUTPUT_PLACEHOLDER : undefined,
+			promptOverview,
+			commandResult.formatted.fullOutputPath,
 			contract,
+			promptDetail,
 		));
 	}
 
@@ -175,54 +189,77 @@ function normalizeFullOutputPath(text, fullOutputPath) {
 	return fullOutputPath ? text.replaceAll(fullOutputPath, FULL_OUTPUT_PLACEHOLDER) : text;
 }
 
-function measurePrompts(scenario, overview, fullOutputPath, contract) {
+async function measurePrompts(scenario, overview, fullOutputPath, contract, promptDetail) {
 	const entries = overview.sections.flatMap((section) => section.items);
 	if (!entries.length) return [];
 	const reportFindings = countEntryFindings(entries);
-	return (scenario.promptSelections ?? [])
-		.map((selection) => measurePromptSelection(scenario, overview, entries, selection, fullOutputPath, reportFindings, contract))
-		.filter(Boolean);
+	const pairs = await Promise.all((scenario.promptSelections ?? []).map((selection) =>
+		measurePromptPair(scenario, overview, entries, selection, fullOutputPath, reportFindings, contract, promptDetail),
+	));
+	return pairs.flat();
+}
+
+async function measurePromptPair(scenario, overview, entries, selection, fullOutputPath, reportFindings, contract, promptDetail) {
+	return Promise.all(promptDetailModes(promptDetail).map((includeFullDetails) =>
+		measurePromptSelection(scenario, overview, entries, selection, fullOutputPath, reportFindings, contract, includeFullDetails),
+	));
+}
+
+function promptDetailModes(promptDetail) {
+	if (promptDetail === "both") return [false, true];
+	return [promptDetail === "full"];
 }
 
 function countEntryFindings(entries) {
 	return collectUniqueFindings(entries.flatMap((entry) => collectBenchmarkFindings(entry.raw))).length;
 }
 
-function measurePromptSelection(scenario, overview, entries, selection, fullOutputPath, reportFindings, contract) {
+async function measurePromptSelection(scenario, overview, entries, selection, fullOutputPath, reportFindings, contract, includeFullDetails) {
 	const selectionCount = resolveSelectionCount(selection, entries.length);
 	if (selectionCount < 1) return undefined;
-	const result = buildNavigatorPrompt(scenario, overview, selectionCount, fullOutputPath);
-	if (!result || result.type !== "prompt") throw new Error(`Failed to build prompt for ${scenario.id}/${selection}.`);
+	const result = await buildNavigatorPrompt(scenario, overview, selectionCount, fullOutputPath, includeFullDetails);
+	assertPromptResult(result, scenario.id, selection);
 	const selectedFindings = collectEntryFindings(entries.slice(0, selectionCount));
+	const prompt = normalizeFullOutputPath(result.prompt, fullOutputPath);
+	const suffix = promptScenarioSuffix(selection, includeFullDetails);
 	return withContextExposure(measureText(
 		"editor-prompt",
-		`${scenario.id}:${selection}`,
-		result.prompt,
+		`${scenario.id}:${suffix}`,
+		prompt,
 		selectedFindings,
-		{ reportFindings, selectedRows: selectionCount, availableRows: entries.length },
+		{ reportFindings, selectedRows: selectionCount, availableRows: entries.length, detail: result.detail },
 	), contract);
+}
+
+function assertPromptResult(result, scenarioId, selection) {
+	if (result?.type !== "prompt") throw new Error(`Failed to build prompt for ${scenarioId}/${selection}.`);
+}
+
+function promptScenarioSuffix(selection, includeFullDetails) {
+	return includeFullDetails ? `${selection}:full` : selection;
 }
 
 function resolveSelectionCount(selection, availableRows) {
 	return selection === "all" ? availableRows : Math.min(selection, availableRows);
 }
 
-function buildNavigatorPrompt(scenario, overview, selectionCount, fullOutputPath) {
-	let result;
-	const navigator = new FallowIssueNavigator(
-		overview,
-		plainTheme,
-		(value) => { result = value; },
-		() => {},
-		{
-			command: `fallow ${scenario.args.join(" ")}`,
-			fullOutputPath,
-			truncated: !!fullOutputPath,
-		},
-	);
-	selectNavigatorRows(navigator, selectionCount);
-	navigator.handleInput("e");
-	return result;
+function buildNavigatorPrompt(scenario, overview, selectionCount, fullOutputPath, includeFullDetails) {
+	return new Promise((resolve) => {
+		const navigator = new FallowIssueNavigator(
+			overview,
+			plainTheme,
+			resolve,
+			() => {},
+			{
+				command: `fallow ${scenario.args.join(" ")}`,
+				fullOutputPath,
+				truncated: !!fullOutputPath,
+			},
+		);
+		selectNavigatorRows(navigator, selectionCount);
+		if (includeFullDetails) navigator.handleInput("d");
+		navigator.handleInput("e");
+	});
 }
 
 function selectNavigatorRows(navigator, selectionCount) {

--- a/tests/navigator.test.mjs
+++ b/tests/navigator.test.mjs
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "node:test";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
 const { FallowIssueNavigator } = await jiti.import("../extensions/fallow/ui/navigator.ts");
+const { buildFallowOverview } = await jiti.import("../extensions/fallow/overview.ts");
 
 const theme = {
 	fg: (_color, text) => text,
@@ -65,6 +69,15 @@ function createFilterOverview() {
 	};
 }
 
+function loadEndFindingPrompt(overview, fullOutputPath, includeFullDetails) {
+	return new Promise((resolve) => {
+		const navigator = new FallowIssueNavigator(overview, theme, resolve, () => {}, { fullOutputPath });
+		navigator.handleInput("\u001b[F");
+		if (includeFullDetails) navigator.handleInput("d");
+		navigator.handleInput("e");
+	});
+}
+
 describe("FallowIssueNavigator prompt generation", () => {
 	it("builds an editable prompt for selected findings", () => {
 		let result = null;
@@ -92,13 +105,12 @@ describe("FallowIssueNavigator prompt generation", () => {
 		assert.match(result.prompt, /Please work on the following selected Fallow findings\./);
 		assert.match(result.prompt, /Additional instructions from user:/);
 		assert.match(result.prompt, /Fallow command: dead-code --format json --quiet/);
-		assert.match(result.prompt, /## 1\. Unused exports: unused helper/);
-		assert.match(result.prompt, /Location: src\/a\.ts:7/);
-		assert.match(result.prompt, /Details: export helper/);
-		assert.match(result.prompt, /Suggested action: Remove the export or add a real use\./);
-		assert.match(result.prompt, /"type": "unused_export"/);
-		assert.match(result.prompt, /## 2\. Unused exports: dead file/);
-		assert.match(result.prompt, /Location: src\/dead\.ts/);
+		assert.equal(result?.detail, "compact");
+		assert.match(result.prompt, /1 \| unused_export \| unknown \| src\/a\.ts:7 \| unused helper/);
+		assert.match(result.prompt, /export helper/);
+		assert.match(result.prompt, /Remove the export or add a real use\./);
+		assert.match(result.prompt, /2 \| unused_file \| unknown \| src\/dead\.ts \| dead file/);
+		assert.doesNotMatch(result.prompt, /Full raw finding JSON/);
 	});
 
 	it("builds a prompt for the current finding when none are marked", () => {
@@ -113,7 +125,7 @@ describe("FallowIssueNavigator prompt generation", () => {
 		assert.equal(result?.type, "prompt");
 		assert.equal(result?.issueCount, 1);
 		assert.doesNotMatch(result.prompt, /unused helper/);
-		assert.match(result.prompt, /## 1\. Unused exports: dead file/);
+		assert.match(result.prompt, /1 \| unused_file \| unknown \| src\/dead\.ts \| dead file/);
 	});
 
 	it("navigates to findings beyond the first visible page", () => {
@@ -124,6 +136,7 @@ describe("FallowIssueNavigator prompt generation", () => {
 			path: `src/file-${index + 1}.ts`,
 			line: index + 1,
 			action: `Review finding ${index + 1}.`,
+			raw: { kind: "test-finding", path: `src/file-${index + 1}.ts`, line: index + 1 },
 		}));
 		overview.sections[0].count = 35;
 		const navigator = new FallowIssueNavigator(overview, theme, (value) => {
@@ -147,6 +160,7 @@ describe("FallowIssueNavigator prompt generation", () => {
 			path: `src/file-${index + 1}.ts`,
 			line: index + 1,
 			action: `Review finding ${index + 1}.`,
+			raw: { kind: "test-finding", path: `src/file-${index + 1}.ts`, line: index + 1 },
 		}));
 		overview.sections[0].count = 35;
 		const navigator = new FallowIssueNavigator(overview, theme, (value) => {
@@ -157,7 +171,7 @@ describe("FallowIssueNavigator prompt generation", () => {
 		navigator.handleInput("e");
 
 		assert.equal(result?.issueCount, 35);
-		assert.match(result.prompt, /## 35\. Unused exports: finding 35/);
+		assert.match(result.prompt, /35 \| test-finding \| unknown \| src\/file-35\.ts:35 \| finding 35/);
 	});
 
 	it("searches without discarding hidden findings", () => {
@@ -224,6 +238,74 @@ describe("FallowIssueNavigator prompt generation", () => {
 
 		assert.equal(doneCalls, 0);
 		assert.match(navigator.render(80).join("\n"), /3 findings/);
+	});
+
+	it("defaults the full-details checkbox to deselected and explains both modes", () => {
+		let result = null;
+		const navigator = new FallowIssueNavigator(createOverview(), theme, (value) => {
+			result = value;
+		}, () => {});
+
+		const compactOverlay = navigator.render(100).join("\n");
+		assert.match(compactOverlay, /☐/);
+		assert.match(compactOverlay, /Compact: sends 1 finding/);
+		navigator.handleInput("d");
+		const fullOverlay = navigator.render(100).join("\n");
+		assert.match(fullOverlay, /☑/);
+		assert.match(fullOverlay, /Full: embeds raw JSON for 1 finding/);
+		navigator.handleInput("e");
+
+		assert.equal(result?.detail, "full");
+		assert.match(result.prompt, /Full raw finding JSON/);
+	});
+
+	it("hydrates compact and full prompts from the complete report", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "pi-fallow-prompt-"));
+		const fullOutputPath = join(directory, "fallow-output.json");
+		const report = {
+			kind: "dead-code",
+			total_issues: 12,
+			unused_exports: Array.from({ length: 12 }, (_, index) => ({
+				benchmark_id: `finding-${index + 1}`,
+				kind: "unused-export",
+				export_name: `unused_${index + 1}`,
+				path: `src/file-${index + 1}.ts`,
+				line: index + 1,
+				severity: "high",
+				evidence: `No callers for finding ${index + 1}.`,
+				actions: [{ description: `Review finding ${index + 1}.` }],
+			})),
+		};
+		await writeFile(fullOutputPath, JSON.stringify(report, null, 2));
+
+		try {
+			const overview = buildFallowOverview(report);
+			assert.equal(overview.sections[0].items[11].raw, undefined);
+			const compactResult = await loadEndFindingPrompt(overview, fullOutputPath, false);
+			assert.equal(compactResult.detail, "compact");
+			assert.match(compactResult.prompt, /finding-12/);
+			assert.match(compactResult.prompt, /No callers for finding 12\./);
+
+			const fullResult = await loadEndFindingPrompt(overview, fullOutputPath, true);
+			assert.equal(fullResult.detail, "full");
+			assert.match(fullResult.prompt, /"benchmark_id": "finding-12"/);
+			assert.match(fullResult.prompt, /"evidence": "No callers for finding 12\."/);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("uses the responsive finding-row count supplied by the overlay", () => {
+		const overview = createOverview();
+		overview.sections[0].items = Array.from({ length: 12 }, (_, index) => ({ label: `finding ${index + 1}` }));
+		overview.sections[0].count = 12;
+		const navigator = new FallowIssueNavigator(overview, theme, () => {}, () => {}, { visibleRows: 3 });
+
+		const rendered = navigator.render(80).join("\n");
+		assert.match(rendered, /finding 3/);
+		assert.doesNotMatch(rendered, /finding 4/);
+		assert.match(rendered, /9 later findings/);
+		assert.match(rendered, /Include full finding JSON/);
 	});
 
 	it("chooses a fluid overlay width capped by the available maximum", () => {

--- a/tests/output.test.mjs
+++ b/tests/output.test.mjs
@@ -120,7 +120,7 @@ describe("formatToolOutput", () => {
 		assert.match(result.text, /Raw JSON:\n{\n  "kind": "dead-code"/);
 	});
 
-	it("preserves complete JSON when navigator normalization omits raw finding fields", async () => {
+	it("preserves complete JSON for TUI navigator prompts", async () => {
 		const report = {
 			kind: "dead-code",
 			total_issues: 12,
@@ -141,6 +141,19 @@ describe("formatToolOutput", () => {
 			assert.ok(result.fullOutputPath);
 			assert.equal(await readFile(result.fullOutputPath, "utf8"), JSON.stringify(report, null, 2));
 			assert.equal(result.overview.sections[0].items.length, 12);
+		} finally {
+			if (result.fullOutputPath) await rm(dirname(result.fullOutputPath), { recursive: true, force: true });
+		}
+	});
+
+	it("saves even a small finding report when the TUI prompt may need full details", async () => {
+		const report = { kind: "dead-code", total_issues: 1, unused_exports: [{ export_name: "helper", path: "src/a.ts" }] };
+		const result = await formatToolOutput(parseJson(JSON.stringify(report), ""), process.cwd(), 1, true);
+
+		try {
+			assert.equal(result.truncated, false);
+			assert.ok(result.fullOutputPath);
+			assert.equal(await readFile(result.fullOutputPath, "utf8"), JSON.stringify(report, null, 2));
 		} finally {
 			if (result.fullOutputPath) await rm(dirname(result.fullOutputPath), { recursive: true, force: true });
 		}

--- a/tests/prompt.test.mjs
+++ b/tests/prompt.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+import { getEncoding } from "js-tiktoken";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { buildFallowPrompt } = await jiti.import("../extensions/fallow/prompt.ts");
+const { buildFallowOverview } = await jiti.import("../extensions/fallow/overview.ts");
+const encoder = getEncoding("o200k_base");
+
+const raw = {
+	benchmark_id: "finding-1",
+	kind: "unused-export",
+	path: "src/a|b.ts",
+	line: 12,
+	severity: "high",
+	evidence: `No callers were found. ${"Evidence ".repeat(40)}`,
+	actions: [{ type: "review-finding", description: "Inspect callers and remove the export if it is unused." }],
+	extra: { complete: true },
+	long_detail: "x".repeat(4000),
+};
+const findings = [{
+	sectionTitle: "Unused exports",
+	item: {
+		label: "helper",
+		path: raw.path,
+		line: raw.line,
+		severity: raw.severity,
+		meta: "public export",
+		action: raw.actions[0].description,
+		raw,
+	},
+}];
+
+describe("buildFallowPrompt", () => {
+	it("builds a compact prompt with the coding-agent essentials", () => {
+		const prompt = buildFallowPrompt({
+			findings,
+			detail: "compact",
+			command: "fallow dead-code --format json --quiet",
+			fullOutputPath: "/tmp/pi-fallow/report.json",
+		});
+
+		assert.match(prompt, /Prompt detail: compact/);
+		assert.match(prompt, /Selected findings: 1/);
+		assert.match(prompt, /unused-export/);
+		assert.match(prompt, /high/);
+		assert.match(prompt, /src\/a\\\|b\.ts:12/);
+		assert.match(prompt, /id finding-1/);
+		assert.match(prompt, /No callers were found/);
+		assert.match(prompt, /Inspect callers and remove the export/);
+		assert.match(prompt, /Complete Fallow report: \/tmp\/pi-fallow\/report\.json/);
+		assert.match(prompt, /…/);
+		assert.doesNotMatch(prompt, /Full raw finding JSON/);
+		assert.doesNotMatch(prompt, /"complete": true/);
+	});
+
+	it("adds complete raw JSON only in full mode", () => {
+		const compact = buildFallowPrompt({ findings, detail: "compact" });
+		const full = buildFallowPrompt({ findings, detail: "full" });
+
+		assert.match(full, /Prompt detail: full/);
+		assert.match(full, /Full raw finding JSON/);
+		assert.match(full, /"benchmark_id": "finding-1"/);
+		assert.match(full, /"complete": true/);
+		assert.ok(full.includes(`"long_detail": "${"x".repeat(4000)}"`));
+		assert.ok(full.length > compact.length);
+	});
+
+	it("keeps the 300-finding compact prompt below its regression budget", async () => {
+		const report = JSON.parse(await readFile(new URL("../benchmarks/fixtures/large-findings.json", import.meta.url), "utf8"));
+		const overview = buildFallowOverview(report, 0, { includeAllRaw: true });
+		const allFindings = overview.sections.flatMap((section) => section.items.map((item) => ({ sectionTitle: section.title, item })));
+		const options = { findings: allFindings, command: "fallow dead-code --format json --quiet", fullOutputPath: "/tmp/PI_FALLOW_FULL_OUTPUT.json" };
+		const compact = buildFallowPrompt({ ...options, detail: "compact" });
+		const full = buildFallowPrompt({ ...options, detail: "full" });
+		const compactTokens = encoder.encode(compact).length;
+		const fullTokens = encoder.encode(full).length;
+
+		assert.equal(allFindings.length, 300);
+		assert.ok(compactTokens <= 17_000, `compact prompt uses ${compactTokens} tokens`);
+		assert.ok(fullTokens > compactTokens * 3, `full prompt uses ${fullTokens} versus ${compactTokens} compact tokens`);
+	});
+
+	it("keeps unknown finding data usable and surfaces hydration warnings", () => {
+		const prompt = buildFallowPrompt({
+			findings: [{ sectionTitle: "Unknown", item: { label: "unknown finding", raw: { message: "Review this value" } } }],
+			detail: "compact",
+			hydrationWarning: "Complete report could not be loaded.",
+		});
+
+		assert.match(prompt, /## Unknown/);
+		assert.match(prompt, /1 \| Unknown \| unknown \| unknown \| unknown finding/);
+		assert.match(prompt, /Review this value/);
+		assert.match(prompt, /Report detail warning: Complete report could not be loaded\./);
+	});
+});


### PR DESCRIPTION
## Summary

Adds the user-controlled prompt detail behavior discussed after the all-findings navigator work.

The navigator now displays a checkbox:

```text
[ ] Include full finding JSON in agent prompt   d toggle
```

It is **deselected by default** for every navigator.

### Compact mode (default)

- includes every selected finding; there is no finding-count cap
- sends type, severity, file/line, subject, stable identifier when needed, concise evidence/details, and concise suggested action
- groups rows by section and declares compact columns once
- includes the original Fallow command and exact complete-report path
- abbreviates evidence/action text with a visible ellipsis rather than pretending it is complete
- reports zero omitted findings in the benchmark corpus

### Full mode (explicit checkbox)

- includes the same compact index
- additionally embeds complete pretty-printed raw JSON for every selected finding
- does not apply the old per-finding raw-character truncation
- hydrates raw records from the exact saved report when they were not retained in navigator memory
- warns in the overlay that the prompt can consume substantial model context

The overlay changes its implication text with the checkbox state and current selection count. `d` toggles the checkbox; `e`/`a` loads the selected mode.

## Complete-report behavior

TUI reports with navigable findings now save exact JSON lazily so compact prompts can link it and full prompts can hydrate from it. Non-TUI runs do not create this additional file unless normal output truncation requires one.

Pi Fallow still never automatically deletes generated reports. Operating-system temporary-file retention applies.

## Token results

Exact `o200k_base` comparison against merged PR #25 behavior:

| Selection | Before | Compact | Reduction |
|---|---:|---:|---:|
| Large, 1/300 | 305 | 180 | 40.98% |
| Large, 5/300 | 1,138 | 396 | 65.20% |
| Large, 300/300 | 17,659 | 16,035 | 9.20% |
| Medium, 20/40 | 4,466 | 1,236 | 72.32% |
| Medium, 40/40 | 8,690 | 2,306 | 73.46% |
| Audit, 40/40 | 9,057 | 2,337 | 74.20% |

Aggregate editor-prompt tokens fall from 66,979 to 31,082 (**53.59%**). Against the frozen `0.2.0` baseline, the reduction is 38.94%.

The 300-finding compact prompt retains 300/300 findings, concise versions of evidence/action, and a complete-output reference. Its exact-value benchmark retention is 66.67% because evidence and action text are intentionally abbreviated. The explicit full mode is measured separately:

| Selection | Compact | Full | Full exact-field retention |
|---|---:|---:|---:|
| Large, 1/300 | 180 | 347 | 100% |
| Large, 5/300 | 396 | 1,212 | 100% |
| Large, 300/300 | 16,035 | 64,715 | 100% |

This context implication is why full mode is default-off and visibly warned.

The token benchmark defaults to compact mode. `--prompt-detail full` measures full mode separately; `--prompt-detail both` is available for exploratory artifacts.

## UI behavior

- checkbox is always visible in the footer
- compact/full implication changes immediately when toggled
- selected count is included in the implication
- prompt preparation prevents duplicate input while full records are hydrated
- navigator row count responds to terminal height so the new controls remain visible
- completion notification reports whether compact or full mode was loaded

## Coverage

All-production-source coverage:

- lines/statements: 75.09%
- functions: 79.75%
- branches: 84.60%

Coverage gates increase to 75% lines/statements, 79% functions, and 83% branches.

## Validation

- [x] 107 tests pass on Node 22.19 and Node 24
- [x] Full-details checkbox is verified default-off
- [x] Both overlay implication states are covered
- [x] Compact and full report hydration are covered
- [x] Full mode preserves raw JSON values longer than the old 3,000-character limit
- [x] 300-finding compact prompt has a fixed ≤17,000-token regression budget
- [x] 300/300 findings are present in both modes
- [x] Full mode retains 100% of exact benchmark fields
- [x] Complete-report files remain exact and are never automatically deleted
- [x] Large/schema retained-memory gates remain ≤2×
- [x] Bundle checks pass on Node 22.19 and Node 24
- [x] Full publish check passes
- [x] Fallow health reports no findings
- [x] Dead-code and duplication checks report zero issues
- [x] Production and full dependency audits pass
- [x] Package smoke test passes
