### PR TITLE
fix: make autocomplete token parsing linear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Pi Fallow are documented here.
 
 ### Fixed
 - Updated the coordinated Pi development packages to 0.81.1, replacing the vulnerable shrinkwrapped `brace-expansion` 5.0.6 with 5.0.7.
+- Replaced the autocomplete token regex with a linear scanner to prevent pathological quoted input from blocking the TUI.
 
 ## [0.3.0] - 2026-07-20
 

--- a/extensions/fallow/autocomplete.ts
+++ b/extensions/fallow/autocomplete.ts
@@ -280,12 +280,57 @@ const FLAGS_BY_COMMAND: Record<string, FlagSpec[]> = {
 
 function parseTokens(input: string): string[] {
 	const tokens: string[] = [];
-	const tokenPattern = /"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|\S+/g;
-	for (const match of input.matchAll(tokenPattern)) {
-		const raw = match[0];
-		tokens.push(raw.replace(/^(["'])(.*)\1$/, "$2"));
+	let index = 0;
+	while (index < input.length) {
+		index = skipTokenWhitespace(input, index);
+		if (index >= input.length) break;
+		const parsed = readToken(input, index);
+		tokens.push(parsed.value);
+		index = parsed.nextIndex;
 	}
 	return tokens;
+}
+
+function skipTokenWhitespace(input: string, startIndex: number): number {
+	let index = startIndex;
+	while (index < input.length && isTokenWhitespace(input[index])) index++;
+	return index;
+}
+
+function isTokenWhitespace(value: string): boolean {
+	return value.trim().length === 0;
+}
+
+function readToken(input: string, startIndex: number): { value: string; nextIndex: number } {
+	const quote = input[startIndex];
+	return isTokenQuote(quote) ? readQuotedToken(input, startIndex, quote) : readUnquotedToken(input, startIndex);
+}
+
+function isTokenQuote(value: string): boolean {
+	return value === '"' || value === "'";
+}
+
+function readUnquotedToken(input: string, startIndex: number): { value: string; nextIndex: number } {
+	let index = startIndex;
+	while (index < input.length && !isTokenWhitespace(input[index])) index++;
+	return { value: input.slice(startIndex, index), nextIndex: index };
+}
+
+function readQuotedToken(input: string, startIndex: number, quote: string): { value: string; nextIndex: number } {
+	let index = startIndex + 1;
+	while (index < input.length) {
+		if (isEscapedTokenCharacter(input, index)) {
+			index += 2;
+			continue;
+		}
+		if (input[index] === quote) return { value: input.slice(startIndex + 1, index), nextIndex: index + 1 };
+		index++;
+	}
+	return { value: input.slice(startIndex), nextIndex: input.length };
+}
+
+function isEscapedTokenCharacter(input: string, index: number): boolean {
+	return input[index] === "\\" && index + 1 < input.length;
 }
 
 function currentToken(argumentText: string): { beforeCurrent: string; current: string; previousTokens: string[] } {
@@ -298,9 +343,12 @@ function currentToken(argumentText: string): { beforeCurrent: string; current: s
 }
 
 function splitCurrentToken(argumentText: string): { beforeCurrent: string; current: string } {
-	const match = argumentText.match(/^(.*?)(\S*)$/) ?? ["", argumentText, ""];
-	const [, beforeCurrent, current] = match;
-	return { beforeCurrent, current };
+	let currentStart = argumentText.length;
+	while (currentStart > 0 && !isTokenWhitespace(argumentText[currentStart - 1])) currentStart--;
+	return {
+		beforeCurrent: argumentText.slice(0, currentStart),
+		current: argumentText.slice(currentStart),
+	};
 }
 
 function commandKey(tokens: string[]): string | undefined {

--- a/tests/autocomplete.test.mjs
+++ b/tests/autocomplete.test.mjs
@@ -48,6 +48,21 @@ describe("Fallow autocomplete", () => {
 		assert.equal(fallowCompletions.getFallowArgumentCompletions("rerun "), null);
 	});
 
+	it("parses quoted and escaped completion tokens", () => {
+		assert.deepEqual(completionLabels("health --coverage 'coverage dir' --group-by o"), ["owner"]);
+		assert.deepEqual(completionLabels('health --coverage "coverage \\"dir\\"" --group-by o'), ["owner"]);
+	});
+
+	it("handles adversarial unmatched quotes in linear time", () => {
+		for (const [quote, escaped] of [["\"", "\\!"], ["'", "\\&"]]) {
+			const input = `${quote}${escaped.repeat(25_000)} `;
+			const startedAt = performance.now();
+			fallowCompletions.getFallowArgumentCompletions(input);
+			const elapsedMs = performance.now() - startedAt;
+			assert.ok(elapsedMs < 250, `${quote} input took ${elapsedMs.toFixed(2)} ms`);
+		}
+	});
+
 	it("uses the configured default command for run flag completion", () => {
 		const previous = process.env.PI_FALLOW_DEFAULT_COMMAND;
 		try {


### PR DESCRIPTION
## Summary

- replaces the ambiguous quoted-token regular expression with a deterministic linear scanner
- removes the overlapping current-token regular expression from the same autocomplete path
- preserves quoted values, escaped characters, ordinary tokens, and incomplete input handling
- adds regression coverage for single/double quotes, escaped quotes, and both adversarial patterns reported by CodeQL

## Security impact

CodeQL identified exponential backtracking in both quoted branches of the old expression. Since parsing runs during slash-command completion, pathological local input could block typing and freeze the TUI. The replacement advances its input index monotonically and does not use a backtracking expression.

Addresses code-scanning alerts:

- https://github.com/revazi/pi-fallow/security/code-scanning/1
- https://github.com/revazi/pi-fallow/security/code-scanning/2

## Validation

- [x] adversarial 50,001-character single- and double-quoted inputs complete in under 1 ms locally
- [x] 124 tests pass
- [x] coverage: 82.96% lines/statements, 83.82% functions, 84.22% branches
- [x] Fallow health reports 0 findings with score 85.5 (A)
- [x] dead-code and duplication checks report 0 issues
- [x] bundle check passes