### PR TITLE
chore: prepare v0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Pi Fallow are documented here.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-22
+
 ### Fixed
 - Updated the coordinated Pi development packages to 0.81.1, replacing the vulnerable shrinkwrapped `brace-expansion` 5.0.6 with 5.0.7.
 - Replaced the autocomplete token regex with a linear scanner to prevent pathological quoted input from blocking the TUI.
@@ -55,6 +57,7 @@ All notable changes to Pi Fallow are documented here.
 - Removed the persistent footer status line (`fallow ready · branch ... · base ...`) while keeping the transient `fallow running…` status during commands.
 - Improved output parsing, overview summaries, and navigator prompt coverage with regression tests.
 
-[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/revazi/pi-fallow/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/revazi/pi-fallow/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/revazi/pi-fallow/compare/v0.1.3...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fallow",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fallow",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.81.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fallow",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "packageManager": "npm@11.6.2",
   "description": "Pi extension that brings Fallow codebase intelligence into Pi as an agent tool and slash command.",


### PR DESCRIPTION
## Summary

- bumps Pi Fallow from 0.3.0 to 0.3.1
- publishes the autocomplete ReDoS correction
- publishes the patched Pi development dependency tree with `brace-expansion` 5.0.7
- finalizes the dated v0.3.1 changelog and compare links

## Security fixes

- CodeQL alerts #1 and #2: replaced the ambiguous autocomplete token regex with a linear scanner
- Dependabot alert #2 / GHSA-3jxr-9vmj-r5cp: updated the Pi suite to 0.81.1 and removed `brace-expansion` 5.0.6

All three GitHub alerts are closed. Production dependencies report zero vulnerabilities. One moderate development-only `protobufjs` advisory remains pinned by Pi coding-agent upstream and is already tracked in earendil-works/pi#5653.

## Validation

- [x] `npm run check:publish` passes
- [x] 124 tests pass
- [x] Fallow health, dead-code, duplication, and CLI smoke checks pass
- [x] production audit reports 0 vulnerabilities
- [x] complete audit reports 0 high/critical vulnerabilities
- [x] package smoke check passes with 53 published files

## Post-merge

Tag the merge commit as `v0.3.1` and push it. The release workflow will publish to npm with provenance and create the GitHub release.