### PR TITLE
feat: add configurable default Fallow command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Pi Fallow are documented here.
 - Added a default-off full-details checkbox to the navigator: compact prompts preserve every selected finding's coding essentials, while full mode explicitly embeds complete raw JSON and displays its model-context implication.
 - Stopped counting health file scores and hotspots as findings; mixed reports hide informational records behind a default-off toggle, informational-only commands omit finding controls, and large result sets can use more terminal height.
 - Centered the Fallow overlay at 90% terminal width, allowed up to 95% terminal height, and expanded large virtualized result sets to 30 visible rows.
+- Made `/fallow` and `/fallow run` default to health, configurable through the shell-free `PI_FALLOW_DEFAULT_COMMAND`; explicit commands remain unchanged.
 - Validated `/fallow explain` issue types before execution and removed contradictory “No issues found” and project-config context from execution-error rendering.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 ## Highlights
 
 - **Compact agent tool:** `fallow_run` uses a small command-plus-args contract while preserving internal validation and older-session compatibility.
-- **Slash command:** `/fallow ...` runs the Fallow CLI from inside Pi.
+- **Slash command:** `/fallow ...` runs the Fallow CLI from inside Pi; `/fallow` and `/fallow run` use a configurable default command.
 - **PR shortcut:** `/fallow pr` maps to `audit --base <detected-base> --gate new-only`.
 - **Rerun shortcut:** `/fallow rerun` repeats the last `/fallow` command.
 - **Non-blocking autocomplete:** subcommands, flags, enum values, static refs, and asynchronously discovered project branch refs are suggested without running Git while you type.
@@ -69,6 +69,9 @@ Ask Pi things like:
 Manual slash command examples:
 
 ```text
+/fallow
+/fallow run
+/fallow run --score
 /fallow pr
 /fallow rerun
 /fallow about
@@ -89,6 +92,14 @@ Manual slash command examples:
 /fallow schema
 /fallow coverage analyze
 ```
+
+`/fallow` and `/fallow run` execute `health` by default. Set `PI_FALLOW_DEFAULT_COMMAND` to a shell-free Fallow command string to change it, for example:
+
+```bash
+export PI_FALLOW_DEFAULT_COMMAND='health --complexity --targets --score'
+```
+
+Arguments after `/fallow run` are appended to the configured default. Explicit commands such as `/fallow dupes` are never replaced. Recursive/extension-only defaults such as `run`, `rerun`, or `about` are rejected.
 
 `/fallow check-changed` is a Pi Fallow convenience alias for Fallow's combined root analysis with `--changed-since`.
 

--- a/extensions/fallow/autocomplete.ts
+++ b/extensions/fallow/autocomplete.ts
@@ -18,6 +18,7 @@ type FlagSpec = {
 
 const COMMANDS: CompletionSpec[] = [
 	{ value: "pr", label: "pr", description: "Run audit with detected PR base (new-only)" },
+	{ value: "run", label: "run", description: "Run the configured default command (health unless overridden)" },
 	{ value: "rerun", label: "rerun", description: "Rerun the last /fallow command" },
 	{ value: "about", label: "about", description: "Show Pi Fallow version, update, and project links" },
 	{ value: "all", description: "Run full repository checks and checks summary" },
@@ -310,7 +311,20 @@ function commandKey(tokens: string[]): string | undefined {
 }
 
 function normalizeRootCommand(command: string): string {
-	return command === "pr" ? "audit" : command;
+	if (command === "pr") return "audit";
+	if (command === "run") return configuredDefaultCommandKey();
+	return command;
+}
+
+function configuredDefaultCommandKey(): string {
+	const configured = process.env.PI_FALLOW_DEFAULT_COMMAND;
+	const tokens = configured ? configured.trim().split(/\s+/).filter(Boolean) : [];
+	return defaultCommandKeyFromTokens(tokens);
+}
+
+function defaultCommandKeyFromTokens(tokens: string[]): string {
+	if (isCoverageAnalyze(tokens[0] ?? "", tokens[1])) return "coverage analyze";
+	return tokens[0] ?? "health";
 }
 
 function isCoverageAnalyze(first: string, second: string | undefined): boolean {

--- a/extensions/fallow/command/args.ts
+++ b/extensions/fallow/command/args.ts
@@ -1,5 +1,33 @@
 type Notify = (message: string, level: "info" | "warning") => void;
 
+const FALLBACK_DEFAULT_COMMAND = ["health"];
+const INVALID_DEFAULT_COMMANDS = new Set(["run", "rerun", "about", "version", "update"]);
+
+export function resolveFallowRunArgs(rawArgs: string[], configuredDefaultArgs: string[]): string[] {
+	if (isExplicitFallowCommand(rawArgs)) return rawArgs;
+	const defaultArgs = resolveDefaultArgs(configuredDefaultArgs);
+	validateDefaultCommand(defaultArgs);
+	return [...defaultArgs, ...runOverrides(rawArgs)];
+}
+
+function isExplicitFallowCommand(args: string[]): boolean {
+	return args.length > 0 && args[0] !== "run";
+}
+
+function resolveDefaultArgs(configured: string[]): string[] {
+	return configured.length ? configured : FALLBACK_DEFAULT_COMMAND;
+}
+
+function runOverrides(args: string[]): string[] {
+	return args[0] === "run" ? args.slice(1) : [];
+}
+
+function validateDefaultCommand(args: string[]): void {
+	if (!args[0] || INVALID_DEFAULT_COMMANDS.has(args[0])) {
+		throw new Error("PI_FALLOW_DEFAULT_COMMAND must start with an executable Fallow command such as health or dead-code.");
+	}
+}
+
 export function needsFallowBaseDetection(rawArgs: string[]): boolean {
 	if (rawArgs[0] !== "pr") return false;
 	const prArgs = rawArgs.slice(1);

--- a/extensions/fallow/command/handler.ts
+++ b/extensions/fallow/command/handler.ts
@@ -3,7 +3,7 @@ import { fallowCli } from "../cli";
 import { detectFallowBaseRef } from "../project/git";
 import type { FallowNavigatorResult } from "../types";
 import { sendFallowAboutMessage } from "../update-notice";
-import { normalizeFallowArgs } from "./args";
+import { normalizeFallowArgs, resolveFallowRunArgs } from "./args";
 import { resolveFallowCommandBaseRef } from "./base";
 import { isFallowTuiMode } from "./mode";
 import { executeFallowResult } from "./result-flow";
@@ -15,7 +15,8 @@ export async function runFallowCommandHandler(
 	commandState: FallowCommandState,
 	rawArgs: string,
 ): Promise<void> {
-	const parsedArgs = rawArgs.trim() ? fallowCli.splitArgs(rawArgs) : [];
+	const parsedArgs = parseFallowHandlerArgs(ctx, rawArgs);
+	if (!parsedArgs) return;
 	if (isFallowAboutCommand(parsedArgs)) {
 		await sendFallowAboutMessage(pi, ctx);
 		return;
@@ -24,6 +25,20 @@ export async function runFallowCommandHandler(
 	if (!args) return;
 	const result = await executeFallowCommandLoop(pi, ctx, commandState, args);
 	applyFallowPrompt(ctx, result);
+}
+
+function parseFallowHandlerArgs(ctx: FallowCommandContext, rawArgs: string): string[] | null {
+	try {
+		const explicitArgs = splitOptionalFallowArgs(rawArgs);
+		const configuredArgs = splitOptionalFallowArgs(process.env.PI_FALLOW_DEFAULT_COMMAND ?? "");
+		return resolveFallowRunArgs(explicitArgs, configuredArgs);
+	} catch (error) {
+		return reportFallowInputError(ctx, error);
+	}
+}
+
+function splitOptionalFallowArgs(value: string): string[] {
+	return value.trim() ? fallowCli.splitArgs(value) : [];
 }
 
 function isFallowAboutCommand(args: string[]): boolean {
@@ -41,10 +56,14 @@ async function normalizeFallowHandlerArgs(
 			if (ctx.hasUI) ctx.ui.notify(message, level);
 		});
 	} catch (error) {
-		if (!ctx.hasUI) throw error;
-		ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
-		return null;
+		return reportFallowInputError(ctx, error);
 	}
+}
+
+function reportFallowInputError(ctx: FallowCommandContext, error: unknown): null {
+	if (!ctx.hasUI) throw error;
+	ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+	return null;
 }
 
 async function executeFallowCommandLoop(

--- a/tests/autocomplete.test.mjs
+++ b/tests/autocomplete.test.mjs
@@ -38,12 +38,26 @@ function git(cwd, args) {
 describe("Fallow autocomplete", () => {
 	it("returns command, flag, and fixed-value completions", () => {
 		assert.ok(labels(fallowCompletions.getFallowRootCommandCompletions()).includes("health"));
+		assert.ok(labels(fallowCompletions.getFallowRootCommandCompletions()).includes("run"));
 		assert.ok(completionLabels("").includes("audit PR (main)"));
 		assert.ok(completionLabels("health --").includes("--group-by"));
+		assert.ok(completionLabels("run --").includes("--file-scores"));
 		assert.deepEqual(completionLabels("health --group-by o"), ["owner"]);
 		assert.ok(completionLabels("health --group-by=o").includes("--group-by=owner"));
 		assert.deepEqual(completionLabels("coverage "), ["analyze"]);
 		assert.equal(fallowCompletions.getFallowArgumentCompletions("rerun "), null);
+	});
+
+	it("uses the configured default command for run flag completion", () => {
+		const previous = process.env.PI_FALLOW_DEFAULT_COMMAND;
+		try {
+			process.env.PI_FALLOW_DEFAULT_COMMAND = "dead-code --production";
+			assert.ok(completionLabels("run --").includes("--include-entry-exports"));
+			assert.equal(completionLabels("run --").includes("--file-scores"), false);
+		} finally {
+			if (previous === undefined) delete process.env.PI_FALLOW_DEFAULT_COMMAND;
+			else process.env.PI_FALLOW_DEFAULT_COMMAND = previous;
+		}
 	});
 
 	it("returns static refs immediately while asynchronously loading project refs", async () => {

--- a/tests/command-args.test.mjs
+++ b/tests/command-args.test.mjs
@@ -3,7 +3,7 @@ import { describe, it } from "node:test";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
-const { normalizeFallowArgs } = await jiti.import("../extensions/fallow/command/args.ts");
+const { normalizeFallowArgs, resolveFallowRunArgs } = await jiti.import("../extensions/fallow/command/args.ts");
 
 function normalize(rawArgs, options = {}) {
 	const notifications = [];
@@ -15,6 +15,26 @@ function normalize(rawArgs, options = {}) {
 	);
 	return { result, notifications };
 }
+
+describe("resolveFallowRunArgs", () => {
+	it("defaults empty and run commands to health", () => {
+		assert.deepEqual(resolveFallowRunArgs([], []), ["health"]);
+		assert.deepEqual(resolveFallowRunArgs(["run"], []), ["health"]);
+		assert.deepEqual(resolveFallowRunArgs(["run", "--score"], []), ["health", "--score"]);
+	});
+
+	it("uses configured shell-free command tokens without changing explicit commands", () => {
+		assert.deepEqual(resolveFallowRunArgs(["run"], ["health", "--complexity", "--targets"]), ["health", "--complexity", "--targets"]);
+		assert.deepEqual(resolveFallowRunArgs(["run", "--score"], ["dead-code", "--production"]), ["dead-code", "--production", "--score"]);
+		assert.deepEqual(resolveFallowRunArgs(["dupes"], ["health"]), ["dupes"]);
+	});
+
+	it("rejects recursive or extension-only defaults", () => {
+		for (const command of ["run", "rerun", "about", "version", "update"]) {
+			assert.throws(() => resolveFallowRunArgs([], [command]), /PI_FALLOW_DEFAULT_COMMAND must start/);
+		}
+	});
+});
 
 describe("normalizeFallowArgs", () => {
 	it("adds PR audit defaults", () => {


### PR DESCRIPTION
## Summary

- makes bare `/fallow` execute `health` by default
- adds `/fallow run` as an explicit way to execute the default command
- supports configuring the default through the shell-free `PI_FALLOW_DEFAULT_COMMAND` environment variable
- appends arguments after `/fallow run` to the configured default
- leaves explicit commands such as `/fallow dupes` unchanged
- adapts `run` flag autocomplete to the configured command
- documents the behavior and configuration

## Examples

```text
/fallow                  # health
/fallow run              # health
/fallow run --score      # health --score
/fallow dupes            # explicit command remains dupes
```

```bash
export PI_FALLOW_DEFAULT_COMMAND='health --complexity --targets --score'
```

With that setting, `/fallow` and `/fallow run` execute the configured health command. Arguments supplied after `run` are appended.

## Safety and compatibility

- parses configuration with the existing shell-style argument parser but executes it as an argument array without a shell
- rejects recursive or extension-only defaults: `run`, `rerun`, `about`, `version`, and `update`
- reports configuration errors through the UI while preserving throws in non-UI modes
- preserves existing aliases, base detection, rerun state, and exit semantics after default resolution

## Validation

- [x] 121 tests pass
- [x] bare and explicit `run` default behavior covered
- [x] configured defaults, appended overrides, invalid defaults, and explicit-command preservation covered
- [x] configured autocomplete covered
- [x] coverage: 80.15% lines/statements, 79.75% functions, 84.63% branches
- [x] bundle check passes
- [x] Fallow health reports 0 findings with score 85.4 (A)