### PR TITLE
ci: baseline upstream Pi audit findings

### DIFF
--- a/.github/npm-audit-ci-baseline.json
+++ b/.github/npm-audit-ci-baseline.json
@@ -1,0 +1,174 @@
+{
+  "schemaVersion": 1,
+  "expiresAt": "2026-08-19T00:00:00.000Z",
+  "upstreamFix": "https://github.com/earendil-works/pi/commit/221a842c136ab3af23aef9e70034af86061d27c1",
+  "vulnerabilityCounts": {
+    "info": 0,
+    "low": 0,
+    "moderate": 1,
+    "high": 2,
+    "critical": 0,
+    "total": 3
+  },
+  "findings": [
+    {
+      "name": "@earendil-works/pi-coding-agent",
+      "version": "0.83.0",
+      "severity": "moderate",
+      "isDirect": true,
+      "via": [
+        "undici"
+      ],
+      "advisories": [],
+      "effects": [],
+      "range": ">=0.75.4",
+      "nodes": [
+        "node_modules/@earendil-works/pi-coding-agent"
+      ],
+      "fixAvailable": {
+        "name": "@earendil-works/pi-coding-agent",
+        "version": "0.75.3",
+        "isSemVerMajor": true
+      }
+    },
+    {
+      "name": "brace-expansion",
+      "version": "5.0.7",
+      "severity": "high",
+      "isDirect": false,
+      "via": [],
+      "advisories": [
+        {
+          "source": 1130591,
+          "title": "brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash",
+          "url": "https://github.com/advisories/GHSA-mh99-v99m-4gvg",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=4.0.0 <5.0.8"
+        },
+        {
+          "source": 1130734,
+          "title": "brace-expansion: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation",
+          "url": "https://github.com/advisories/GHSA-rgw5-rvv9-x895",
+          "severity": "high",
+          "cwe": [
+            "CWE-400",
+            "CWE-770"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": ">=4.0.0 <5.0.9"
+        }
+      ],
+      "effects": [],
+      "range": "4.0.0 - 5.0.8",
+      "nodes": [
+        "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion"
+      ],
+      "fixAvailable": true
+    },
+    {
+      "name": "undici",
+      "version": "8.5.0",
+      "severity": "high",
+      "isDirect": false,
+      "via": [],
+      "advisories": [
+        {
+          "source": 1130714,
+          "title": "undici vulnerable to downstream response desynchronization via retry interceptor",
+          "url": "https://github.com/advisories/GHSA-8xcm-r25x-g524",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-444"
+          ],
+          "cvss": {
+            "score": 4.8,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+          },
+          "range": ">=8.0.0 <8.9.0"
+        },
+        {
+          "source": 1130717,
+          "title": "undici vulnerable to cross-user information disclosure and parse-time crash via degenerate private cache directives",
+          "url": "https://github.com/advisories/GHSA-4cwx-7wf7-3272",
+          "severity": "high",
+          "cwe": [
+            "CWE-200",
+            "CWE-248",
+            "CWE-525"
+          ],
+          "cvss": {
+            "score": 7.4,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H"
+          },
+          "range": ">=8.0.0 <8.9.0"
+        },
+        {
+          "source": 1130725,
+          "title": "undici vulnerable to CRLF Injection via blob-like body 'type' property",
+          "url": "https://github.com/advisories/GHSA-m8rv-5g2x-5cg5",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-93"
+          ],
+          "cvss": {
+            "score": 4.2,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N"
+          },
+          "range": ">=8.0.0 <8.9.0"
+        },
+        {
+          "source": 1130728,
+          "title": "undici vulnerable to cross-user information disclosure via whitespace around equals in Cache-Control directives",
+          "url": "https://github.com/advisories/GHSA-jr45-8vmc-qm54",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-436",
+            "CWE-524"
+          ],
+          "cvss": {
+            "score": 5.9,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+          },
+          "range": ">=8.0.0 <8.9.0"
+        },
+        {
+          "source": 1130730,
+          "title": "undici vulnerable to cookie attribute injection via unsanitized domain and unparsed setCookie fields",
+          "url": "https://github.com/advisories/GHSA-v3r7-h72x-cjcm",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-74"
+          ],
+          "cvss": {
+            "score": 4.8,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+          },
+          "range": ">=8.0.0 <8.9.0"
+        }
+      ],
+      "effects": [
+        "@earendil-works/pi-coding-agent"
+      ],
+      "range": "8.0.0 - 8.8.0",
+      "nodes": [
+        "node_modules/@earendil-works/pi-coding-agent/node_modules/undici"
+      ],
+      "fixAvailable": {
+        "name": "@earendil-works/pi-coding-agent",
+        "version": "0.75.3",
+        "isSemVerMajor": true
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Audit production dependency tree
         run: npm run audit:production
 
-      - name: Audit complete dependency tree
-        run: npm run audit:all
+      - name: Audit complete dependency tree against temporary baseline
+        run: npm run audit:ci
 
   dependency-review:
     name: Dependency review

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,3 +37,33 @@ Pi Fallow is a Pi extension that shells out to the Fallow CLI. Reports are espec
 - package installation or update behavior
 
 For vulnerabilities in Pi or Fallow themselves, please report them to those upstream projects directly.
+
+## Temporary development-audit risk acceptance
+
+Normal repository CI has a narrow, temporary exception for vulnerabilities pinned inside the published development-only `@earendil-works/pi-coding-agent@0.83.0` tree. The exception expires at **2026-08-19 00:00 UTC** and does not apply to production dependencies or releases.
+
+The accepted `npm audit --json` result is exactly:
+
+- the direct `@earendil-works/pi-coding-agent@0.83.0` moderate meta finding caused by nested `undici`;
+- `node_modules/@earendil-works/pi-coding-agent/node_modules/undici@8.5.0`, with only:
+  - <https://github.com/advisories/GHSA-8xcm-r25x-g524>
+  - <https://github.com/advisories/GHSA-4cwx-7wf7-3272>
+  - <https://github.com/advisories/GHSA-m8rv-5g2x-5cg5>
+  - <https://github.com/advisories/GHSA-jr45-8vmc-qm54>
+  - <https://github.com/advisories/GHSA-v3r7-h72x-cjcm>
+- `node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion@5.0.7`, with only:
+  - <https://github.com/advisories/GHSA-mh99-v99m-4gvg>
+  - <https://github.com/advisories/GHSA-rgw5-rvv9-x895>
+
+`.github/npm-audit-ci-baseline.json` records the exact packages, paths, versions, advisory identities/ranges/severities, finding severities, and aggregate counts. `npm run audit:ci` runs a fresh complete-development audit and fails closed unless the nonzero result and lockfile match that boundary. It also fails on audit execution errors, malformed output, a fixed tree, or expiry; it is not a package/range ignore mechanism.
+
+This exception is confined to the normal CI complete-development audit step. `npm run audit:production` remains strict. `npm run audit:all`, `npm run check:publish`, and `.github/workflows/release.yml` remain strict, so releases stay blocked while these findings exist.
+
+The nested versions come from the Pi package's published shrinkwrap and cannot be replaced by this repository's root dependency resolution. Upstream Pi commit [`221a842c`](https://github.com/earendil-works/pi/commit/221a842c136ab3af23aef9e70034af86061d27c1) updates them, but it is not present in a published Pi release as of this acceptance. GitHub Dependabot update job `1508340585` consequently reports `security_update_not_possible`: `undici@8.5.0` is the latest resolvable version because `@earendil-works/pi-coding-agent@0.83.0` requires it, while `8.9.0` is the lowest non-vulnerable version. Dependabot security updates remain enabled; this external failed update attempt is not suppressed.
+
+As soon as an upstream release containing the fix is published:
+
+1. upgrade the Pi development packages and regenerate `package-lock.json`;
+2. verify both strict audits are clean;
+3. change normal CI back to `npm run audit:all` and remove the baseline, validator, tests, and this section; and
+4. update/rebase draft release PR #43 so its unchanged strict release gate can pass.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test": "node --test",
     "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=75 --statements=75 --functions=79 --branches=83 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
+    "audit:ci": "node scripts/audit-ci.mjs",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",
     "bench:tokens:compare": "node scripts/token-benchmark-compare.mjs",

--- a/scripts/audit-ci.mjs
+++ b/scripts/audit-ci.mjs
@@ -1,0 +1,380 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const BASELINE_PATH = resolve(ROOT, ".github", "npm-audit-ci-baseline.json");
+const LOCKFILE_PATH = resolve(ROOT, "package-lock.json");
+const FINDING_KEYS = ["effects", "fixAvailable", "isDirect", "name", "nodes", "range", "severity", "via"];
+const ADVISORY_KEYS = ["cwe", "cvss", "dependency", "name", "range", "severity", "source", "title", "url"];
+const DEPENDENCY_COUNT_KEYS = ["dev", "optional", "peer", "peerOptional", "prod", "total"];
+const EXPIRY_CEILING = Date.parse("2026-08-19T00:00:00.000Z");
+const UPSTREAM_FIX = "https://github.com/earendil-works/pi/commit/221a842c136ab3af23aef9e70034af86061d27c1";
+const REMEDIATION = "Upgrade @earendil-works/pi-coding-agent to a published release containing upstream fix 221a842c136ab3af23aef9e70034af86061d27c1, regenerate package-lock.json, restore normal CI to audit:all, and remove the temporary baseline.";
+
+export class AuditBaselineError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = "AuditBaselineError";
+	}
+}
+
+export function validateAuditExecution(execution, { baseline, lockfile, now = new Date() }) {
+	validateBaselineDefinition(baseline);
+	validateExpiry(baseline.expiresAt, now);
+	validateExecutionOutcome(execution);
+	const report = parseAuditJson(execution.stdout);
+	validateAuditReport(report, baseline, lockfile);
+	return {
+		expiresAt: baseline.expiresAt,
+		findingCount: baseline.findings.length,
+		advisoryCount: baseline.findings.reduce((total, finding) => total + finding.advisories.length, 0),
+	};
+}
+
+export function validateAuditReport(report, baseline, lockfile) {
+	requirePlainObject(report, "audit report");
+	requireExactKeys(report, ["auditReportVersion", "metadata", "vulnerabilities"], "audit report");
+	requireEqual(report.auditReportVersion, 2, "npm audit report version changed.");
+
+	requirePlainObject(report.vulnerabilities, "audit vulnerabilities");
+	const expectedByName = new Map(baseline.findings.map((finding) => [finding.name, finding]));
+	requireExactKeys(report.vulnerabilities, [...expectedByName.keys()], "vulnerability package set");
+	for (const [name, expected] of expectedByName) validateFinding(report.vulnerabilities[name], expected, lockfile);
+	validateMetadata(report.metadata, baseline.vulnerabilityCounts);
+}
+
+function validateExecutionOutcome(execution) {
+	requirePlainObject(execution, "npm audit execution");
+	requireFalsy(execution.error, `npm audit did not complete normally. ${REMEDIATION}`);
+	requireFalsy(execution.signal, `npm audit did not complete normally. ${REMEDIATION}`);
+	requireInteger(execution.status, `npm audit did not complete normally. ${REMEDIATION}`);
+	requireAuditStatus(execution.status);
+	requireString(execution.stdout, "npm audit returned malformed output.");
+}
+
+function requireAuditStatus(status) {
+	if (status === 0) fail(`npm audit found no blocking vulnerabilities; the accepted-risk baseline must now be removed. ${REMEDIATION}`);
+	if (status !== 1) fail(`npm audit failed with an execution status instead of a vulnerability result. ${REMEDIATION}`);
+}
+
+function parseAuditJson(stdout) {
+	try {
+		return JSON.parse(stdout);
+	} catch {
+		fail("npm audit returned malformed JSON.");
+	}
+}
+
+function validateBaselineDefinition(baseline) {
+	requirePlainObject(baseline, "baseline");
+	requireExactKeys(
+		baseline,
+		["expiresAt", "findings", "schemaVersion", "upstreamFix", "vulnerabilityCounts"],
+		"baseline",
+	);
+	requireEqual(baseline.schemaVersion, 1, "Unsupported audit baseline schema.");
+	validateUpstreamFix(baseline.upstreamFix);
+	validateCountObject(baseline.vulnerabilityCounts, "baseline vulnerability counts");
+	requireArray(baseline.findings, "Audit baseline findings are malformed.");
+	requireNonEmpty(baseline.findings, "Audit baseline has no findings.");
+	validateBaselineFindings(baseline.findings);
+}
+
+function validateUpstreamFix(upstreamFix) {
+	requireString(upstreamFix, "Audit baseline is missing the reviewed upstream fix.");
+	requireEqual(upstreamFix, UPSTREAM_FIX, "Audit baseline is missing the reviewed upstream fix.");
+}
+
+function validateBaselineFindings(findings) {
+	const names = new Set();
+	for (const finding of findings) validateBaselineFinding(finding, names);
+}
+
+function validateBaselineFinding(finding, names) {
+	requirePlainObject(finding, "baseline finding");
+	requireExactKeys(
+		finding,
+		["advisories", "effects", "fixAvailable", "isDirect", "name", "nodes", "range", "severity", "version", "via"],
+		"baseline finding",
+	);
+	requireString(finding.name, "Audit baseline finding names must be unique strings.");
+	requireUniqueEntry(names, finding.name, "Audit baseline finding names must be unique strings.");
+	requireString(finding.version, `Audit baseline finding ${finding.name} is malformed.`);
+	requireString(finding.severity, `Audit baseline finding ${finding.name} is malformed.`);
+	requireString(finding.range, `Audit baseline finding ${finding.name} is malformed.`);
+	requireBoolean(finding.isDirect, `Audit baseline finding ${finding.name} has invalid directness.`);
+	validateBaselineFindingArrays(finding);
+	validateBaselineAdvisories(finding.advisories, finding.name);
+}
+
+function validateBaselineFindingArrays(finding) {
+	for (const field of ["via", "effects", "nodes", "advisories"]) {
+		requireArray(finding[field], `Audit baseline finding ${finding.name} has invalid ${field}.`);
+	}
+}
+
+function validateBaselineAdvisories(advisories, packageName) {
+	for (const advisory of advisories) validateBaselineAdvisory(advisory, packageName);
+}
+
+function validateBaselineAdvisory(advisory, packageName) {
+	requirePlainObject(advisory, `baseline advisory for ${packageName}`);
+	requireExactKeys(
+		advisory,
+		["cwe", "cvss", "range", "severity", "source", "title", "url"],
+		`baseline advisory for ${packageName}`,
+	);
+	requireInteger(advisory.source, `Audit baseline advisory for ${packageName} is malformed.`);
+	requireString(advisory.url, `Audit baseline advisory for ${packageName} is malformed.`);
+	requireString(advisory.severity, `Audit baseline advisory for ${packageName} is malformed.`);
+	requireString(advisory.range, `Audit baseline advisory for ${packageName} is malformed.`);
+	validateAdvisoryDetails(advisory, advisory.url);
+}
+
+function validateExpiry(expiresAt, now) {
+	const expiration = parseDate(expiresAt, "Audit baseline expiry is malformed.");
+	const current = parseDate(now, "Audit baseline expiry is malformed.");
+	requireMaximum(expiration.getTime(), EXPIRY_CEILING, "Audit baseline expiry exceeds the reviewed deadline.");
+	requireBefore(current, expiration, `Temporary audit baseline expired at ${expiresAt}. ${REMEDIATION}`);
+}
+
+function parseDate(value, message) {
+	const parsed = new Date(value);
+	requireFinite(parsed.getTime(), message);
+	return parsed;
+}
+
+function validateFinding(actual, expected, lockfile) {
+	requirePlainObject(actual, `finding ${expected.name}`);
+	requireExactKeys(actual, FINDING_KEYS, `finding ${expected.name}`);
+	validateFindingFields(actual, expected);
+	compareStringSet(actual.nodes, expected.nodes, `nodes for ${expected.name}`);
+	compareStringSet(actual.effects, expected.effects, `effects for ${expected.name}`);
+	validateFindingVia(actual.via, expected, expected.name);
+	validateLockedVersions(lockfile, expected);
+}
+
+function validateFindingFields(actual, expected) {
+	for (const field of ["name", "severity", "isDirect", "range", "fixAvailable"]) {
+		requireDeepEqual(actual[field], expected[field], `Audit finding ${expected.name} changed ${field}.`);
+	}
+}
+
+function validateFindingVia(actualVia, expected, packageName) {
+	requireArray(actualVia, `Audit finding ${packageName} has malformed advisory data.`);
+	const viaPackages = actualVia.filter((item) => typeof item === "string");
+	const advisories = actualVia.filter((item) => isPlainObject(item));
+	requireEqual(viaPackages.length + advisories.length, actualVia.length, `Audit finding ${packageName} has malformed advisory data.`);
+	compareStringSet(viaPackages, expected.via, `via packages for ${packageName}`);
+	validateAdvisories(advisories, expected.advisories, packageName);
+}
+
+function validateAdvisories(actual, expected, packageName) {
+	requireEqual(actual.length, expected.length, `Audit finding ${packageName} changed advisory count.`);
+	const expectedBySource = new Map(expected.map((advisory) => [advisory.source, advisory]));
+	requireEqual(expectedBySource.size, expected.length, `Audit baseline for ${packageName} has duplicate advisory sources.`);
+	requireUniqueValues(actual.map((advisory) => advisory.source), `Audit finding ${packageName} contains duplicate advisories.`);
+	for (const advisory of actual) validateAdvisory(advisory, expectedBySource, packageName);
+}
+
+function validateAdvisory(advisory, expectedBySource, packageName) {
+	requireExactKeys(advisory, ADVISORY_KEYS, `advisory for ${packageName}`);
+	const expected = expectedBySource.get(advisory.source);
+	requireTruthy(expected, `Audit finding ${packageName} contains an unexpected advisory.`);
+	requireEqual(advisory.name, packageName, `Audit finding ${packageName} changed advisory package identity.`);
+	requireEqual(advisory.dependency, packageName, `Audit finding ${packageName} changed advisory package identity.`);
+	validateAdvisoryFields(advisory, expected);
+	validateAdvisoryDetails(advisory, expected.url);
+}
+
+function validateAdvisoryFields(actual, expected) {
+	for (const field of ["title", "url", "severity", "cwe", "cvss", "range"]) {
+		requireDeepEqual(actual[field], expected[field], `Audit advisory ${expected.url} changed ${field}.`);
+	}
+}
+
+function validateAdvisoryDetails(advisory, url) {
+	requireString(advisory.title, `Audit advisory ${url} is malformed.`);
+	validateStringArray(advisory.cwe, `Audit advisory ${url} is malformed.`);
+	requirePlainObject(advisory.cvss, `CVSS data for ${url}`);
+	requireExactKeys(advisory.cvss, ["score", "vectorString"], `CVSS data for ${url}`);
+	requireNumber(advisory.cvss.score, `Audit advisory ${url} has malformed CVSS data.`);
+	requireString(advisory.cvss.vectorString, `Audit advisory ${url} has malformed CVSS data.`);
+}
+
+function validateLockedVersions(lockfile, expected) {
+	requirePlainObject(lockfile, "package lock");
+	requireEqual(lockfile.lockfileVersion, 3, "package-lock.json format changed.");
+	requirePlainObject(lockfile.packages, "package lock packages");
+	for (const node of expected.nodes) validateLockedNode(lockfile.packages[node], expected, node);
+}
+
+function validateLockedNode(lockedPackage, expected, node) {
+	requirePlainObject(lockedPackage, `locked package at ${node}`);
+	requireEqual(lockedPackage.version, expected.version, `Locked version or node changed for ${expected.name}.`);
+}
+
+function validateMetadata(metadata, expectedCounts) {
+	requirePlainObject(metadata, "audit metadata");
+	requireExactKeys(metadata, ["dependencies", "vulnerabilities"], "audit metadata");
+	validateCountObject(metadata.vulnerabilities, "audit vulnerability counts");
+	requireDeepEqual(metadata.vulnerabilities, expectedCounts, "Audit vulnerability severity counts changed.");
+	validateDependencyCounts(metadata.dependencies);
+}
+
+function validateDependencyCounts(counts) {
+	requirePlainObject(counts, "audit dependency counts");
+	requireExactKeys(counts, DEPENDENCY_COUNT_KEYS, "audit dependency counts");
+	validateNonnegativeCounts(counts, "Audit dependency counts are malformed.");
+}
+
+function validateCountObject(counts, label) {
+	requirePlainObject(counts, label);
+	requireExactKeys(counts, ["critical", "high", "info", "low", "moderate", "total"], label);
+	validateNonnegativeCounts(counts, `${label} are malformed.`);
+}
+
+function validateNonnegativeCounts(counts, message) {
+	for (const count of Object.values(counts)) {
+		requireInteger(count, message);
+		requireMinimum(count, 0, message);
+	}
+}
+
+function compareStringSet(actual, expected, label) {
+	const left = sortedUniqueStrings(actual, `Audit ${label} are malformed.`);
+	const right = sortedUniqueStrings(expected, `Audit ${label} are malformed.`);
+	requireDeepEqual(left, right, `Audit ${label} changed.`);
+}
+
+function sortedUniqueStrings(values, message) {
+	validateStringArray(values, message);
+	requireUniqueValues(values, message);
+	return [...values].sort();
+}
+
+function validateStringArray(values, message) {
+	requireArray(values, message);
+	for (const value of values) requireString(value, message);
+}
+
+function requirePlainObject(value, label) {
+	requireValue(isPlainObject(value), `${label} is malformed.`);
+}
+
+function requireExactKeys(value, expectedKeys, label) {
+	const actualKeys = Object.keys(value).sort();
+	const sortedExpected = [...expectedKeys].sort();
+	requireDeepEqual(actualKeys, sortedExpected, `${label} changed shape or membership.`);
+}
+
+function requireUniqueEntry(entries, value, message) {
+	requireValue(!entries.has(value), message);
+	entries.add(value);
+}
+
+function requireUniqueValues(values, message) {
+	requireEqual(new Set(values).size, values.length, message);
+}
+
+function requireBefore(value, limit, message) {
+	requireValue(value.getTime() < limit.getTime(), message);
+}
+
+function requireNonEmpty(value, message) {
+	requireValue(value.length > 0, message);
+}
+
+function requireMinimum(value, minimum, message) {
+	requireValue(value >= minimum, message);
+}
+
+function requireMaximum(value, maximum, message) {
+	requireValue(value <= maximum, message);
+}
+
+function requireTruthy(value, message) {
+	requireValue(Boolean(value), message);
+}
+
+function requireFalsy(value, message) {
+	requireValue(!value, message);
+}
+
+function requireArray(value, message) {
+	requireValue(Array.isArray(value), message);
+}
+
+function requireBoolean(value, message) {
+	requireValue(typeof value === "boolean", message);
+}
+
+function requireString(value, message) {
+	requireValue(typeof value === "string", message);
+}
+
+function requireNumber(value, message) {
+	requireValue(typeof value === "number", message);
+}
+
+function requireInteger(value, message) {
+	requireValue(Number.isInteger(value), message);
+}
+
+function requireFinite(value, message) {
+	requireValue(Number.isFinite(value), message);
+}
+
+function requireEqual(actual, expected, message) {
+	requireValue(actual === expected, message);
+}
+
+function requireDeepEqual(actual, expected, message) {
+	requireValue(isDeepStrictEqual(actual, expected), message);
+}
+
+function requireValue(condition, message) {
+	if (!condition) fail(message);
+}
+
+function isPlainObject(value) {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function fail(message) {
+	throw new AuditBaselineError(message);
+}
+
+function readJson(path, label) {
+	try {
+		return JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		fail(`Unable to read valid ${label}.`);
+	}
+}
+
+export function main() {
+	try {
+		const baseline = readJson(BASELINE_PATH, "audit baseline");
+		const lockfile = readJson(LOCKFILE_PATH, "package lock");
+		const execution = spawnSync("npm", ["audit", "--json", "--audit-level=high"], {
+			cwd: ROOT,
+			encoding: "utf8",
+			maxBuffer: 10 * 1024 * 1024,
+			timeout: 120_000,
+		});
+		const result = validateAuditExecution(execution, { baseline, lockfile });
+		console.log(`Temporary CI development-audit baseline matched exactly: ${result.findingCount} findings and ${result.advisoryCount} advisories; expires ${result.expiresAt}.`);
+		console.log(REMEDIATION);
+	} catch (error) {
+		const message = error instanceof AuditBaselineError ? error.message : "Unexpected audit baseline validator failure.";
+		console.error(`CI development audit rejected: ${message}`);
+		process.exitCode = 1;
+	}
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) main();

--- a/tests/audit-ci.test.mjs
+++ b/tests/audit-ci.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { describe, it } from "node:test";
+
+import { validateAuditExecution } from "../scripts/audit-ci.mjs";
+
+const baseline = JSON.parse(await readFile(new URL("../.github/npm-audit-ci-baseline.json", import.meta.url), "utf8"));
+const validNow = new Date("2026-08-05T12:00:00.000Z");
+
+describe("temporary CI development-audit baseline", () => {
+	it("accepts the exact known Pi development-tree audit result", () => {
+		const result = validate(auditReport());
+		assert.deepEqual(result, {
+			expiresAt: baseline.expiresAt,
+			findingCount: 3,
+			advisoryCount: 7,
+		});
+	});
+
+	it("rejects an unexpected advisory", () => {
+		const report = auditReport();
+		report.vulnerabilities.undici.via.push(advisory("undici", {
+			source: 9999999,
+			url: "https://github.com/advisories/GHSA-test-test-test",
+			severity: "high",
+			range: ">=8.0.0 <9.0.0",
+		}));
+		assert.throws(() => validate(report), /changed advisory count/);
+	});
+
+	it("rejects an unexpected vulnerability package", () => {
+		const report = auditReport();
+		report.vulnerabilities["synthetic-package"] = structuredClone(report.vulnerabilities.undici);
+		report.vulnerabilities["synthetic-package"].name = "synthetic-package";
+		assert.throws(() => validate(report), /vulnerability package set changed/);
+	});
+
+	it("rejects an unexpected node path", () => {
+		const report = auditReport();
+		report.vulnerabilities.undici.nodes = ["node_modules/undici"];
+		assert.throws(() => validate(report), /nodes for undici changed/);
+	});
+
+	it("rejects missing and fully fixed findings", () => {
+		const missing = auditReport();
+		delete missing.vulnerabilities["brace-expansion"];
+		assert.throws(() => validate(missing), /vulnerability package set changed/);
+
+		const fixed = auditReport();
+		fixed.vulnerabilities = {};
+		fixed.metadata.vulnerabilities = zeroCounts();
+		assert.throws(
+			() => validateAuditExecution(execution(fixed, 0), options()),
+			/no blocking vulnerabilities; the accepted-risk baseline must now be removed/,
+		);
+	});
+
+	it("rejects lockfile version drift at an expected node", () => {
+		const lockfile = lockfileForBaseline();
+		lockfile.packages["node_modules/@earendil-works/pi-coding-agent/node_modules/undici"].version = "8.9.0";
+		assert.throws(() => validate(auditReport(), { lockfile }), /Locked version or node changed for undici/);
+	});
+
+	it("rejects malformed audit JSON and malformed report shapes", () => {
+		assert.throws(
+			() => validateAuditExecution({ status: 1, signal: null, error: undefined, stdout: "not json" }, options()),
+			/malformed JSON/,
+		);
+		const report = auditReport();
+		report.extra = true;
+		assert.throws(() => validate(report), /audit report changed shape/);
+	});
+
+	it("rejects audit command failures without inspecting partial output", () => {
+		assert.throws(
+			() => validateAuditExecution({ status: 2, signal: null, error: undefined, stdout: "{}" }, options()),
+			/execution status instead of a vulnerability result/,
+		);
+		assert.throws(
+			() => validateAuditExecution({ status: null, signal: "SIGTERM", error: undefined, stdout: "" }, options()),
+			/did not complete normally/,
+		);
+	});
+
+	it("rejects the baseline at expiry and prevents deadline extension", () => {
+		assert.throws(
+			() => validateAuditExecution(execution(auditReport()), options({ now: new Date(baseline.expiresAt) })),
+			/Temporary audit baseline expired.*published release containing upstream fix/s,
+		);
+
+		const extended = structuredClone(baseline);
+		extended.expiresAt = "2026-08-20T00:00:00.000Z";
+		assert.throws(
+			() => validateAuditExecution(execution(auditReport()), options({ baseline: extended })),
+			/expiry exceeds the reviewed deadline/,
+		);
+	});
+
+	it("rejects finding, advisory, and aggregate severity drift", () => {
+		const findingSeverity = auditReport();
+		findingSeverity.vulnerabilities.undici.severity = "critical";
+		assert.throws(() => validate(findingSeverity), /undici changed severity/);
+
+		const advisorySeverity = auditReport();
+		advisorySeverity.vulnerabilities.undici.via[0].severity = "high";
+		assert.throws(() => validate(advisorySeverity), /changed severity/);
+
+		const advisoryScore = auditReport();
+		advisoryScore.vulnerabilities.undici.via[0].cvss.score = 9;
+		assert.throws(() => validate(advisoryScore), /changed cvss/);
+
+		const aggregateSeverity = auditReport();
+		aggregateSeverity.metadata.vulnerabilities.high = 3;
+		aggregateSeverity.metadata.vulnerabilities.total = 4;
+		assert.throws(() => validate(aggregateSeverity), /severity counts changed/);
+	});
+});
+
+function validate(report, overrides = {}) {
+	return validateAuditExecution(execution(report), options(overrides));
+}
+
+function options(overrides = {}) {
+	return {
+		baseline: structuredClone(baseline),
+		lockfile: lockfileForBaseline(),
+		now: validNow,
+		...overrides,
+	};
+}
+
+function execution(report, status = 1) {
+	return { status, signal: null, error: undefined, stdout: JSON.stringify(report) };
+}
+
+function lockfileForBaseline() {
+	return {
+		lockfileVersion: 3,
+		packages: Object.fromEntries(
+			baseline.findings.flatMap((finding) => finding.nodes.map((node) => [node, { version: finding.version }])),
+		),
+	};
+}
+
+function auditReport() {
+	return {
+		auditReportVersion: 2,
+		vulnerabilities: Object.fromEntries(baseline.findings.map((finding) => [finding.name, auditFinding(finding)])),
+		metadata: {
+			vulnerabilities: structuredClone(baseline.vulnerabilityCounts),
+			dependencies: { prod: 1, dev: 351, optional: 67, peer: 4, peerOptional: 0, total: 351 },
+		},
+	};
+}
+
+function auditFinding(finding) {
+	return {
+		name: finding.name,
+		severity: finding.severity,
+		isDirect: finding.isDirect,
+		via: [...finding.via, ...finding.advisories.map((item) => advisory(finding.name, item))],
+		effects: [...finding.effects],
+		range: finding.range,
+		nodes: [...finding.nodes],
+		fixAvailable: structuredClone(finding.fixAvailable),
+	};
+}
+
+function advisory(packageName, item) {
+	return {
+		source: item.source,
+		name: packageName,
+		dependency: packageName,
+		title: item.title ?? `Synthetic ${packageName} advisory fixture`,
+		url: item.url,
+		severity: item.severity,
+		cwe: structuredClone(item.cwe ?? ["CWE-400"]),
+		cvss: structuredClone(item.cvss ?? { score: 7.5, vectorString: "CVSS:3.1/AV:N" }),
+		range: item.range,
+	};
+}
+
+function zeroCounts() {
+	return { info: 0, low: 0, moderate: 0, high: 0, critical: 0, total: 0 };
+}

--- a/tests/package-metadata.test.mjs
+++ b/tests/package-metadata.test.mjs
@@ -7,7 +7,9 @@ import { describe, it } from "node:test";
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
 const workflowNames = ["ci.yml", "codeql.yml", "release.yml"];
-const workflows = await Promise.all(workflowNames.map((name) => readFile(join(root, ".github", "workflows", name), "utf8")));
+const workflows = Object.fromEntries(await Promise.all(
+	workflowNames.map(async (name) => [name, await readFile(join(root, ".github", "workflows", name), "utf8")]),
+));
 const dependabot = await readFile(join(root, ".github", "dependabot.yml"), "utf8");
 
 describe("package and automation metadata", () => {
@@ -27,11 +29,22 @@ describe("package and automation metadata", () => {
 	});
 
 	it("pins every workflow action to a full commit SHA", () => {
-		for (const workflow of workflows) {
+		for (const workflow of Object.values(workflows)) {
 			for (const reference of workflow.matchAll(/uses:\s+[^@\s]+@([^\s#]+)/g)) {
 				assert.match(reference[1], /^[a-f0-9]{40}$/);
 			}
 		}
+	});
+
+	it("limits the temporary audit baseline to normal CI", () => {
+		assert.equal(manifest.scripts["audit:production"], "npm audit --omit=dev --audit-level=high");
+		assert.equal(manifest.scripts["audit:all"], "npm audit --audit-level=high");
+		assert.equal(manifest.scripts["audit:ci"], "node scripts/audit-ci.mjs");
+		assert.match(workflows["ci.yml"], /Audit complete dependency tree against temporary baseline\n\s+run: npm run audit:ci/);
+		assert.doesNotMatch(workflows["release.yml"], /audit:ci/);
+		assert.match(workflows["release.yml"], /run: npm run check:publish/);
+		assert.match(manifest.scripts["check:publish"], /npm run audit:production && npm run audit:all/);
+		assert.doesNotMatch(manifest.scripts["check:publish"], /audit:ci/);
 	});
 
 	it("configures npm and GitHub Actions dependency updates", () => {


### PR DESCRIPTION
## Summary

- restores the repository-owned main CI audit job while the current published Pi coding-agent shrinkwrap cannot be remediated locally
- adds an exact, fail-closed, development-only audit baseline expiring 2026-08-19
- accepts only the reviewed Pi 0.83.0 nested `undici@8.5.0` and `brace-expansion@5.0.7` findings, exact paths, seven advisory identities/details, severities, counts, and lockfile versions
- keeps production audit, `audit:all`, `check:publish`, and the release workflow strict
- keeps Dependabot security updates enabled and unsuppressed

## Why a baseline is required

`@earendil-works/pi-coding-agent@0.83.0` publishes an `npm-shrinkwrap.json` that pins the affected nested packages. Independent override experiments confirmed npm root overrides do not replace those installed shrinkwrapped versions. Upstream commit [`221a842c`](https://github.com/earendil-works/pi/commit/221a842c136ab3af23aef9e70034af86061d27c1) fixes the package, but no coordinated npm release contains it yet.

## Fail-closed behavior

`npm run audit:ci` rejects:

- any additional, missing, changed, or fixed finding
- any changed package, path, installed version, advisory, severity, count, range, CVSS/CWE data, or fix metadata
- malformed/partial output, command/network failure, signal, or unexpected exit status
- expiry or extension beyond 2026-08-19

A fixed audit result intentionally fails and instructs maintainers to remove this temporary mechanism.

## Security boundary

- `npm run audit:production`: strict and clean
- normal CI complete-development step: exact temporary baseline
- `npm run audit:all`: unchanged and still strict/red
- `npm run check:publish`: unchanged and still strict/red
- release workflow and draft release PR #43: still blocked
- GitHub-managed Dependabot security update: remains enabled and may continue reporting `security_update_not_possible`

## Validation

Independent implementation/review: **APPROVED**.

- `npm ci`
- `npm run audit:production` — 0 vulnerabilities
- `npm run audit:ci` — exact baseline accepted
- `npm run audit:all` — expected strict failure, 3 findings
- `npm run check:publish` — expected strict failure at `audit:all`
- 141 tests passed on current and Node 22.19
- coverage, bundles, Fallow health/dead-code/dupes/smoke, package smoke, pack check passed
- token/performance comparisons passed
- synthetic tests verify fail-closed mutation, fixed-tree, command-error, and expiry behavior

## Removal

When a fixed coordinated Pi release is published: update all Pi packages, verify strict audits, restore normal CI to `audit:all`, delete the baseline/validator/tests and SECURITY exception, then refresh draft PR #43.
