### PR TITLE
fix: separate informational navigator context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Pi Fallow are documented here.
 - Kept every normalized finding available in the TUI navigator and added search, section/severity filters, select-all-visible, and persistent multi-selection across filters.
 - Saved complete JSON whenever navigator normalization omits raw fields; generated report artifacts are never automatically deleted by Pi Fallow.
 - Added a default-off full-details checkbox to the navigator: compact prompts preserve every selected finding's coding essentials, while full mode explicitly embeds complete raw JSON and displays its model-context implication.
+- Stopped counting health file scores and hotspots as findings; mixed reports hide informational records behind a default-off toggle, informational-only commands omit finding controls, and large result sets can use more terminal height.
 
 ### Fixed
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 - **PR shortcut:** `/fallow pr` maps to `audit --base <detected-base> --gate new-only`.
 - **Rerun shortcut:** `/fallow rerun` repeats the last `/fallow` command.
 - **Non-blocking autocomplete:** subcommands, flags, enum values, static refs, and asynchronously discovered project branch refs are suggested without running Git while you type.
-- **Interactive navigator:** every normalized finding remains navigable with search, section/severity filters, multi-selection, tracing, and editor loading.
+- **Interactive navigator:** every actionable finding remains navigable with search, section/severity filters, multi-selection, tracing, and editor loading; informational file scores/hotspots are classified separately.
 - **Run-mode support:** `/fallow` executes in TUI, RPC, JSON, and print modes; terminal loaders and navigator overlays are TUI-only, while non-TUI modes retain full transcript output.
 - **Robust output parsing:** direct or noisy embedded JSON is scanned once with nesting, strings, and escapes handled correctly.
 - **Safe defaults:** JSON and quiet output are added when appropriate; complete output is saved to a temp file whenever transcript or navigator data omits fields, and released from retained engine state after formatting. Pi Fallow never automatically deletes saved reports.
@@ -106,12 +106,15 @@ In the interactive navigator:
 - `/` — search section, label, path, severity, details, and suggested action
 - `f` / `v` — cycle section/severity filters
 - `x` — clear filters; `c` — clear explicit selections
+- `i` — show/hide informational file scores and hotspots; they are hidden by default and never counted as findings
 - `d` — toggle full raw finding JSON in the agent prompt; it is deselected by default
 - `e` or `a` — load selected findings into the editor
 - `t` — run a trace for the selected finding when possible
 - `q` / `Esc` — close (`Esc` first cancels an active search)
 
 The navigator defaults to compact prompts. Compact mode includes every selected finding with type, severity, location, subject, concise evidence/details, and suggested action, plus the complete-report path. Selecting the full-details checkbox additionally embeds complete raw JSON for every selected finding; the overlay warns that this can use substantially more model context.
+
+Plain `fallow health` can return actionable findings alongside informational per-file scores and hotspots. Pi Fallow hides those informational records by default and reports their count separately. Explicit informational commands such as `health --file-scores` and `flags` show their records directly without finding-selection or agent-prompt controls. Large result sets use more of the available terminal height while retaining a virtualized viewport.
 
 ## Requirements
 

--- a/extensions/fallow/command/navigator.ts
+++ b/extensions/fallow/command/navigator.ts
@@ -1,0 +1,25 @@
+const NAVIGATOR_STATIC_ROWS = 17;
+const INFORMATIONAL_STATIC_ROWS = 9;
+const MIN_VISIBLE_ROWS = 3;
+const MAX_VISIBLE_ROWS = 20;
+
+const INFORMATIONAL_HEALTH_FLAGS = ["--file-scores", "--hotspots", "--ownership"];
+const ACTIONABLE_HEALTH_FLAGS = ["--complexity", "--targets", "--coverage-gaps", "--css"];
+
+export function resolveFallowNavigatorVisibleRows(terminalRows: number, informationalMode: boolean): number {
+	if (!Number.isFinite(terminalRows) || terminalRows < 1) return MAX_VISIBLE_ROWS;
+	const overlayRows = Math.floor(terminalRows * 0.9);
+	const staticRows = informationalMode ? INFORMATIONAL_STATIC_ROWS : NAVIGATOR_STATIC_ROWS;
+	return Math.max(MIN_VISIBLE_ROWS, Math.min(MAX_VISIBLE_ROWS, overlayRows - staticRows));
+}
+
+export function isInformationalNavigatorCommand(args: string[]): boolean {
+	if (args[0] === "flags") return true;
+	if (args[0] !== "health") return false;
+	if (!hasAnyFlag(args, INFORMATIONAL_HEALTH_FLAGS)) return false;
+	return !hasAnyFlag(args, ACTIONABLE_HEALTH_FLAGS);
+}
+
+function hasAnyFlag(args: string[], flags: string[]): boolean {
+	return flags.some((flag) => args.includes(flag));
+}

--- a/extensions/fallow/command/result-flow.ts
+++ b/extensions/fallow/command/result-flow.ts
@@ -6,15 +6,13 @@ import type { FallowNavigatorResult, FallowPrSummary, FallowProjectState } from 
 import { FallowIssueNavigator } from "../ui";
 import { buildFallowExecutor, buildFallowFinalArgs, runFallowWithLoaderIfUi, type FallowCommandExecutor, type FallowCommandResult } from "./loader";
 import { hasFallowNavigator, isFallowTuiMode } from "./mode";
+import { isInformationalNavigatorCommand, resolveFallowNavigatorVisibleRows } from "./navigator";
 import { buildFallowTranscriptContent } from "./transcript";
 import type { FallowCommandContext } from "./types";
 
 const FALLOW_NAVIGATOR_MAX_WIDTH_RATIO = 0.9;
 const FALLBACK_FALLOW_NAVIGATOR_MAX_WIDTH = 100;
 const FALLOW_NAVIGATOR_MIN_WIDTH = 50;
-const FALLOW_NAVIGATOR_STATIC_ROWS = 15;
-const FALLOW_NAVIGATOR_MIN_VISIBLE_ROWS = 3;
-const FALLOW_NAVIGATOR_MAX_VISIBLE_ROWS = 10;
 
 export async function executeFallowResult(
 	pi: ExtensionAPI,
@@ -100,6 +98,7 @@ function openFallowNavigator(
 	const { formatted } = result;
 	if (!isFallowTuiMode(ctx.mode) || !formatted.overview) return Promise.resolve(null);
 	let navigator: FallowIssueNavigator | undefined;
+	const informationalMode = isInformationalNavigatorCommand(executedArgs);
 	return ctx.ui.custom<FallowNavigatorResult | null>((tui, theme, _keybindings, done) => {
 		navigator = new FallowIssueNavigator(
 			formatted.overview!,
@@ -112,7 +111,8 @@ function openFallowNavigator(
 				truncated: formatted.truncated,
 				projectState,
 				prSummary,
-				visibleRows: resolveFallowNavigatorVisibleRows(tui.terminal.rows),
+				visibleRows: resolveFallowNavigatorVisibleRows(tui.terminal.rows, informationalMode),
+				informationalMode,
 			},
 		);
 		return navigator;
@@ -121,17 +121,11 @@ function openFallowNavigator(
 		overlayOptions: () => ({
 			width: resolveFallowNavigatorOverlayWidth(navigator),
 			minWidth: FALLOW_NAVIGATOR_MIN_WIDTH,
-			maxHeight: "80%",
+			maxHeight: "90%",
 			anchor: "top-center",
-			row: "25%",
+			row: "5%",
 		}),
 	});
-}
-
-function resolveFallowNavigatorVisibleRows(terminalRows: number): number {
-	if (!Number.isFinite(terminalRows) || terminalRows < 1) return FALLOW_NAVIGATOR_MAX_VISIBLE_ROWS;
-	const overlayRows = Math.floor(terminalRows * 0.8);
-	return Math.max(FALLOW_NAVIGATOR_MIN_VISIBLE_ROWS, Math.min(FALLOW_NAVIGATOR_MAX_VISIBLE_ROWS, overlayRows - FALLOW_NAVIGATOR_STATIC_ROWS));
 }
 
 function resolveFallowNavigatorOverlayWidth(navigator: FallowIssueNavigator | undefined): number {

--- a/extensions/fallow/overview.ts
+++ b/extensions/fallow/overview.ts
@@ -134,24 +134,25 @@ function buildDeadCodeSections(data: Record<string, any>, includeAllRaw = false)
 
 function buildHealthSections(data: Record<string, any>, includeAllRaw = false): FallowOverviewSection[] {
 	const sections: FallowOverviewSection[] = [];
-	appendHealthSection(sections, "Complexity findings", "error", asArray(data.findings), INLINE_RAW_EXTENDED, includeAllRaw, buildComplexityIssue);
-	appendHealthSection(sections, "Worst file scores", "accent", asArray(data.file_scores), INLINE_RAW_DEFAULT, includeAllRaw, buildFileScoreIssue);
-	appendHealthSection(sections, "Refactoring targets", "warning", asArray(data.targets), INLINE_RAW_DEFAULT, includeAllRaw, buildRefactoringTargetIssue);
-	appendHealthSection(sections, "Hotspots", "warning", asArray(data.hotspots), INLINE_RAW_DEFAULT, includeAllRaw, buildHotspotIssue);
+	appendHealthSection(sections, "Complexity findings", "error", "finding", asArray(data.findings), INLINE_RAW_EXTENDED, includeAllRaw, buildComplexityIssue);
+	appendHealthSection(sections, "Worst file scores", "accent", "context", asArray(data.file_scores), INLINE_RAW_DEFAULT, includeAllRaw, buildFileScoreIssue);
+	appendHealthSection(sections, "Refactoring targets", "warning", "finding", asArray(data.targets), INLINE_RAW_DEFAULT, includeAllRaw, buildRefactoringTargetIssue);
+	appendHealthSection(sections, "Hotspots", "muted", "context", asArray(data.hotspots), INLINE_RAW_DEFAULT, includeAllRaw, buildHotspotIssue);
 	return sections;
 }
 
 function appendHealthSection(
 	sections: FallowOverviewSection[],
 	title: string,
-	color: "error" | "accent" | "warning",
+	color: "error" | "accent" | "warning" | "muted",
+	role: "finding" | "context",
 	entries: unknown[],
 	rawLimit: number,
 	includeAllRaw: boolean,
 	buildItem: (entry: unknown, includeRaw: boolean) => FallowIssueLine,
 ): void {
 	if (!entries.length) return;
-	sections.push({ title, count: entries.length, color, items: entries.map((entry, index) => buildItem(entry, includeAllRaw || index < rawLimit)) });
+	sections.push({ title, count: entries.length, color, role, items: entries.map((entry, index) => buildItem(entry, includeAllRaw || index < rawLimit)) });
 }
 
 function buildComplexityIssue(entry: unknown, includeRaw = true): FallowIssueLine {
@@ -362,6 +363,7 @@ function addFeatureFlags(root: Record<string, any>, sections: FallowOverviewSect
 		title: "Feature flags",
 		count: flags.length,
 		color: "accent",
+		role: "context",
 		items: flags.map((entry, index) => makeIssue("flag", asRecord(entry) ?? {}, includeAllRaw || index < INLINE_RAW_EXTENDED)),
 	});
 }
@@ -559,5 +561,5 @@ function isFallowErrorState(root: Record<string, any>, exitCode: number): boolea
 }
 
 function isFallowWarningState(sections: FallowOverviewSection[], exitCode: number): boolean {
-	return sections.length > 0 || exitCode === 1;
+	return sections.some((section) => section.role !== "context" && section.items.length > 0) || exitCode === 1;
 }

--- a/extensions/fallow/types.ts
+++ b/extensions/fallow/types.ts
@@ -54,6 +54,7 @@ export interface FallowOverviewSection {
 	count?: number;
 	items: FallowIssueLine[];
 	color?: "success" | "warning" | "error" | "accent" | "muted";
+	role?: "finding" | "context";
 }
 
 export interface FallowOverview {

--- a/extensions/fallow/ui/navigator.ts
+++ b/extensions/fallow/ui/navigator.ts
@@ -11,13 +11,44 @@ const MIN_NAVIGATOR_WIDTH = 50;
 const FRAME_BORDER_WIDTH = 4;
 const HEADER_BORDER_WIDTH = 2;
 const VISIBLE_ISSUE_ROWS = 10;
+const PREFERRED_NAVIGATOR_MAX_WIDTH = 140;
 const SEVERITY_ORDER = ["critical", "high", "error", "medium", "warning", "low", "info", "unspecified"];
 
-function buildHeaderTitle(visibleCount: number, totalCount: number, title: string, status: FallowOverview["status"], theme: any): string {
+function buildHeaderTitle(
+	visibleFindings: number,
+	totalFindings: number,
+	informationalText: string | undefined,
+	informationalMode: boolean,
+	title: string,
+	status: FallowOverview["status"],
+	theme: any,
+): string {
 	const statusColor = getOverviewStatusColor(status);
-	const count = visibleCount === totalCount ? `${totalCount}` : `${visibleCount}/${totalCount}`;
-	const findingText = `${count} finding${totalCount === 1 ? "" : "s"}`;
-	return `${purple(" ✦ ")}${theme.fg(statusColor, theme.bold(title))}${theme.fg("dim", " · ")}${pill(findingText, totalCount ? pink : cyan)} `;
+	const findings = buildFindingsHeader(visibleFindings, totalFindings, informationalMode, theme);
+	const information = buildInformationHeader(informationalText, theme);
+	return `${purple(" ✦ ")}${theme.fg(statusColor, theme.bold(title))}${findings}${information} `;
+}
+
+function buildFindingsHeader(visible: number, total: number, informationalMode: boolean, theme: any): string {
+	if (informationalMode) return "";
+	const text = `${visibleCountText(visible, total)} ${findingNoun(total)}`;
+	return `${theme.fg("dim", " · ")}${pill(text, findingColor(total))}`;
+}
+
+function visibleCountText(visible: number, total: number): string {
+	return visible === total ? `${total}` : `${visible}/${total}`;
+}
+
+function findingNoun(total: number): string {
+	return total === 1 ? "finding" : "findings";
+}
+
+function findingColor(total: number): (text: string) => string {
+	return total ? pink : cyan;
+}
+
+function buildInformationHeader(text: string | undefined, theme: any): string {
+	return text ? `${theme.fg("dim", " · ")}${pill(text, cyan)}` : "";
 }
 
 interface FallowNavigatorOptions {
@@ -27,6 +58,7 @@ interface FallowNavigatorOptions {
 	projectState?: FallowProjectState;
 	prSummary?: FallowPrSummary;
 	visibleRows?: number;
+	informationalMode?: boolean;
 }
 
 interface FlatIssue {
@@ -48,6 +80,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	private editingSearch = false;
 	private sectionFilter?: number;
 	private severityFilter?: string;
+	private showInformational = false;
 	private includeFullDetails = false;
 	private preparingPrompt = false;
 	private cachedWidth?: number;
@@ -60,6 +93,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 		private requestRender: () => void,
 		private options: FallowNavigatorOptions = {},
 	) {
+		this.showInformational = options.informationalMode === true;
 		this.issues = overview.sections
 			.flatMap((section, sectionIndex) => section.items.map((item, itemIndex) => ({ section, item, sectionIndex, itemIndex })))
 			.map((entry, id) => ({ ...entry, id }));
@@ -68,7 +102,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	preferredWidth(maxWidth: number): number {
 		const boundedMax = normalizeMaxWidth(maxWidth);
 		const measuredWidth = Math.max(MIN_NAVIGATOR_WIDTH, this.measurePreferredWidth());
-		return Math.min(measuredWidth, boundedMax);
+		return Math.min(measuredWidth, boundedMax, PREFERRED_NAVIGATOR_MAX_WIDTH);
 	}
 
 	handleInput(data: string): void {
@@ -86,6 +120,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 			{ matches: (value) => value === "s" || matchesKey(value, "tab"), action: () => this.toggleMarked() },
 			{ matches: (value) => value === "A", action: () => this.toggleAllVisible() },
 			{ matches: (value) => value === "c", action: () => this.clearMarked() },
+			{ matches: (value) => value === "i", action: () => this.toggleInformational() },
 			{ matches: (value) => value === "d", action: () => this.togglePromptDetail() },
 			{ matches: (value) => value === "e" || value === "a", action: () => this.finishWithPrompt() },
 			{ matches: (value) => value === "t", action: () => this.finishWithTrace() },
@@ -113,7 +148,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 		const visible = this.visibleIssues();
 		const lines: string[] = [];
 
-		this.renderHeader(frameWidth, innerWidth, visible.length, lines);
+		this.renderHeader(frameWidth, innerWidth, visible, lines);
 		this.renderBody(frameWidth, innerWidth, visible, lines);
 		this.renderFooter(frameWidth, lines);
 		lines.push(this.bottomBorder(frameWidth));
@@ -168,13 +203,13 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private cycleSectionFilter(): void {
-		const options: Array<number | undefined> = [undefined, ...new Set(this.issues.map((issue) => issue.sectionIndex))];
+		const options: Array<number | undefined> = [undefined, ...new Set(this.availableIssues().map((issue) => issue.sectionIndex))];
 		this.sectionFilter = nextOption(options, this.sectionFilter);
 		this.filtersChanged();
 	}
 
 	private cycleSeverityFilter(): void {
-		const severities = [...new Set(this.issues.map((issue) => issueSeverity(issue)))].sort(compareSeverities);
+		const severities = [...new Set(this.availableIssues().map((issue) => issueSeverity(issue)))].sort(compareSeverities);
 		this.severityFilter = nextOption([undefined, ...severities], this.severityFilter);
 		this.filtersChanged();
 	}
@@ -187,8 +222,16 @@ export class FallowIssueNavigator implements Component, Focusable {
 		this.filtersChanged();
 	}
 
-	private renderHeader(frameWidth: number, innerWidth: number, visibleCount: number, lines: string[]): void {
-		const title = buildHeaderTitle(visibleCount, this.issues.length, this.overview.title, this.overview.status, this.theme);
+	private renderHeader(frameWidth: number, innerWidth: number, visible: FlatIssue[], lines: string[]): void {
+		const title = buildHeaderTitle(
+			visible.filter((entry) => !isInformational(entry)).length,
+			this.findingIssues().length,
+			this.informationalHeaderText(visible),
+			this.isInformationalMode(),
+			this.overview.title,
+			this.overview.status,
+			this.theme,
+		);
 		lines.push(this.topBorder(frameWidth, title));
 		lines.push(...this.statLines(innerWidth).map((line) => this.frame(line, frameWidth)));
 		for (const line of this.filterLines(innerWidth)) lines.push(this.frame(line, frameWidth));
@@ -230,15 +273,24 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private renderBody(frameWidth: number, innerWidth: number, visible: FlatIssue[], lines: string[]): void {
-		if (!this.issues.length) {
-			lines.push(this.frame(this.theme.fg("success", "No navigable findings in this Fallow report."), frameWidth));
-			return;
-		}
-		if (!visible.length) {
-			lines.push(this.frame(this.theme.fg("warning", "No findings match the active filters."), frameWidth));
+		const empty = this.emptyBodyMessage(visible);
+		if (empty) {
+			lines.push(this.frame(this.theme.fg(empty.tone, empty.text), frameWidth));
 			return;
 		}
 		this.renderIssues(frameWidth, innerWidth, visible, lines);
+	}
+
+	private emptyBodyMessage(visible: FlatIssue[]): { text: string; tone: "success" | "warning" } | undefined {
+		if (!this.issues.length) return { text: "No navigable findings in this Fallow report.", tone: "success" };
+		if (this.hasOnlyHiddenInformation()) return { text: "No actionable findings. Informational file scores and hotspots are hidden.", tone: "success" };
+		if (!visible.length) return { text: "No findings match the active filters.", tone: "warning" };
+		return undefined;
+	}
+
+	private hasOnlyHiddenInformation(): boolean {
+		if (this.availableIssues().length) return false;
+		return this.informationalIssues().length > 0;
 	}
 
 	private renderIssues(frameWidth: number, innerWidth: number, visible: FlatIssue[], lines: string[]): void {
@@ -246,9 +298,9 @@ export class FallowIssueNavigator implements Component, Focusable {
 		this.ensureVisible(visibleRows, visible.length);
 		const start = this.scrollStart;
 		const end = Math.min(visible.length, start + visibleRows);
-		if (start > 0) lines.push(this.frame(this.theme.fg("dim", `… ${start} earlier findings`), frameWidth));
+		if (start > 0) lines.push(this.frame(this.theme.fg("dim", `… ${start} earlier items`), frameWidth));
 		for (const row of this.renderIssueRows(start, end, innerWidth, visible)) lines.push(this.frame(row, frameWidth));
-		if (end < visible.length) lines.push(this.frame(this.theme.fg("dim", `… ${visible.length - end} later findings`), frameWidth));
+		if (end < visible.length) lines.push(this.frame(this.theme.fg("dim", `… ${visible.length - end} later items`), frameWidth));
 	}
 
 	private renderIssueRows(start: number, end: number, innerWidth: number, visible: FlatIssue[]): string[] {
@@ -273,12 +325,31 @@ export class FallowIssueNavigator implements Component, Focusable {
 
 	private renderFooter(frameWidth: number, lines: string[]): void {
 		lines.push(this.separator(frameWidth));
-		lines.push(this.frame(this.footerSelectionLine(), frameWidth));
-		lines.push(this.frame(this.promptDetailLine(), frameWidth));
 		const innerWidth = Math.max(1, frameWidth - FRAME_BORDER_WIDTH);
-		for (const line of wrapTextWithAnsi(this.promptImplicationLine(), innerWidth)) lines.push(this.frame(line, frameWidth));
+		this.renderFooterControls(frameWidth, innerWidth, lines);
 		for (const line of this.summaryBlockLines()) lines.push(this.frame(line, frameWidth));
 		for (const line of this.footerMetaLines()) lines.push(this.frame(line, frameWidth));
+	}
+
+	private renderFooterControls(frameWidth: number, innerWidth: number, lines: string[]): void {
+		if (this.isInformationalMode()) {
+			this.appendWrappedFooter(this.informationalImplicationLine(), frameWidth, innerWidth, lines);
+			return;
+		}
+		lines.push(this.frame(this.footerSelectionLine(), frameWidth));
+		this.renderInformationalToggle(frameWidth, innerWidth, lines);
+		lines.push(this.frame(this.promptDetailLine(), frameWidth));
+		this.appendWrappedFooter(this.promptImplicationLine(), frameWidth, innerWidth, lines);
+	}
+
+	private renderInformationalToggle(frameWidth: number, innerWidth: number, lines: string[]): void {
+		if (!this.informationalIssues().length) return;
+		lines.push(this.frame(this.informationalToggleLine(), frameWidth));
+		this.appendWrappedFooter(this.informationalImplicationLine(), frameWidth, innerWidth, lines);
+	}
+
+	private appendWrappedFooter(text: string, frameWidth: number, innerWidth: number, lines: string[]): void {
+		for (const line of wrapTextWithAnsi(text, innerWidth)) lines.push(this.frame(line, frameWidth));
 	}
 
 	private footerSelectionLine(): string {
@@ -288,6 +359,17 @@ export class FallowIssueNavigator implements Component, Focusable {
 	private selectionStatus(): string {
 		if (this.marked.size) return `${this.marked.size} selected`;
 		return this.currentIssue() ? "current finding" : "0 selected";
+	}
+
+	private informationalToggleLine(): string {
+		const checkbox = this.showInformational ? this.theme.fg("success", "☑") : this.theme.fg("dim", "☐");
+		return `${checkbox} ${this.theme.fg("text", `Show informational files (${this.informationalIssues().length})`)} ${pill("i toggle", violet)}`;
+	}
+
+	private informationalImplicationLine(): string {
+		if (this.isInformationalMode()) return this.theme.fg("muted", "Informational command output: file scores and hotspots are context, not findings.");
+		if (this.showInformational) return this.theme.fg("muted", "Informational file scores and hotspots are visible, but they are not counted as findings.");
+		return this.theme.fg("muted", "File scores and hotspots are context, not findings, and stay hidden by default.");
 	}
 
 	private promptDetailLine(): string {
@@ -321,13 +403,19 @@ export class FallowIssueNavigator implements Component, Focusable {
 
 	private measurePreferredWidth(): number {
 		const visible = this.visibleIssues();
-		const headerTitle = buildHeaderTitle(visible.length, this.issues.length, this.overview.title, this.overview.status, this.theme);
+		const headerTitle = buildHeaderTitle(
+			visible.filter((entry) => !isInformational(entry)).length,
+			this.findingIssues().length,
+			this.informationalHeaderText(visible),
+			this.isInformationalMode(),
+			this.overview.title,
+			this.overview.status,
+			this.theme,
+		);
 		const frameCandidates = [
 			...this.preferredHeaderLines(),
 			...this.preferredIssueLines(visible),
-			this.footerSelectionLine(),
-			this.promptDetailLine(),
-			this.promptImplicationLine(),
+			...this.preferredFooterControlLines(),
 			...this.summaryBlockLines(),
 			...this.footerMetaLines(),
 		];
@@ -335,13 +423,23 @@ export class FallowIssueNavigator implements Component, Focusable {
 		return Math.max(visibleWidth(headerTitle) + HEADER_BORDER_WIDTH, contentWidth + FRAME_BORDER_WIDTH);
 	}
 
+	private preferredFooterControlLines(): string[] {
+		if (this.isInformationalMode()) return [this.informationalImplicationLine()];
+		return [
+			this.footerSelectionLine(),
+			...(this.informationalIssues().length ? [this.informationalToggleLine(), this.informationalImplicationLine()] : []),
+			this.promptDetailLine(),
+			this.promptImplicationLine(),
+		];
+	}
+
 	private preferredHeaderLines(): string[] {
 		return [this.statLine(), this.hasActiveFilters() ? this.filterLine() : undefined, this.helpLine()].filter(Boolean) as string[];
 	}
 
 	private preferredIssueLines(visible: FlatIssue[]): string[] {
-		if (!this.issues.length) return [this.theme.fg("success", "No navigable findings in this Fallow report.")];
-		if (!visible.length) return [this.theme.fg("warning", "No findings match the active filters.")];
+		const empty = this.emptyBodyMessage(visible);
+		if (empty) return [this.theme.fg(empty.tone, empty.text)];
 		const entries = visible.slice(0, this.visibleRowCount());
 		return entries.flatMap((entry, index) => this.preferredIssueEntryLines(entry, index, entries));
 	}
@@ -372,6 +470,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private toggleMarked(): void {
+		if (this.isInformationalMode()) return;
 		const current = this.currentIssue();
 		if (!current) return;
 		if (this.marked.has(current.id)) this.marked.delete(current.id);
@@ -380,14 +479,18 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private toggleAllVisible(): void {
+		if (this.isInformationalMode()) return;
 		const visible = this.visibleIssues();
 		if (!visible.length) return;
-		const allMarked = visible.every((entry) => this.marked.has(entry.id));
-		for (const entry of visible) {
-			if (allMarked) this.marked.delete(entry.id);
-			else this.marked.add(entry.id);
-		}
+		this.setVisibleMarked(visible, !visible.every((entry) => this.marked.has(entry.id)));
 		this.changed();
+	}
+
+	private setVisibleMarked(visible: FlatIssue[], marked: boolean): void {
+		for (const entry of visible) {
+			if (marked) this.marked.add(entry.id);
+			else this.marked.delete(entry.id);
+		}
 	}
 
 	private clearMarked(): void {
@@ -433,7 +536,31 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private visibleIssues(): FlatIssue[] {
-		return this.issues.filter((entry) => this.matchesFilters(entry));
+		return this.availableIssues().filter((entry) => this.matchesFilters(entry));
+	}
+
+	private availableIssues(): FlatIssue[] {
+		return this.showInformational ? this.issues : this.findingIssues();
+	}
+
+	private isInformationalMode(): boolean {
+		return this.options.informationalMode === true;
+	}
+
+	private findingIssues(): FlatIssue[] {
+		return this.issues.filter((entry) => !isInformational(entry));
+	}
+
+	private informationalIssues(): FlatIssue[] {
+		return this.issues.filter(isInformational);
+	}
+
+	private informationalHeaderText(visible: FlatIssue[]): string | undefined {
+		const total = this.informationalIssues().length;
+		if (!total) return undefined;
+		if (!this.showInformational) return `${total} informational hidden`;
+		const visibleCount = visible.filter(isInformational).length;
+		return visibleCount === total ? `${total} informational` : `${visibleCount}/${total} informational`;
 	}
 
 	private matchesFilters(entry: FlatIssue): boolean {
@@ -458,7 +585,19 @@ export class FallowIssueNavigator implements Component, Focusable {
 		return current ? [current] : [];
 	}
 
+	private toggleInformational(): void {
+		if (this.isInformationalMode()) return;
+		this.showInformational = !this.showInformational;
+		this.sectionFilter = undefined;
+		this.severityFilter = undefined;
+		if (!this.showInformational) {
+			for (const entry of this.informationalIssues()) this.marked.delete(entry.id);
+		}
+		this.filtersChanged();
+	}
+
 	private togglePromptDetail(): void {
+		if (this.isInformationalMode()) return;
 		this.includeFullDetails = !this.includeFullDetails;
 		this.changed();
 	}
@@ -468,8 +607,13 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private finishWithPrompt(): void {
+		if (this.isInformationalMode()) return;
 		const issues = this.selection();
 		if (!issues.length) return;
+		this.preparePrompt(issues);
+	}
+
+	private preparePrompt(issues: FlatIssue[]): void {
 		if (!issues.some((entry) => entry.item.raw === undefined)) {
 			this.emitPrompt(issues);
 			return;
@@ -520,6 +664,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private finishWithTrace(): void {
+		if (this.isInformationalMode()) return;
 		const trace = this.currentTraceCandidate();
 		if (!trace) return;
 		this.onDone({ type: "trace", commandArgs: ["dead-code", "--trace-file", trace] });
@@ -559,16 +704,22 @@ export class FallowIssueNavigator implements Component, Focusable {
 
 	private helpLine(): string {
 		const key = (text: string) => pill(text, violet);
-		return [
+		const common = [
 			`${key("↑↓/jk")} ${this.theme.fg("muted", "navigate")}`,
-			`${key("enter")} ${this.theme.fg("muted", "expand")}`,
-			`${key("s")} ${this.theme.fg("muted", "select")}`,
-			`${key("A")} ${this.theme.fg("muted", "all visible")}`,
 			`${key("/")} ${this.theme.fg("muted", "search")}`,
 			`${key("f")} ${this.theme.fg("muted", "section")}`,
 			`${key("v")} ${this.theme.fg("muted", "severity")}`,
 			`${key("x")} ${this.theme.fg("muted", "reset filters")}`,
+		];
+		if (this.isInformationalMode()) return [...common, `${key("q")} ${this.theme.fg("muted", "close")}`].join("  ");
+		return [
+			common[0],
+			`${key("enter")} ${this.theme.fg("muted", "expand")}`,
+			`${key("s")} ${this.theme.fg("muted", "select")}`,
+			`${key("A")} ${this.theme.fg("muted", "all visible")}`,
+			...common.slice(1),
 			`${key("c")} ${this.theme.fg("muted", "clear selected")}`,
+			`${key("i")} ${this.theme.fg("muted", "informational files")}`,
 			`${key("d")} ${this.theme.fg("muted", "prompt detail")}`,
 			`${key("e/a")} ${this.theme.fg("muted", "load")}`,
 			`${key("t")} ${this.theme.fg("muted", "trace")}`,
@@ -593,6 +744,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private issueLineCheck(entry: FlatIssue): string {
+		if (this.isInformationalMode()) return this.theme.fg("dim", " ");
 		return this.marked.has(entry.id) ? this.theme.fg("success", "☑") : this.theme.fg("dim", "☐");
 	}
 
@@ -653,6 +805,10 @@ export class FallowIssueNavigator implements Component, Focusable {
 		this.cachedLines = lines;
 		return lines;
 	}
+}
+
+function isInformational(entry: FlatIssue): boolean {
+	return entry.section.role === "context";
 }
 
 function issueSeverity(entry: FlatIssue): string {

--- a/scripts/token-benchmark.mjs
+++ b/scripts/token-benchmark.mjs
@@ -190,7 +190,7 @@ function normalizeFullOutputPath(text, fullOutputPath) {
 }
 
 async function measurePrompts(scenario, overview, fullOutputPath, contract, promptDetail) {
-	const entries = overview.sections.flatMap((section) => section.items);
+	const entries = overview.sections.filter((section) => section.role !== "context").flatMap((section) => section.items);
 	if (!entries.length) return [];
 	const reportFindings = countEntryFindings(entries);
 	const pairs = await Promise.all((scenario.promptSelections ?? []).map((selection) =>

--- a/tests/navigator-mode.test.mjs
+++ b/tests/navigator-mode.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const {
+	isInformationalNavigatorCommand,
+	resolveFallowNavigatorVisibleRows,
+} = await jiti.import("../extensions/fallow/command/navigator.ts");
+
+describe("navigator command mode", () => {
+	it("distinguishes informational-only health and flags commands", () => {
+		assert.equal(isInformationalNavigatorCommand(["flags", "--format", "json"]), true);
+		assert.equal(isInformationalNavigatorCommand(["health", "--file-scores", "--score"]), true);
+		assert.equal(isInformationalNavigatorCommand(["health", "--hotspots", "--ownership"]), true);
+		assert.equal(isInformationalNavigatorCommand(["health"]), false);
+		assert.equal(isInformationalNavigatorCommand(["health", "--file-scores", "--targets"]), false);
+		assert.equal(isInformationalNavigatorCommand(["dead-code"]), false);
+	});
+
+	it("uses more terminal height for large result sets", () => {
+		assert.equal(resolveFallowNavigatorVisibleRows(Number.NaN, false), 20);
+		assert.equal(resolveFallowNavigatorVisibleRows(24, false), 4);
+		assert.equal(resolveFallowNavigatorVisibleRows(24, true), 12);
+		assert.equal(resolveFallowNavigatorVisibleRows(50, false), 20);
+		assert.equal(resolveFallowNavigatorVisibleRows(50, true), 20);
+	});
+});

--- a/tests/navigator.test.mjs
+++ b/tests/navigator.test.mjs
@@ -69,6 +69,22 @@ function createFilterOverview() {
 	};
 }
 
+function createContextOverview(includeFinding = true) {
+	return {
+		title: "Fallow health",
+		status: includeFinding ? "warning" : "success",
+		stats: [{ label: "score", value: "85 A" }],
+		notes: [],
+		sections: [
+			...(includeFinding ? [{ title: "Complexity findings", count: 1, role: "finding", items: [{ label: "complex function", path: "src/complex.ts", severity: "high" }] }] : []),
+			{ title: "Worst file scores", count: 2, role: "context", items: [
+				{ label: "score 95", path: "src/healthy.ts" },
+				{ label: "score 55", path: "src/risky.ts" },
+			] },
+		],
+	};
+}
+
 function loadEndFindingPrompt(overview, fullOutputPath, includeFullDetails) {
 	return new Promise((resolve) => {
 		const navigator = new FallowIssueNavigator(overview, theme, resolve, () => {}, { fullOutputPath });
@@ -240,6 +256,39 @@ describe("FallowIssueNavigator prompt generation", () => {
 		assert.match(navigator.render(80).join("\n"), /3 findings/);
 	});
 
+	it("hides informational files by default and never counts them as findings", () => {
+		const navigator = new FallowIssueNavigator(createContextOverview(), theme, () => {}, () => {});
+
+		const defaultView = navigator.render(100).join("\n");
+		assert.match(defaultView, /1 finding/);
+		assert.match(defaultView, /2 informational hidden/);
+		assert.match(defaultView, /Show informational files \(2\)/);
+		assert.match(defaultView, /File scores and hotspots are context, not findings/);
+		assert.doesNotMatch(defaultView, /src\/healthy\.ts/);
+
+		navigator.handleInput("i");
+		const informationVisible = navigator.render(100).join("\n");
+		assert.match(informationVisible, /2 informational/);
+		assert.match(informationVisible, /src\/healthy\.ts/);
+		assert.match(informationVisible, /not counted as findings/);
+	});
+
+	it("renders explicit informational commands without finding controls", () => {
+		let result = null;
+		const navigator = new FallowIssueNavigator(createContextOverview(false), theme, (value) => {
+			result = value;
+		}, () => {}, { informationalMode: true, visibleRows: 20 });
+
+		const rendered = navigator.render(100).join("\n");
+		assert.match(rendered, /2 informational/);
+		assert.match(rendered, /src\/healthy\.ts/);
+		assert.match(rendered, /Informational command output/);
+		assert.doesNotMatch(rendered, /0 findings/);
+		assert.doesNotMatch(rendered, /Include full finding JSON/);
+		navigator.handleInput("e");
+		assert.equal(result, null);
+	});
+
 	it("defaults the full-details checkbox to deselected and explains both modes", () => {
 		let result = null;
 		const navigator = new FallowIssueNavigator(createOverview(), theme, (value) => {
@@ -304,7 +353,7 @@ describe("FallowIssueNavigator prompt generation", () => {
 		const rendered = navigator.render(80).join("\n");
 		assert.match(rendered, /finding 3/);
 		assert.doesNotMatch(rendered, /finding 4/);
-		assert.match(rendered, /9 later findings/);
+		assert.match(rendered, /9 later items/);
 		assert.match(rendered, /Include full finding JSON/);
 	});
 

--- a/tests/overview.test.mjs
+++ b/tests/overview.test.mjs
@@ -86,6 +86,24 @@ describe("buildFallowOverview", () => {
 		});
 	});
 
+	it("classifies file scores and hotspots as informational context", () => {
+		const overview = buildFallowOverview({
+			kind: "health",
+			findings: [],
+			file_scores: [
+				{ path: "src/healthy.ts", maintainability_index: 95, lines: 20, dead_code_ratio: 0, crap_max: 1 },
+				{ path: "src/risky.ts", maintainability_index: 55, lines: 200, dead_code_ratio: 0.2, crap_max: 25 },
+			],
+			hotspots: [{ path: "src/busy.ts", score: 30, commits: 12, lines_added: 100, lines_deleted: 50 }],
+		});
+
+		assert.equal(overview.status, "success");
+		assert.deepEqual(overview.sections.map((section) => [section.title, section.role, section.items.length]), [
+			["Worst file scores", "context", 2],
+			["Hotspots", "context", 1],
+		]);
+	});
+
 	it("keeps every finding available to the navigator", () => {
 		const unusedExports = Array.from({ length: 40 }, (_, index) => ({
 			export_name: `unused_${index}`,


### PR DESCRIPTION
## Summary

Fixes the navigator regression where standalone Fallow health context was presented as actionable findings.

- classifies `health.findings` and qualified `targets` as findings
- classifies `file_scores` and `hotspots` as informational context
- classifies feature-flag inventory as informational context
- hides context in mixed/default health reports behind a default-off `i` checkbox
- reports separate counts such as `0 findings · 84 informational hidden`
- never lets context-only sections turn a successful health report into warning status
- excludes informational rows from select-all and generated agent prompts unless explicitly shown

Explicit informational commands such as `health --file-scores`, `health --hotspots`, and `flags` use an informational overlay mode:

- records are shown directly because the user requested them
- no finding count/selection checkbox/prompt-detail controls are shown
- the overlay explicitly says the records are context, not findings

## Larger overlays

Large reports can now use up to 90% of terminal height and display up to 20 virtualized rows. Informational-only overlays reserve fewer static rows, so a 24-row terminal can show 12 records instead of 4. Normal mixed/actionable overlays still reserve room for selection and prompt controls.

## Current-main behavior verified

Standalone `fallow health --format json --quiet` currently returns zero findings, 65 file scores, and 19 hotspots. This PR keeps the exact report but stops Pi Fallow from calling those 84 context records findings.

## Validation

- [x] 112 tests pass
- [x] mixed health reports hide context by default
- [x] explicit informational commands omit finding controls
- [x] context-only reports remain success status
- [x] selectable prompt rows exclude informational context
- [x] responsive height behavior is covered
- [x] all rendered lines remain width-bounded
- [x] coverage: 76.08% lines, 81.46% functions, 84.81% branches
- [x] Fallow health reports no findings
- [x] bundle and token benchmarks pass
