### PR TITLE
Accept bounded Pi development audit risk for v0.4.0

### DIFF
--- a/.github/npm-audit-accepted-development.json
+++ b/.github/npm-audit-accepted-development.json
@@ -1,5 +1,7 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
+  "releaseVersion": "0.4.0",
+  "lockfileSha256": "9821a3fb8dfe81a92602b72108f47c1c1cea17435ffe5f959623a587cfc56c4b",
   "expiresAt": "2026-08-19T00:00:00.000Z",
   "upstreamFix": "https://github.com/earendil-works/pi/commit/221a842c136ab3af23aef9e70034af86061d27c1",
   "vulnerabilityCounts": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
       - name: Audit production dependency tree
         run: npm run audit:production
 
-      - name: Audit complete dependency tree against temporary baseline
-        run: npm run audit:ci
+      - name: Audit complete dependency tree against accepted-development baseline
+        run: npm run audit:accepted-development
 
   dependency-review:
     name: Dependency review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Pi Fallow are documented here.
 ### Changed
 - Validated Pi Fallow against Fallow 3.14.0 using its signed executable, command help, capability schema, and real JSON outputs. Companion status, saved-report conversion, and browser/file-oriented `viz` remain direct Fallow CLI features rather than Pi Fallow report commands.
 - Refreshed the coordinated Pi development packages to 0.83.0, the direct TypeBox lock to 1.3.10, safe transitive dependency fixes, and the checkout and CodeQL workflow actions.
+- Kept the v0.4.0 production and package audits strict while accepting only the exact, expiring development-tree findings pinned by Pi 0.83.0; any package-version, lockfile, advisory, severity, path, count, or expiry drift still fails closed.
 
 ## [0.3.1] - 2026-07-22
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,9 +38,9 @@ Pi Fallow is a Pi extension that shells out to the Fallow CLI. Reports are espec
 
 For vulnerabilities in Pi or Fallow themselves, please report them to those upstream projects directly.
 
-## Temporary development-audit risk acceptance
+## Temporary v0.4.0 development-audit risk acceptance
 
-Normal repository CI has a narrow, temporary exception for vulnerabilities pinned inside the published development-only `@earendil-works/pi-coding-agent@0.83.0` tree. The exception expires at **2026-08-19 00:00 UTC** and does not apply to production dependencies or releases.
+Normal repository CI and the `pi-fallow@0.4.0` release gate have a narrow, temporary exception for vulnerabilities pinned inside the development-only `@earendil-works/pi-coding-agent@0.83.0` tree. The exception expires at **2026-08-19 00:00 UTC**, is rejected for any other package version, and does not apply to extension-owned production dependencies or packed package contents.
 
 The accepted `npm audit --json` result is exactly:
 
@@ -55,15 +55,15 @@ The accepted `npm audit --json` result is exactly:
   - <https://github.com/advisories/GHSA-mh99-v99m-4gvg>
   - <https://github.com/advisories/GHSA-rgw5-rvv9-x895>
 
-`.github/npm-audit-ci-baseline.json` records the exact packages, paths, versions, advisory identities/ranges/severities, finding severities, and aggregate counts. `npm run audit:ci` runs a fresh complete-development audit and fails closed unless the nonzero result and lockfile match that boundary. It also fails on audit execution errors, malformed output, a fixed tree, or expiry; it is not a package/range ignore mechanism.
+`.github/npm-audit-accepted-development.json` records the accepted release version and exact packages, paths, versions, advisory identities/ranges/severities, finding severities, and aggregate counts. `npm run audit:accepted-development` runs a fresh complete-development audit and fails closed unless the nonzero result, lockfile, and package version match that boundary. It also fails on audit execution errors, malformed output, a fixed tree, expiry, or any finding drift; it is not a package/range ignore mechanism.
 
-This exception is confined to the normal CI complete-development audit step. `npm run audit:production` remains strict. `npm run audit:all`, `npm run check:publish`, and `.github/workflows/release.yml` remain strict, so releases stay blocked while these findings exist.
+`npm run audit:release` combines the unchanged strict production audit with that exact accepted-development validator. `npm run check:publish` additionally builds, tests, runs Fallow's checks, and packs and installs the release tarball. The package smoke check proves the tarball has no owned, optional, or bundled runtime dependencies or `node_modules`; the Pi packages remain host-provided peers. `npm run audit:all` remains available and is expected to report the accepted findings until upstream publishes its fix. This policy does not describe the complete development audit as clean.
 
 The nested versions come from the Pi package's published shrinkwrap and cannot be replaced by this repository's root dependency resolution. Upstream Pi commit [`221a842c`](https://github.com/earendil-works/pi/commit/221a842c136ab3af23aef9e70034af86061d27c1) updates them, but it is not present in a published Pi release as of this acceptance. GitHub Dependabot update job `1508340585` consequently reports `security_update_not_possible`: `undici@8.5.0` is the latest resolvable version because `@earendil-works/pi-coding-agent@0.83.0` requires it, while `8.9.0` is the lowest non-vulnerable version. Dependabot security updates remain enabled; this external failed update attempt is not suppressed.
 
-As soon as an upstream release containing the fix is published:
+As soon as an upstream release containing the fix is published—or before changing the package version or reaching the deadline:
 
-1. upgrade the Pi development packages and regenerate `package-lock.json`;
-2. verify both strict audits are clean;
-3. change normal CI back to `npm run audit:all` and remove the baseline, validator, tests, and this section; and
-4. update/rebase draft release PR #43 so its unchanged strict release gate can pass.
+1. upgrade the coordinated Pi development packages and regenerate `package-lock.json`;
+2. verify `npm run audit:all` and the strict production audit are clean;
+3. change CI and release validation back to `npm run audit:all`; and
+4. remove the accepted baseline, validator, tests, scripts, and this section.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "check": "npm test && npm run check:bundle && npm run health",
-    "check:publish": "npm test && npm run check:bundle && npm run health && npm run dupes && npm run dead-code && npm run smoke:fallow && npm run audit:production && npm run audit:all && npm run package:smoke",
+    "check:publish": "npm test && npm run check:bundle && npm run health && npm run dupes && npm run dead-code && npm run smoke:fallow && npm run audit:release && npm run package:smoke",
     "check:bundle": "esbuild extensions/fallow.ts --bundle --platform=node --format=esm --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-tui --external:@earendil-works/pi-ai --external:typebox --outdir=/tmp/pi-fallow-esbuild && esbuild extensions/index.ts --bundle --platform=node --format=esm --external:@earendil-works/pi-coding-agent --external:@earendil-works/pi-tui --external:@earendil-works/pi-ai --external:typebox --outdir=/tmp/pi-fallow-esbuild",
     "health": "fallow health --format json --quiet",
     "dupes": "fallow dupes --format json --quiet",
@@ -33,7 +33,8 @@
     "test": "node --test",
     "coverage": "c8 --all --include='extensions/**/*.ts' --reporter=text --reporter=lcov --reports-dir=coverage --check-coverage --lines=75 --statements=75 --functions=79 --branches=83 node --test",
     "audit:production": "npm audit --omit=dev --audit-level=high",
-    "audit:ci": "node scripts/audit-ci.mjs",
+    "audit:accepted-development": "node scripts/audit-accepted-development.mjs",
+    "audit:release": "npm run audit:production && npm run audit:accepted-development",
     "audit:all": "npm audit --audit-level=high",
     "bench:tokens": "node scripts/token-benchmark.mjs",
     "bench:tokens:compare": "node scripts/token-benchmark-compare.mjs",

--- a/scripts/audit-accepted-development.mjs
+++ b/scripts/audit-accepted-development.mjs
@@ -1,18 +1,21 @@
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 
 const ROOT = resolve(import.meta.dirname, "..");
-const BASELINE_PATH = resolve(ROOT, ".github", "npm-audit-ci-baseline.json");
+const BASELINE_PATH = resolve(ROOT, ".github", "npm-audit-accepted-development.json");
 const LOCKFILE_PATH = resolve(ROOT, "package-lock.json");
+const MANIFEST_PATH = resolve(ROOT, "package.json");
 const FINDING_KEYS = ["effects", "fixAvailable", "isDirect", "name", "nodes", "range", "severity", "via"];
 const ADVISORY_KEYS = ["cwe", "cvss", "dependency", "name", "range", "severity", "source", "title", "url"];
 const DEPENDENCY_COUNT_KEYS = ["dev", "optional", "peer", "peerOptional", "prod", "total"];
 const EXPIRY_CEILING = Date.parse("2026-08-19T00:00:00.000Z");
 const UPSTREAM_FIX = "https://github.com/earendil-works/pi/commit/221a842c136ab3af23aef9e70034af86061d27c1";
-const REMEDIATION = "Upgrade @earendil-works/pi-coding-agent to a published release containing upstream fix 221a842c136ab3af23aef9e70034af86061d27c1, regenerate package-lock.json, restore normal CI to audit:all, and remove the temporary baseline.";
+const ACCEPTED_RELEASE_VERSION = "0.4.0";
+const REMEDIATION = "Upgrade @earendil-works/pi-coding-agent to a published release containing upstream fix 221a842c136ab3af23aef9e70034af86061d27c1, regenerate package-lock.json, restore CI and release validation to audit:all, and remove the temporary accepted-development baseline.";
 
 export class AuditBaselineError extends Error {
 	constructor(message) {
@@ -21,8 +24,10 @@ export class AuditBaselineError extends Error {
 	}
 }
 
-export function validateAuditExecution(execution, { baseline, lockfile, now = new Date() }) {
+export function validateAuditExecution(execution, { baseline, lockfile, lockfileSha256, manifest, now = new Date() }) {
 	validateBaselineDefinition(baseline);
+	validateReleaseScope(baseline, manifest);
+	validateLockfileBoundary(baseline, lockfileSha256);
 	validateExpiry(baseline.expiresAt, now);
 	validateExecutionOutcome(execution);
 	const report = parseAuditJson(execution.stdout);
@@ -72,10 +77,13 @@ function validateBaselineDefinition(baseline) {
 	requirePlainObject(baseline, "baseline");
 	requireExactKeys(
 		baseline,
-		["expiresAt", "findings", "schemaVersion", "upstreamFix", "vulnerabilityCounts"],
+		["expiresAt", "findings", "lockfileSha256", "releaseVersion", "schemaVersion", "upstreamFix", "vulnerabilityCounts"],
 		"baseline",
 	);
-	requireEqual(baseline.schemaVersion, 1, "Unsupported audit baseline schema.");
+	requireEqual(baseline.schemaVersion, 2, "Unsupported audit baseline schema.");
+	requireString(baseline.lockfileSha256, "Audit baseline lockfile digest is malformed.");
+	requireValue(/^[a-f0-9]{64}$/.test(baseline.lockfileSha256), "Audit baseline lockfile digest is malformed.");
+	requireEqual(baseline.releaseVersion, ACCEPTED_RELEASE_VERSION, "Audit baseline release scope changed.");
 	validateUpstreamFix(baseline.upstreamFix);
 	validateCountObject(baseline.vulnerabilityCounts, "baseline vulnerability counts");
 	requireArray(baseline.findings, "Audit baseline findings are malformed.");
@@ -86,6 +94,17 @@ function validateBaselineDefinition(baseline) {
 function validateUpstreamFix(upstreamFix) {
 	requireString(upstreamFix, "Audit baseline is missing the reviewed upstream fix.");
 	requireEqual(upstreamFix, UPSTREAM_FIX, "Audit baseline is missing the reviewed upstream fix.");
+}
+
+function validateReleaseScope(baseline, manifest) {
+	requirePlainObject(manifest, "package manifest");
+	requireEqual(manifest.name, "pi-fallow", "Accepted development audit is limited to pi-fallow.");
+	requireEqual(manifest.version, baseline.releaseVersion, `Accepted development audit is limited to pi-fallow@${baseline.releaseVersion}.`);
+}
+
+function validateLockfileBoundary(baseline, lockfileSha256) {
+	requireString(lockfileSha256, "Package lock digest is malformed.");
+	requireEqual(lockfileSha256, baseline.lockfileSha256, "package-lock.json changed outside the accepted development-audit boundary.");
 }
 
 function validateBaselineFindings(findings) {
@@ -348,6 +367,10 @@ function fail(message) {
 	throw new AuditBaselineError(message);
 }
 
+function sha256(bytes) {
+	return createHash("sha256").update(bytes).digest("hex");
+}
+
 function readJson(path, label) {
 	try {
 		return JSON.parse(readFileSync(path, "utf8"));
@@ -359,19 +382,26 @@ function readJson(path, label) {
 export function main() {
 	try {
 		const baseline = readJson(BASELINE_PATH, "audit baseline");
+		const lockfileBytes = readFileSync(LOCKFILE_PATH);
 		const lockfile = readJson(LOCKFILE_PATH, "package lock");
+		const manifest = readJson(MANIFEST_PATH, "package manifest");
 		const execution = spawnSync("npm", ["audit", "--json", "--audit-level=high"], {
 			cwd: ROOT,
 			encoding: "utf8",
 			maxBuffer: 10 * 1024 * 1024,
 			timeout: 120_000,
 		});
-		const result = validateAuditExecution(execution, { baseline, lockfile });
-		console.log(`Temporary CI development-audit baseline matched exactly: ${result.findingCount} findings and ${result.advisoryCount} advisories; expires ${result.expiresAt}.`);
+		const result = validateAuditExecution(execution, {
+			baseline,
+			lockfile,
+			lockfileSha256: sha256(lockfileBytes),
+			manifest,
+		});
+		console.log(`Temporary accepted-development audit matched exactly for pi-fallow@${manifest.version}: ${result.findingCount} findings and ${result.advisoryCount} advisories; expires ${result.expiresAt}.`);
 		console.log(REMEDIATION);
 	} catch (error) {
 		const message = error instanceof AuditBaselineError ? error.message : "Unexpected audit baseline validator failure.";
-		console.error(`CI development audit rejected: ${message}`);
+		console.error(`Accepted development audit rejected: ${message}`);
 		process.exitCode = 1;
 	}
 }

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -52,6 +52,16 @@ function validateInstalledPackage(cwd) {
 	const packageRoot = join(cwd, "node_modules", "pi-fallow");
 	const manifest = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
 	assert.equal(manifest.name, "pi-fallow");
+	assert.equal(manifest.dependencies, undefined, "Published package must not own runtime dependencies.");
+	assert.equal(manifest.optionalDependencies, undefined, "Published package must not own optional runtime dependencies.");
+	assert.equal(manifest.bundleDependencies, undefined, "Published package must not bundle dependencies.");
+	assert.equal(manifest.bundledDependencies, undefined, "Published package must not bundle dependencies.");
+	assert.deepEqual(manifest.peerDependencies, {
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*",
+		typebox: "*",
+	});
 	assert.deepEqual(manifest.pi?.extensions, ["./extensions/index.ts"]);
 	assert.ok(readFileSync(join(packageRoot, "extensions", "index.ts"), "utf8").length > 0);
 }

--- a/tests/audit-accepted-development.test.mjs
+++ b/tests/audit-accepted-development.test.mjs
@@ -2,12 +2,12 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { describe, it } from "node:test";
 
-import { validateAuditExecution } from "../scripts/audit-ci.mjs";
+import { validateAuditExecution } from "../scripts/audit-accepted-development.mjs";
 
-const baseline = JSON.parse(await readFile(new URL("../.github/npm-audit-ci-baseline.json", import.meta.url), "utf8"));
+const baseline = JSON.parse(await readFile(new URL("../.github/npm-audit-accepted-development.json", import.meta.url), "utf8"));
 const validNow = new Date("2026-08-05T12:00:00.000Z");
 
-describe("temporary CI development-audit baseline", () => {
+describe("temporary accepted-development audit baseline", () => {
 	it("accepts the exact known Pi development-tree audit result", () => {
 		const result = validate(auditReport());
 		assert.deepEqual(result, {
@@ -55,10 +55,26 @@ describe("temporary CI development-audit baseline", () => {
 		);
 	});
 
-	it("rejects lockfile version drift at an expected node", () => {
+	it("rejects lockfile digest and vulnerable-node drift", () => {
+		assert.throws(
+			() => validate(auditReport(), { lockfileSha256: "0".repeat(64) }),
+			/package-lock\.json changed outside the accepted development-audit boundary/,
+		);
+
 		const lockfile = lockfileForBaseline();
 		lockfile.packages["node_modules/@earendil-works/pi-coding-agent/node_modules/undici"].version = "8.9.0";
 		assert.throws(() => validate(auditReport(), { lockfile }), /Locked version or node changed for undici/);
+	});
+
+	it("rejects use outside the accepted v0.4.0 package scope", () => {
+		assert.throws(
+			() => validate(auditReport(), { manifest: { name: "pi-fallow", version: "0.4.1" } }),
+			/limited to pi-fallow@0\.4\.0/,
+		);
+		assert.throws(
+			() => validate(auditReport(), { manifest: { name: "another-package", version: "0.4.0" } }),
+			/limited to pi-fallow/,
+		);
 	});
 
 	it("rejects malformed audit JSON and malformed report shapes", () => {
@@ -124,6 +140,8 @@ function options(overrides = {}) {
 	return {
 		baseline: structuredClone(baseline),
 		lockfile: lockfileForBaseline(),
+		lockfileSha256: baseline.lockfileSha256,
+		manifest: { name: "pi-fallow", version: "0.4.0" },
 		now: validNow,
 		...overrides,
 	};

--- a/tests/package-metadata.test.mjs
+++ b/tests/package-metadata.test.mjs
@@ -36,15 +36,15 @@ describe("package and automation metadata", () => {
 		}
 	});
 
-	it("limits the temporary audit baseline to normal CI", () => {
+	it("keeps production auditing strict and bounds the accepted development audit to CI and v0.4.0 release validation", () => {
 		assert.equal(manifest.scripts["audit:production"], "npm audit --omit=dev --audit-level=high");
 		assert.equal(manifest.scripts["audit:all"], "npm audit --audit-level=high");
-		assert.equal(manifest.scripts["audit:ci"], "node scripts/audit-ci.mjs");
-		assert.match(workflows["ci.yml"], /Audit complete dependency tree against temporary baseline\n\s+run: npm run audit:ci/);
-		assert.doesNotMatch(workflows["release.yml"], /audit:ci/);
+		assert.equal(manifest.scripts["audit:accepted-development"], "node scripts/audit-accepted-development.mjs");
+		assert.equal(manifest.scripts["audit:release"], "npm run audit:production && npm run audit:accepted-development");
+		assert.match(workflows["ci.yml"], /Audit complete dependency tree against accepted-development baseline\n\s+run: npm run audit:accepted-development/);
 		assert.match(workflows["release.yml"], /run: npm run check:publish/);
-		assert.match(manifest.scripts["check:publish"], /npm run audit:production && npm run audit:all/);
-		assert.doesNotMatch(manifest.scripts["check:publish"], /audit:ci/);
+		assert.match(manifest.scripts["check:publish"], /npm run audit:release && npm run package:smoke/);
+		assert.doesNotMatch(manifest.scripts["check:publish"], /audit:all/);
 	});
 
 	it("configures npm and GitHub Actions dependency updates", () => {


### PR DESCRIPTION
## Summary

- keep the production dependency audit strict for `pi-fallow@0.4.0`
- replace the CI-only exception with an exact, fail-closed accepted-development validator used by both CI and release validation
- bind the exception to package name/version, the full `package-lock.json` SHA-256, exact vulnerable nodes/versions/findings/advisories/severities/counts, and the existing 2026-08-19 expiry ceiling
- strengthen package smoke checks to prove the tarball owns or bundles no runtime dependencies and keeps Pi/TypeBox host-provided peers
- retain `audit:all` as an intentionally nonzero diagnostic; do not describe the full development audit as clean

## Risk decision

This PR records the explicitly approved, temporary v0.4.0 risk acceptance for findings pinned by the published `@earendil-works/pi-coding-agent@0.83.0` shrinkwrap. It is not a package/range ignore:

- any new, missing, fixed, drifted, malformed, signaled, or expired audit result fails
- any package-version or lockfile change fails
- `audit:production` remains unchanged and reports zero vulnerabilities
- packed `pi-fallow` contains no Pi packages, `node_modules`, or owned/optional/bundled runtime dependencies

Upstream Pi commit `221a842c136ab3af23aef9e70034af86061d27c1` fixes the nested dependencies, but no coordinated fixed Pi npm release is published yet. The exception must be removed when that release arrives, before the package version changes, or by the deadline.

## Verification

- [x] `npm run check:publish`
- [x] `npm run coverage`
- [x] `npm run audit:production` — 0 vulnerabilities
- [x] `npm run audit:accepted-development` — exact 3 findings / 7 advisories accepted
- [x] `npm run audit:all` — expected exit 1, only the accepted 1 moderate / 2 high findings
- [x] `npm run package:smoke` — 53 files; extracted package install passed
- [x] `git diff --check`

Independent review: APPROVED. Adversarial probe: PASS.

## Non-scope

No dependency, extension/runtime code, release workflow, package version, npm publication, tag, or GitHub Release is changed or created by this PR.