### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Pi Fallow are documented here.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-05
+
 ### Added
 - Exposed Fallow 3.14's stable type-aware symbol-impact and advisory type-coupling report flags through `fallow_run`, `/fallow`, and autocomplete, including project/completeness controls, syntactic opt-out, and health baseline identity mode.
 - Added focused semantic-evidence rendering that keeps incomplete symbol-impact results and type-coupling conclusions explicitly advisory.
@@ -65,7 +67,8 @@ All notable changes to Pi Fallow are documented here.
 - Removed the persistent footer status line (`fallow ready · branch ... · base ...`) while keeping the transient `fallow running…` status during commands.
 - Improved output parsing, overview summaries, and navigator prompt coverage with regression tests.
 
-[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/revazi/pi-fallow/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/revazi/pi-fallow/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/revazi/pi-fallow/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/revazi/pi-fallow/compare/v0.1.3...v0.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fallow",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fallow",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fallow",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "packageManager": "npm@11.6.2",
   "description": "Pi extension that brings Fallow codebase intelligence into Pi as an agent tool and slash command.",


### PR DESCRIPTION
## Summary

- bump Pi Fallow from 0.3.1 to 0.4.0
- finalize the 2026-08-05 changelog for the user-facing Fallow 3.14 type-aware symbol-impact and advisory type-coupling functionality
- merge the reviewed release metadata while keeping tag/publication blocked by the unchanged strict release gate

## User-visible changes

The release includes type-aware symbol-impact and advisory type-coupling report support in `fallow_run`, `/fallow`, and autocomplete, plus focused semantic-evidence rendering. This PR itself changes only `package.json`, `package-lock.json`, and `CHANGELOG.md`.

## Validation

Independent implementer/reviewer orchestration approved the release-preparation diff.

- [x] normal repository CI and CodeQL
- [x] `npm ci`
- [x] `npm test` (141 tests after the temporary audit-baseline work)
- [x] bundle, Fallow, coverage, package smoke, and pack checks
- [x] production audit (0 vulnerabilities)
- [x] normal CI's exact, fail-closed temporary development-audit baseline
- [x] documented token/performance comparisons
- [ ] strict `npm run audit:all`
- [ ] unchanged `npm run check:publish`

## Publication gate

This metadata PR is approved for merge, but **do not create `v0.4.0`, publish npm, or create a GitHub release yet**.

The published/shrinkwrapped `@earendil-works/pi-coding-agent@0.83.0` still contains nested `undici@8.5.0` and `brace-expansion@5.0.7`. Normal CI has an exact baseline expiring 2026-08-19, while `audit:all`, `check:publish`, and the release workflow remain strict.

Before tagging:

1. update all coordinated Pi packages to a published version containing upstream fix `221a842c136ab3af23aef9e70034af86061d27c1`;
2. remove the temporary audit baseline and restore normal CI to `audit:all`;
3. rerun the complete release suite until `npm run check:publish` passes unchanged;
4. review the resulting main commit, then create and push `v0.4.0` and monitor trusted publishing.
