### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to Pi Fallow are documented here.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-20
+
 ### Added
+- Added frozen token and execution baselines with deterministic token, runner, Git, parser, memory, and cold/warm benchmark tooling.
 - Added Node.js compatibility matrices, dependency audits, dependency review, CodeQL, package-install smoke checks, coverage thresholds, Dependabot, and OIDC-based npm release automation.
 
 ### Changed
@@ -48,4 +51,6 @@ All notable changes to Pi Fallow are documented here.
 - Removed the persistent footer status line (`fallow ready · branch ... · base ...`) while keeping the transient `fallow running…` status during commands.
 - Improved output parsing, overview summaries, and navigator prompt coverage with regression tests.
 
+[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/revazi/pi-fallow/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/revazi/pi-fallow/compare/v0.1.3...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fallow",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fallow",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.80.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fallow",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "packageManager": "npm@11.6.2",
   "description": "Pi extension that brings Fallow codebase intelligence into Pi as an agent tool and slash command.",


### PR DESCRIPTION
## Summary

- bumps `pi-fallow` from 0.2.0 to 0.3.0
- moves the accumulated unreleased notes into the dated v0.3.0 changelog section
- adds compare links for v0.3.0 and future unreleased changes
- records the deterministic benchmark tooling added during this release cycle

## Release highlights

- reliable cancellation and non-TUI execution
- non-blocking Git autocomplete and cached runner resolution
- bounded retained output and linear embedded-JSON scanning
- 85.20% smaller fixed tool contract
- all-findings navigator with search, filters, persistent selection, and responsive centered layout
- compact/full prompt detail control with exact full-report preservation
- correct separation of actionable findings and informational health context
- bare `/fallow` and `/fallow run` with configurable defaults
- canonical `pi update npm:pi-fallow` release notices
- Node 22.19/24 CI, package smoke tests, audits, CodeQL, coverage, and provenance publishing

## Validation

- [x] `npm run check:publish` passes
- [x] 122 tests pass
- [x] coverage: 82.87% lines/statements, 83.64% functions, 83.98% branches
- [x] Fallow health reports 0 findings with score 85.4 (A)
- [x] dead-code and duplication checks report 0 issues
- [x] production and full dependency audits report 0 vulnerabilities
- [x] package smoke check passes with 53 published files
- [x] npm currently reports 0.2.0 and the v0.3.0 tag does not exist

## Post-merge release

After this PR is merged, create and push the `v0.3.0` tag from the merge commit. The release workflow will verify the tag/changelog, rerun `check:publish`, publish to npm with provenance, and create the GitHub release.