### PR TITLE
fix: expand and center Fallow overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Pi Fallow are documented here.
 - Saved complete JSON whenever navigator normalization omits raw fields; generated report artifacts are never automatically deleted by Pi Fallow.
 - Added a default-off full-details checkbox to the navigator: compact prompts preserve every selected finding's coding essentials, while full mode explicitly embeds complete raw JSON and displays its model-context implication.
 - Stopped counting health file scores and hotspots as findings; mixed reports hide informational records behind a default-off toggle, informational-only commands omit finding controls, and large result sets can use more terminal height.
+- Centered the Fallow overlay at 90% terminal width, allowed up to 95% terminal height, and expanded large virtualized result sets to 30 visible rows.
 - Validated `/fallow explain` issue types before execution and removed contradictory “No issues found” and project-config context from execution-error rendering.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ In the interactive navigator:
 
 The navigator defaults to compact prompts. Compact mode includes every selected finding with type, severity, location, subject, concise evidence/details, and suggested action, plus the complete-report path. Selecting the full-details checkbox additionally embeds complete raw JSON for every selected finding; the overlay warns that this can use substantially more model context.
 
-Plain `fallow health` can return actionable findings alongside informational per-file scores and hotspots. Pi Fallow hides those informational records by default and reports their count separately. Explicit informational commands such as `health --file-scores` and `flags` show their records directly without finding-selection or agent-prompt controls. Large result sets use more of the available terminal height while retaining a virtualized viewport.
+Plain `fallow health` can return actionable findings alongside informational per-file scores and hotspots. Pi Fallow hides those informational records by default and reports their count separately. Explicit informational commands such as `health --file-scores` and `flags` show their records directly without finding-selection or agent-prompt controls. The overlay stays centered at 90% terminal width, can use up to 95% of terminal height, and expands large virtualized result sets to as many as 30 visible rows.
 
 ## Requirements
 

--- a/extensions/fallow/command/navigator.ts
+++ b/extensions/fallow/command/navigator.ts
@@ -1,14 +1,21 @@
 const NAVIGATOR_STATIC_ROWS = 17;
 const INFORMATIONAL_STATIC_ROWS = 9;
 const MIN_VISIBLE_ROWS = 3;
-const MAX_VISIBLE_ROWS = 20;
+const MAX_VISIBLE_ROWS = 30;
+
+export const FALLOW_NAVIGATOR_OVERLAY_OPTIONS = {
+	width: "90%",
+	minWidth: 50,
+	maxHeight: "95%",
+	anchor: "center",
+} as const;
 
 const INFORMATIONAL_HEALTH_FLAGS = ["--file-scores", "--hotspots", "--ownership"];
 const ACTIONABLE_HEALTH_FLAGS = ["--complexity", "--targets", "--coverage-gaps", "--css"];
 
 export function resolveFallowNavigatorVisibleRows(terminalRows: number, informationalMode: boolean): number {
 	if (!Number.isFinite(terminalRows) || terminalRows < 1) return MAX_VISIBLE_ROWS;
-	const overlayRows = Math.floor(terminalRows * 0.9);
+	const overlayRows = Math.floor(terminalRows * 0.95);
 	const staticRows = informationalMode ? INFORMATIONAL_STATIC_ROWS : NAVIGATOR_STATIC_ROWS;
 	return Math.max(MIN_VISIBLE_ROWS, Math.min(MAX_VISIBLE_ROWS, overlayRows - staticRows));
 }

--- a/extensions/fallow/command/result-flow.ts
+++ b/extensions/fallow/command/result-flow.ts
@@ -6,13 +6,9 @@ import type { FallowNavigatorResult, FallowPrSummary, FallowProjectState } from 
 import { FallowIssueNavigator } from "../ui";
 import { buildFallowExecutor, buildFallowFinalArgs, runFallowWithLoaderIfUi, type FallowCommandExecutor, type FallowCommandResult } from "./loader";
 import { hasFallowNavigator, isFallowTuiMode } from "./mode";
-import { isInformationalNavigatorCommand, resolveFallowNavigatorVisibleRows } from "./navigator";
+import { FALLOW_NAVIGATOR_OVERLAY_OPTIONS, isInformationalNavigatorCommand, resolveFallowNavigatorVisibleRows } from "./navigator";
 import { buildFallowTranscriptContent } from "./transcript";
 import type { FallowCommandContext } from "./types";
-
-const FALLOW_NAVIGATOR_MAX_WIDTH_RATIO = 0.9;
-const FALLBACK_FALLOW_NAVIGATOR_MAX_WIDTH = 100;
-const FALLOW_NAVIGATOR_MIN_WIDTH = 50;
 
 export async function executeFallowResult(
 	pi: ExtensionAPI,
@@ -97,10 +93,9 @@ function openFallowNavigator(
 ): Promise<FallowNavigatorResult | null> {
 	const { formatted } = result;
 	if (!isFallowTuiMode(ctx.mode) || !formatted.overview) return Promise.resolve(null);
-	let navigator: FallowIssueNavigator | undefined;
 	const informationalMode = isInformationalNavigatorCommand(executedArgs);
 	return ctx.ui.custom<FallowNavigatorResult | null>((tui, theme, _keybindings, done) => {
-		navigator = new FallowIssueNavigator(
+		return new FallowIssueNavigator(
 			formatted.overview!,
 			theme,
 			done,
@@ -118,23 +113,6 @@ function openFallowNavigator(
 		return navigator;
 	}, {
 		overlay: true,
-		overlayOptions: () => ({
-			width: resolveFallowNavigatorOverlayWidth(navigator),
-			minWidth: FALLOW_NAVIGATOR_MIN_WIDTH,
-			maxHeight: "90%",
-			anchor: "top-center",
-			row: "5%",
-		}),
+		overlayOptions: FALLOW_NAVIGATOR_OVERLAY_OPTIONS,
 	});
-}
-
-function resolveFallowNavigatorOverlayWidth(navigator: FallowIssueNavigator | undefined): number {
-	const maxWidth = resolveFallowNavigatorMaxWidth();
-	return navigator?.preferredWidth(maxWidth) ?? maxWidth;
-}
-
-function resolveFallowNavigatorMaxWidth(): number {
-	const terminalWidth = process.stdout.columns;
-	if (!terminalWidth || terminalWidth < 1) return FALLBACK_FALLOW_NAVIGATOR_MAX_WIDTH;
-	return Math.max(1, Math.floor(terminalWidth * FALLOW_NAVIGATOR_MAX_WIDTH_RATIO));
 }

--- a/extensions/fallow/ui/navigator.ts
+++ b/extensions/fallow/ui/navigator.ts
@@ -7,11 +7,9 @@ import { renderFallowPrSummary } from "../pr-summary/render";
 import type { FallowIssueLine, FallowNavigatorResult, FallowOverview, FallowOverviewSection, FallowPrSummary, FallowProjectState } from "../types";
 import { amber, cyan, getOverviewStatusColor, pill, pink, purple, violet } from "./shared";
 
-const MIN_NAVIGATOR_WIDTH = 50;
 const FRAME_BORDER_WIDTH = 4;
 const HEADER_BORDER_WIDTH = 2;
 const VISIBLE_ISSUE_ROWS = 10;
-const PREFERRED_NAVIGATOR_MAX_WIDTH = 140;
 const SEVERITY_ORDER = ["critical", "high", "error", "medium", "warning", "low", "info", "unspecified"];
 
 function buildHeaderTitle(
@@ -97,12 +95,6 @@ export class FallowIssueNavigator implements Component, Focusable {
 		this.issues = overview.sections
 			.flatMap((section, sectionIndex) => section.items.map((item, itemIndex) => ({ section, item, sectionIndex, itemIndex })))
 			.map((entry, id) => ({ ...entry, id }));
-	}
-
-	preferredWidth(maxWidth: number): number {
-		const boundedMax = normalizeMaxWidth(maxWidth);
-		const measuredWidth = Math.max(MIN_NAVIGATOR_WIDTH, this.measurePreferredWidth());
-		return Math.min(measuredWidth, boundedMax, PREFERRED_NAVIGATOR_MAX_WIDTH);
 	}
 
 	handleInput(data: string): void {
@@ -399,57 +391,6 @@ export class FallowIssueNavigator implements Component, Focusable {
 			this.options.fullOutputPath ? `${cyan("Full JSON")} ${this.theme.fg("dim", this.options.fullOutputPath)}` : undefined,
 			this.options.command ? `${violet("Command")} ${this.theme.fg("muted", this.options.command)}` : undefined,
 		].filter(Boolean) as string[];
-	}
-
-	private measurePreferredWidth(): number {
-		const visible = this.visibleIssues();
-		const headerTitle = buildHeaderTitle(
-			visible.filter((entry) => !isInformational(entry)).length,
-			this.findingIssues().length,
-			this.informationalHeaderText(visible),
-			this.isInformationalMode(),
-			this.overview.title,
-			this.overview.status,
-			this.theme,
-		);
-		const frameCandidates = [
-			...this.preferredHeaderLines(),
-			...this.preferredIssueLines(visible),
-			...this.preferredFooterControlLines(),
-			...this.summaryBlockLines(),
-			...this.footerMetaLines(),
-		];
-		const contentWidth = Math.max(0, ...frameCandidates.map((line) => visibleWidth(line)));
-		return Math.max(visibleWidth(headerTitle) + HEADER_BORDER_WIDTH, contentWidth + FRAME_BORDER_WIDTH);
-	}
-
-	private preferredFooterControlLines(): string[] {
-		if (this.isInformationalMode()) return [this.informationalImplicationLine()];
-		return [
-			this.footerSelectionLine(),
-			...(this.informationalIssues().length ? [this.informationalToggleLine(), this.informationalImplicationLine()] : []),
-			this.promptDetailLine(),
-			this.promptImplicationLine(),
-		];
-	}
-
-	private preferredHeaderLines(): string[] {
-		return [this.statLine(), this.hasActiveFilters() ? this.filterLine() : undefined, this.helpLine()].filter(Boolean) as string[];
-	}
-
-	private preferredIssueLines(visible: FlatIssue[]): string[] {
-		const empty = this.emptyBodyMessage(visible);
-		if (empty) return [this.theme.fg(empty.tone, empty.text)];
-		const entries = visible.slice(0, this.visibleRowCount());
-		return entries.flatMap((entry, index) => this.preferredIssueEntryLines(entry, index, entries));
-	}
-
-	private preferredIssueEntryLines(entry: FlatIssue, index: number, entries: FlatIssue[]): string[] {
-		return [
-			...(entries[index - 1]?.sectionIndex === entry.sectionIndex ? [] : [this.sectionHeaderLine(entry)]),
-			this.issueLineRaw(entry, index),
-			...(entry.item.action ? [this.detailActionLine(entry.item)] : []),
-		];
 	}
 
 	private visibleRowCount(): number {
@@ -856,7 +797,3 @@ function pickPathFromText(text: string, pattern: RegExp): string | null {
 	return match?.[1] ?? null;
 }
 
-function normalizeMaxWidth(maxWidth: number): number {
-	if (!Number.isFinite(maxWidth)) return Number.POSITIVE_INFINITY;
-	return Math.max(1, Math.floor(maxWidth));
-}

--- a/tests/navigator-mode.test.mjs
+++ b/tests/navigator-mode.test.mjs
@@ -4,6 +4,7 @@ import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
 const {
+	FALLOW_NAVIGATOR_OVERLAY_OPTIONS,
 	isInformationalNavigatorCommand,
 	resolveFallowNavigatorVisibleRows,
 } = await jiti.import("../extensions/fallow/command/navigator.ts");
@@ -19,10 +20,19 @@ describe("navigator command mode", () => {
 	});
 
 	it("uses more terminal height for large result sets", () => {
-		assert.equal(resolveFallowNavigatorVisibleRows(Number.NaN, false), 20);
-		assert.equal(resolveFallowNavigatorVisibleRows(24, false), 4);
-		assert.equal(resolveFallowNavigatorVisibleRows(24, true), 12);
-		assert.equal(resolveFallowNavigatorVisibleRows(50, false), 20);
-		assert.equal(resolveFallowNavigatorVisibleRows(50, true), 20);
+		assert.equal(resolveFallowNavigatorVisibleRows(Number.NaN, false), 30);
+		assert.equal(resolveFallowNavigatorVisibleRows(24, false), 5);
+		assert.equal(resolveFallowNavigatorVisibleRows(24, true), 13);
+		assert.equal(resolveFallowNavigatorVisibleRows(50, false), 30);
+		assert.equal(resolveFallowNavigatorVisibleRows(50, true), 30);
+	});
+
+	it("keeps the overlay centered and uses nearly the full terminal", () => {
+		assert.deepEqual(FALLOW_NAVIGATOR_OVERLAY_OPTIONS, {
+			width: "90%",
+			minWidth: 50,
+			maxHeight: "95%",
+			anchor: "center",
+		});
 	});
 });

--- a/tests/navigator.test.mjs
+++ b/tests/navigator.test.mjs
@@ -357,13 +357,6 @@ describe("FallowIssueNavigator prompt generation", () => {
 		assert.match(rendered, /Include full finding JSON/);
 	});
 
-	it("chooses a fluid overlay width capped by the available maximum", () => {
-		const navigator = new FallowIssueNavigator(createOverview(), theme, () => {}, () => {});
-
-		assert.equal(navigator.preferredWidth(60), 60);
-		assert.ok(navigator.preferredWidth(200) < 200);
-	});
-
 	it("renders within the width provided by the overlay", () => {
 		const navigator = new FallowIssueNavigator(createOverview(), theme, () => {}, () => {});
 		const width = 60;


### PR DESCRIPTION
## Summary

- keeps the Fallow overlay centered
- uses exactly 90% terminal width with a 50-column minimum
- allows up to 95% terminal height
- increases the virtualized viewport from 20 to 30 rows for large reports
- reserves fewer static rows for informational-only commands
- removes the old 5%/top-center positioning override

## Validation

- [x] overlay geometry is covered
- [x] responsive 24-row and 50-row terminal behavior is covered
- [x] 118 tests pass
- [x] coverage: 80.02% lines, 79.90% functions, 84.23% branches
- [x] bundle and Fallow health checks pass