### PR TITLE
fix: validate explain arguments before execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Pi Fallow are documented here.
 - Saved complete JSON whenever navigator normalization omits raw fields; generated report artifacts are never automatically deleted by Pi Fallow.
 - Added a default-off full-details checkbox to the navigator: compact prompts preserve every selected finding's coding essentials, while full mode explicitly embeds complete raw JSON and displays its model-context implication.
 - Stopped counting health file scores and hotspots as findings; mixed reports hide informational records behind a default-off toggle, informational-only commands omit finding controls, and large result sets can use more terminal height.
+- Validated `/fallow explain` issue types before execution and removed contradictory “No issues found” and project-config context from execution-error rendering.
 
 ### Fixed
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Manual slash command examples:
 /fallow health --file-scores --targets --score
 /fallow inspect --file extensions/fallow/cli.ts
 /fallow inspect --symbol extensions/fallow/cli.ts:fallowCli
+/fallow explain unused-export
 /fallow trace extensions/fallow/cli.ts:fallowCli
 /fallow trace-file extensions/fallow/ui.ts
 /fallow trace-export extensions/fallow/ui.ts FallowIssueNavigator

--- a/extensions/fallow/command/args.ts
+++ b/extensions/fallow/command/args.ts
@@ -54,11 +54,19 @@ function hasFlag(args: string[], flag: string): boolean {
 
 function resolveFallbackArgs(rawArgs: string[]): string[] {
 	const normalized = [...rawArgs];
+	validateRequiredCommandArgs(normalized);
 	const command = normalized[0] ?? "";
 	const alias = commandAliasMap[command];
 	if (alias) return alias(normalized);
 	const translator = traceCommandMap[command];
 	return translator ? translator(normalized) : normalized;
+}
+
+function validateRequiredCommandArgs(args: string[]): void {
+	if (args[0] !== "explain") return;
+	if (args.some((arg) => arg === "--help" || arg === "-h")) return;
+	if (args.slice(1).some((arg) => !arg.startsWith("-"))) return;
+	throw new Error("explain requires at least one issue type, for example: /fallow explain unused-export");
 }
 
 const commandAliasMap: Record<string, (args: string[]) => string[]> = {

--- a/extensions/fallow/command/handler.ts
+++ b/extensions/fallow/command/handler.ts
@@ -35,10 +35,16 @@ async function normalizeFallowHandlerArgs(
 	commandState: FallowCommandState,
 	parsedArgs: string[],
 ): Promise<string[] | null> {
-	const baseRef = await resolveFallowCommandBaseRef(parsedArgs, ctx.cwd, commandState, detectFallowBaseRef);
-	return normalizeFallowArgs(parsedArgs, baseRef, commandState.lastArgs, (message, level) => {
-		if (ctx.hasUI) ctx.ui.notify(message, level);
-	});
+	try {
+		const baseRef = await resolveFallowCommandBaseRef(parsedArgs, ctx.cwd, commandState, detectFallowBaseRef);
+		return normalizeFallowArgs(parsedArgs, baseRef, commandState.lastArgs, (message, level) => {
+			if (ctx.hasUI) ctx.ui.notify(message, level);
+		});
+	} catch (error) {
+		if (!ctx.hasUI) throw error;
+		ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+		return null;
+	}
 }
 
 async function executeFallowCommandLoop(

--- a/extensions/fallow/overview.ts
+++ b/extensions/fallow/overview.ts
@@ -494,8 +494,17 @@ function appendFallbackNotes(
 	notes: string[],
 ): void {
 	if (sections.length) return;
+	appendRootMessage(root, notes);
+	if (shouldAddNoIssuesNote(root, stats)) notes.push("No issues found in the selected report sections.");
+}
+
+function appendRootMessage(root: Record<string, any>, notes: string[]): void {
 	if (root.message) notes.push(String(root.message));
-	if (stats.length <= 1) notes.push("No issues found in the selected report sections.");
+}
+
+function shouldAddNoIssuesNote(root: Record<string, any>, stats: Array<{ label: string; value: string | number }>): boolean {
+	if (root.error) return false;
+	return stats.length <= 1;
 }
 
 function addIfDefined(stats: Array<{ label: string; value: string | number }>, label: string, value: string | number | undefined): void {
@@ -525,6 +534,7 @@ export function buildFallowOverview(
 	addWorkspaceStats(root, stats, title, notes);
 	addSchemaStats(root, stats, title);
 	addDefaultNotes(root, sections, stats, notes);
+	applyErrorTitle(root, title);
 	addExitCodeNote(notes, exitCode);
 
 	return {
@@ -534,6 +544,10 @@ export function buildFallowOverview(
 		sections,
 		notes,
 	};
+}
+
+function applyErrorTitle(root: Record<string, any>, title: { value: string }): void {
+	if (root.error) title.value = "Fallow error";
 }
 
 function addOverviewSections(

--- a/extensions/fallow/tool-render.ts
+++ b/extensions/fallow/tool-render.ts
@@ -42,8 +42,7 @@ export function renderFallowToolResult(
 			command: commandDisplay(details.command, details.args),
 			fullOutputPath: details.fullOutputPath,
 			truncated: details.truncated,
-			projectState: details.projectState,
-			prSummary: details.prSummary,
+			...visibleOverviewContext(details),
 		});
 	}
 	return new Text(buildFallowCompactMessage(details, expanded, theme), 0, 0);
@@ -158,8 +157,7 @@ function renderFallowOverviewResultMessage(
 		command: resolveOverviewCommand(details),
 		fullOutputPath: details.fullOutputPath,
 		truncated: details.truncated,
-		projectState: details.projectState,
-		prSummary: details.prSummary,
+		...visibleOverviewContext(details),
 	});
 }
 
@@ -168,8 +166,17 @@ function resolveOverviewCommand(details: MessageRendererDetails | undefined): st
 	return commandDisplay(details.command, details.args);
 }
 
+function visibleOverviewContext(details: Pick<MessageRendererDetails, "exitCode" | "projectState" | "prSummary">): {
+	projectState?: FallowProjectState;
+	prSummary?: FallowPrSummary;
+} {
+	if ((details.exitCode ?? 0) >= 2) return {};
+	return { projectState: details.projectState, prSummary: details.prSummary };
+}
+
 type MessageRendererDetails = {
 	command?: string;
+	exitCode?: number;
 	args?: string[];
 	overview?: FallowOverview;
 	compact?: boolean;

--- a/tests/command-args.test.mjs
+++ b/tests/command-args.test.mjs
@@ -47,6 +47,12 @@ describe("normalizeFallowArgs", () => {
 		assert.throws(() => normalize(["check-changed"]), /requires --changed-since or --base/);
 	});
 
+	it("validates explain before launching Fallow", () => {
+		assert.throws(() => normalize(["explain"]), /explain requires at least one issue type/);
+		assert.deepEqual(normalize(["explain", "unused-export"]).result, ["explain", "unused-export"]);
+		assert.deepEqual(normalize(["explain", "--help"]).result, ["explain", "--help"]);
+	});
+
 	it("maps trace aliases", () => {
 		assert.deepEqual(normalize(["trace-file", "extensions/fallow/cli.ts"]).result, [
 			"dead-code", "--trace-file", "extensions/fallow/cli.ts",

--- a/tests/output.test.mjs
+++ b/tests/output.test.mjs
@@ -159,6 +159,16 @@ describe("formatToolOutput", () => {
 		}
 	});
 
+	it("formats structured CLI argument errors without claiming there are no issues", async () => {
+		const report = { error: true, message: "missing required issue type", exit_code: 2 };
+		const result = await formatToolOutput(parseJson(JSON.stringify(report), ""), process.cwd(), 2);
+
+		assert.equal(result.overview.title, "Fallow error");
+		assert.deepEqual(result.overview.notes, ["missing required issue type"]);
+		assert.match(result.summary, /error: missing required issue type/);
+		assert.doesNotMatch(result.text, /No issues found/);
+	});
+
 	it("uses raw output when no structured JSON is available", async () => {
 		const result = await formatToolOutput({ parsed: false, raw: "plain fallow output" }, process.cwd(), 1);
 

--- a/tests/overview.test.mjs
+++ b/tests/overview.test.mjs
@@ -119,6 +119,15 @@ describe("buildFallowOverview", () => {
 		assert.equal(overview.sections[0].items[39].raw, undefined);
 	});
 
+	it("renders execution errors without a contradictory no-issues note", () => {
+		const overview = buildFallowOverview({ error: true, message: "missing required issue type", exit_code: 2 }, 2);
+
+		assert.equal(overview.title, "Fallow error");
+		assert.equal(overview.status, "error");
+		assert.deepEqual(overview.sections, []);
+		assert.deepEqual(overview.notes, ["missing required issue type"]);
+	});
+
 	it("summarizes workspace, schema, and config outputs", () => {
 		const workspace = buildFallowOverview({ kind: "list-workspaces", workspace_count: 0, workspaces: [], workspace_diagnostics: [] });
 		assert.equal(workspace.title, "Fallow workspaces");

--- a/tests/tool-render.test.mjs
+++ b/tests/tool-render.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const {
+	renderFallowMessageRenderer,
+	renderFallowToolResult,
+} = await jiti.import("../extensions/fallow/tool-render.ts");
+
+const theme = {
+	fg: (_color, text) => text,
+	bg: (_color, text) => text,
+	bold: (text) => text,
+};
+const overview = {
+	title: "Fallow error",
+	status: "error",
+	stats: [],
+	sections: [],
+	notes: ["missing required issue type"],
+};
+const details = {
+	command: "fallow",
+	args: ["explain", "--format", "json", "--quiet"],
+	cwd: process.cwd(),
+	exitCode: 2,
+	elapsedMs: 1,
+	parsed: true,
+	summary: "error: missing required issue type",
+	overview,
+	projectState: { configPath: ".fallowrc.json", configSource: "file", cacheEnabled: true, cacheFiles: [] },
+};
+
+describe("Fallow execution-error rendering", () => {
+	it("hides unrelated project configuration from tool errors", () => {
+		const rendered = renderFallowToolResult({ details }, { expanded: true }, theme).render(100).join("\n");
+
+		assert.match(rendered, /Fallow error/);
+		assert.match(rendered, /missing required issue type/);
+		assert.doesNotMatch(rendered, /Config:/);
+		assert.doesNotMatch(rendered, /No issues found/);
+	});
+
+	it("hides unrelated project configuration from slash-command errors", () => {
+		const rendered = renderFallowMessageRenderer({ details, content: "error" }, { expanded: true }, theme).render(100).join("\n");
+
+		assert.match(rendered, /Fallow error/);
+		assert.match(rendered, /missing required issue type/);
+		assert.doesNotMatch(rendered, /Config:/);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the malformed `/fallow explain` experience shown in the issue report.

Before:

```text
fallow explain --format json --quiet
error: required <ISSUE_TYPE>...
No issues found in the selected report sections.
Config: .fallowrc.json
```

After:

- `/fallow explain` is rejected before starting a subprocess
- TUI/RPC users receive: `explain requires at least one issue type, for example: /fallow explain unused-export`
- `/fallow explain --help` remains valid
- `/fallow explain unused-export` executes normally
- non-UI modes retain execution-error propagation

The generic structured-error path is also corrected:

- error reports are titled `Fallow error`
- errors no longer append the contradictory “No issues found” note
- unrelated project config and PR metadata are hidden for exit code 2+
- complete Fallow error text remains visible

## Validation

- [x] required explain positional validation covered
- [x] valid explain and help forms covered
- [x] structured exit-code-2 formatting covered
- [x] tool and slash-command error rendering covered
- [x] project config is absent from execution errors
- [x] 117 tests pass
- [x] coverage: 79.69% lines, 79.90% functions, 84.25% branches
- [x] Fallow health reports no findings
- [x] bundle checks pass
