### PR TITLE
fix: use Pi package update command in notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Pi Fallow are documented here.
 - Validated `/fallow explain` issue types before execution and removed contradictory “No issues found” and project-config context from execution-error rendering.
 
 ### Fixed
+- Corrected update notices to recommend `pi update npm:pi-fallow` and display outdated installations as warnings.
 - Propagated the tool abort signal through Fallow execution and made cancellation terminate wrapper process trees, including force-killing commands that ignore graceful termination.
 - Made `/fallow` execute directly in RPC, JSON, and print modes while reserving loaders and navigator overlays for TUI mode and retaining full non-TUI transcript output.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Arguments after `/fallow run` are appended to the configured default. Explicit c
 
 The agent-facing `fallow_run` tool passes command-specific flags as separate `args` tokens. For example, a PR audit uses `{ "command": "audit", "args": ["--base", "main", "--gate", "new-only"] }`. Manual `/fallow` command syntax is unchanged.
 
-`/fallow about` shows the installed Pi Fallow version, latest npm version, update command, and project links. Pi Fallow also checks npm once per TUI session and shows a non-blocking update notice when a newer version is available. Set `PI_FALLOW_DISABLE_UPDATE_NOTICE=1` to disable startup update notices.
+`/fallow about` shows the installed Pi Fallow version, latest npm version, update command, and project links. Pi Fallow also checks npm once per TUI session and shows a non-blocking warning when a newer version is available. Update an npm installation with `pi update npm:pi-fallow`. Set `PI_FALLOW_DISABLE_UPDATE_NOTICE=1` to disable startup update notices.
 
 Saved full reports remain in the operating system's temporary directory. Pi Fallow never deletes them automatically; the operating system's own temporary-file retention policy still applies.
 

--- a/extensions/fallow/update-notice.ts
+++ b/extensions/fallow/update-notice.ts
@@ -9,7 +9,7 @@ const PI_FALLOW_RELEASES_URL = "https://github.com/revazi/pi-fallow/releases";
 const PI_FALLOW_ISSUES_URL = "https://github.com/revazi/pi-fallow/issues";
 const PI_REPO_URL = "https://github.com/earendil-works/pi";
 const FALLOW_DOCS_URL = "https://fallow.tools/docs/";
-const PI_FALLOW_UPDATE_COMMAND = "pi install npm:pi-fallow";
+const PI_FALLOW_UPDATE_COMMAND = "pi update npm:pi-fallow";
 const PI_FALLOW_DISABLE_UPDATE_ENV = "PI_FALLOW_DISABLE_UPDATE_NOTICE";
 
 const NPM_LATEST_URL = `https://registry.npmjs.org/${PI_FALLOW_PACKAGE_NAME}/latest`;
@@ -58,7 +58,7 @@ export function scheduleFallowUpdateNotice(
 	void getPiFallowVersionInfo()
 		.then((info) => {
 			if (!info.updateAvailable || !info.latestVersion) return;
-			ctx.ui?.notify(buildShortUpdateNotice(info), "info");
+			ctx.ui?.notify(buildShortUpdateNotice(info), "warning");
 		})
 		.catch(() => {
 			// Update checks are best-effort and must never affect Pi startup.

--- a/tests/update-notice.test.mjs
+++ b/tests/update-notice.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const {
+	scheduleFallowUpdateNotice,
+	sendFallowAboutMessage,
+} = await jiti.import("../extensions/fallow/update-notice.ts");
+const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+
+async function drainPromises() {
+	await new Promise((resolve) => setImmediate(resolve));
+	await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("Pi Fallow update notices", () => {
+	it("reports newer npm releases once with the canonical Pi update command", async () => {
+		const originalFetch = globalThis.fetch;
+		const originalDisable = process.env.PI_FALLOW_DISABLE_UPDATE_NOTICE;
+		let latestVersion = "99.0.0";
+		let fetchCalls = 0;
+		const messages = [];
+		const notifications = [];
+		const pi = { sendMessage(message) { messages.push(message); } };
+		const ctx = {
+			hasUI: true,
+			ui: { notify(message, level) { notifications.push({ message, level }); } },
+		};
+
+		globalThis.fetch = async () => {
+			fetchCalls++;
+			return { ok: true, async json() { return { version: latestVersion }; } };
+		};
+
+		try {
+			await sendFallowAboutMessage(pi, { hasUI: false });
+			assert.equal(messages[0].details.currentVersion, packageJson.version);
+			assert.equal(messages[0].details.latestVersion, "99.0.0");
+			assert.equal(messages[0].details.updateAvailable, true);
+			assert.equal(messages[0].details.updateCommand, "pi update npm:pi-fallow");
+			assert.match(messages[0].content, /Update command: pi update npm:pi-fallow/);
+
+			process.env.PI_FALLOW_DISABLE_UPDATE_NOTICE = "1";
+			scheduleFallowUpdateNotice(pi, ctx);
+			await drainPromises();
+			assert.deepEqual(notifications, []);
+
+			delete process.env.PI_FALLOW_DISABLE_UPDATE_NOTICE;
+			scheduleFallowUpdateNotice(pi, ctx);
+			await drainPromises();
+			assert.deepEqual(notifications, [{
+				message: `Pi Fallow 99.0.0 is available (you have ${packageJson.version}). Update: pi update npm:pi-fallow. Details: /fallow about`,
+				level: "warning",
+			}]);
+
+			scheduleFallowUpdateNotice(pi, ctx);
+			await drainPromises();
+			assert.equal(notifications.length, 1);
+
+			latestVersion = packageJson.version;
+			await sendFallowAboutMessage(pi, { hasUI: false });
+			assert.equal(messages[1].details.updateAvailable, false);
+			assert.equal(fetchCalls, 2);
+		} finally {
+			globalThis.fetch = originalFetch;
+			if (originalDisable === undefined) delete process.env.PI_FALLOW_DISABLE_UPDATE_NOTICE;
+			else process.env.PI_FALLOW_DISABLE_UPDATE_NOTICE = originalDisable;
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- changes the recommended package command from `pi install npm:pi-fallow` to the canonical `pi update npm:pi-fallow`
- presents available updates as non-blocking warning notifications
- documents the exact update command
- adds focused coverage for version reporting, opt-out behavior, one-time notices, warning content, and up-to-date status

## Release relevance

Existing Pi Fallow installations already query npm for newer versions. This ensures v0.3.0 and later installations provide the canonical command when announcing future releases.

## Validation

- [x] 122 tests pass
- [x] coverage: 82.87% lines/statements, 83.64% functions, 83.98% branches
- [x] Fallow health reports 0 findings with score 85.4 (A)
- [x] dead-code check reports 0 issues
- [x] bundle check passes