### PR TITLE
Fix fallow_run output detail semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to Pi Fallow are documented here.
 - Upgraded the coordinated Pi development packages to 0.84.0, incorporating the upstream dependency security fix.
 - Removed the temporary development-audit vulnerability acceptance after the upstream fix; CI and release validation now strictly audit the complete dependency tree.
 
+### Fixed
+- Made `fallow_run.detail` effective: tool calls now default to bounded normalized findings, while `summary` returns bounded status/counts and `raw` preserves the bounded raw-output behavior. Any omitted complete report is retained through a temporary-file reference.
+
 ## [0.4.0] - 2026-08-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Arguments after `/fallow run` are appended to the configured default. Explicit c
 
 The agent-facing `fallow_run` tool passes command-specific flags as separate `args` tokens. For example, a PR audit uses `{ "command": "audit", "args": ["--base", "main", "--gate", "new-only"] }`. Type-aware reports use the existing structured commands, for example `{ "command": "dead-code", "args": ["--type-aware", "--symbol-impact", "src/api.ts:Client"] }` or `{ "command": "health", "args": ["--type-aware", "--type-coupling"] }`. Manual `/fallow` command syntax is unchanged.
 
+`fallow_run.detail` controls model-facing output and defaults to `findings`. Use `summary` for bounded status and counts, `findings` for bounded normalized findings with locations, evidence, and suggested actions, or `raw` for bounded raw Fallow JSON/output. Summary and findings responses always link to a complete report in the operating system's temporary directory; raw responses do so when truncation omits content. This setting does not change `/fallow` slash-command or navigator rendering.
+
 `--type-aware-project` selects a TypeScript project and `--type-aware-require best-effort|complete` controls required completeness. Always inspect the returned type-aware completeness, omissions, and abstentions: incomplete evidence remains advisory and must not be treated as exact delete-safety proof. Fallow 3.14 also supports `--baseline-mode count|identity` for health baselines and `--no-type-aware` to override config for a syntactic-only run.
 
 Some Fallow surfaces deliberately remain direct CLI features rather than Pi Fallow report commands:

--- a/extensions/fallow/cli.ts
+++ b/extensions/fallow/cli.ts
@@ -5,6 +5,7 @@ import { stripAtPrefix } from "./path";
 import { execFallowProcess } from "./process";
 import { createFallowRunner } from "./runner";
 import type { FallowRunParams as CompactFallowRunParams } from "./schema";
+import type { FallowOutputDetail } from "./types";
 
 // Compatibility shape for tool calls stored by Pi before the compact contract.
 type FallowRunParams = CompactFallowRunParams & Record<string, any>;
@@ -506,6 +507,10 @@ function resolveFallowTimeout(params: CompactFallowRunParams): number {
 	return Number(process.env.FALLOW_TIMEOUT_SECS || 120);
 }
 
+function resolveFallowOutputDetail(detail: CompactFallowRunParams["detail"]): FallowOutputDetail {
+	return detail ?? "findings";
+}
+
 async function runFallow(pi: ExtensionAPI, params: CompactFallowRunParams, ctx: ExtensionContext, signal?: AbortSignal) {
 	const { details, content } = await fallowEngine.runFallowWithExecutor({
 		pi,
@@ -514,6 +519,7 @@ async function runFallow(pi: ExtensionAPI, params: CompactFallowRunParams, ctx: 
 		signal: signal ?? ctx.signal,
 		timeoutSecs: resolveFallowTimeout(params),
 		executor: execFallow,
+		outputDetail: resolveFallowOutputDetail(params.detail),
 	});
 	return { content: [{ type: "text" as const, text: content }], details };
 }
@@ -614,5 +620,6 @@ export const fallowCli = {
 	splitArgs,
 	buildFallowArgs,
 	prepareFallowRunParams,
+	resolveFallowOutputDetail,
 };
 

--- a/extensions/fallow/engine.ts
+++ b/extensions/fallow/engine.ts
@@ -5,7 +5,7 @@ import { detectFallowProjectState } from "./project/state";
 import { formatFallowProjectStateText } from "./project/text";
 import { parseJson } from "./json";
 import { formatToolOutput } from "./output";
-import type { FallowDetails, FallowOverview, FallowPrSummary, FallowProjectState } from "./types";
+import type { FallowDetails, FallowOutputDetail, FallowOverview, FallowPrSummary, FallowProjectState } from "./types";
 
 interface FallowExecutor {
 	(pi: ExtensionAPI, args: string[], cwd: string, signal: AbortSignal | undefined, timeoutSecs: number): Promise<{
@@ -24,6 +24,7 @@ interface FallowCommandInput {
 	executor: FallowExecutor;
 	throwOnExecutionError?: boolean;
 	preserveNavigatorDetails?: boolean;
+	outputDetail?: FallowOutputDetail;
 }
 
 interface ExecutedFallowCommand {
@@ -64,11 +65,11 @@ async function runFallowWithExecutor(input: FallowCommandInput): Promise<FallowC
 	const execution = await executeCommand(input);
 	const projectStatePromise = detectFallowProjectState(input.cwd, execution.args);
 	const parsed = parseJson(execution.stdout, execution.stderr);
-	const formattedPromise = formatToolOutput(parsed, input.cwd, execution.code, input.preserveNavigatorDetails);
+	const formattedPromise = formatToolOutput(parsed, input.cwd, execution.code, input.preserveNavigatorDetails, input.outputDetail);
 	const prSummary = buildFallowPrSummary(parsed.data, execution.args, execution.code);
 	const [projectState, formattedOutput] = await Promise.all([projectStatePromise, formattedPromise]);
 	if (shouldThrowExecutionError(execution, input.throwOnExecutionError ?? true)) {
-		throwExecutionError(execution, formattedOutput.text);
+		throwExecutionError(execution, formattedOutput.errorText);
 	}
 	const formatted = retainFormattedMetadata(formattedOutput);
 	return {

--- a/extensions/fallow/output-detail.ts
+++ b/extensions/fallow/output-detail.ts
@@ -1,0 +1,438 @@
+import { Buffer } from "node:buffer";
+import { asRecord } from "./data";
+import type { FallowIssueLine, FallowOutputDetail, FallowOverview } from "./types";
+
+const FALLOW_DETAIL_BUDGETS = {
+	summary: { characters: 4_096, tokens: { o200k_base: 4_000, cl100k_base: 4_000 } },
+	findings: { characters: 6_000, tokens: { o200k_base: 6_000, cl100k_base: 6_000 } },
+} as const;
+
+type DetailBudget = (typeof FALLOW_DETAIL_BUDGETS)[keyof typeof FALLOW_DETAIL_BUDGETS];
+type NormalizedStat = { label: string; value: string | number };
+
+interface DetailFormatResult {
+	text: string;
+	truncated: boolean;
+}
+
+interface NormalizedFinding {
+	section: string;
+	type: string;
+	id?: string;
+	severity?: string;
+	location?: { path: string; line?: number };
+	subject: string;
+	details?: string;
+	evidence?: string;
+	action?: string;
+}
+
+interface SummaryPayload {
+	detail: "summary";
+	title: string;
+	status: "success" | "warning" | "error";
+	summary: string;
+	summary_truncated: boolean;
+	finding_count: number;
+	context_count: number;
+	stat_count: number;
+	included_stats: number;
+	omitted_stats: number;
+	stats: NormalizedStat[];
+	note_count: number;
+	included_notes: number;
+	omitted_notes: number;
+	notes: string[];
+	complete_output_path: string;
+}
+
+interface FindingsPayload {
+	detail: "findings";
+	title: string;
+	status: "success" | "warning" | "error";
+	summary: string;
+	stats: NormalizedStat[];
+	finding_count: number;
+	included_findings: number;
+	omitted_findings: number;
+	findings: NormalizedFinding[];
+	context_count: number;
+	included_context: number;
+	omitted_context: number;
+	context: NormalizedFinding[];
+	notes: string[];
+	complete_output_path: string;
+}
+
+const SUMMARY_HEADER = "Fallow summary:\n";
+const FINDINGS_HEADER = "Fallow findings:\n";
+const MAX_FINDINGS_SUMMARY_CHARS = 1_000;
+const MAX_STAT_VALUE_CHARS = 200;
+const MAX_NOTE_CHARS = 300;
+const MAX_SECTION_CHARS = 160;
+const MAX_TYPE_CHARS = 160;
+const MAX_ID_CHARS = 240;
+const MAX_PATH_CHARS = 500;
+const MAX_SUBJECT_CHARS = 300;
+const MAX_DETAILS_CHARS = 700;
+const MAX_EVIDENCE_CHARS = 1_000;
+const MAX_ACTION_CHARS = 500;
+const MAX_STATS = 12;
+const MAX_NOTES = 6;
+
+function formatSelectedOutputDetail(
+	detail: Exclude<FallowOutputDetail, "raw">,
+	summary: string,
+	overview: FallowOverview | undefined,
+	fullOutputPath: string,
+): DetailFormatResult {
+	if (detail === "summary") return formatSummaryDetail(summary, overview, fullOutputPath);
+	return formatFindingsDetail(summary, overview, fullOutputPath);
+}
+
+function formatSummaryDetail(
+	summary: string,
+	overview: FallowOverview | undefined,
+	fullOutputPath: string,
+): DetailFormatResult {
+	const payload = createSummaryPayload(summary, overview, fullOutputPath);
+	const initiallyTruncated = isSummaryPayloadTruncated(payload);
+	fitSummaryPayload(payload, summary);
+	return { text: renderSummary(payload), truncated: initiallyTruncated || isSummaryPayloadTruncated(payload) };
+}
+
+function createSummaryPayload(
+	summary: string,
+	overview: FallowOverview | undefined,
+	fullOutputPath: string,
+): SummaryPayload {
+	const stats = normalizeStats(overview);
+	const notes = normalizeNotes(overview);
+	const statCount = overview ? overview.stats.length : 0;
+	const noteCount = overview ? overview.notes.length : 0;
+	const compactSummary = compactText(summary, MAX_FINDINGS_SUMMARY_CHARS);
+	return {
+		detail: "summary",
+		title: normalizeTitle(overview),
+		status: normalizeStatus(overview),
+		summary: compactSummary,
+		summary_truncated: compactSummary !== summary,
+		finding_count: countEntries(overview, false),
+		context_count: countEntries(overview, true),
+		stat_count: statCount,
+		included_stats: stats.length,
+		omitted_stats: statCount - stats.length,
+		stats,
+		note_count: noteCount,
+		included_notes: notes.length,
+		omitted_notes: noteCount - notes.length,
+		notes,
+		complete_output_path: fullOutputPath,
+	};
+}
+
+function fitSummaryPayload(payload: SummaryPayload, originalSummary: string): void {
+	trimSummaryNotes(payload);
+	payload.summary = fitStringToBudget(
+		payload.summary,
+		0,
+		(candidate) => renderSummary({ ...payload, summary: candidate, summary_truncated: candidate !== originalSummary }),
+		FALLOW_DETAIL_BUDGETS.summary,
+	);
+	payload.summary_truncated = payload.summary !== originalSummary;
+	trimSummaryStats(payload);
+	payload.title = fitStringToBudget(
+		payload.title,
+		1,
+		(candidate) => renderSummary({ ...payload, title: candidate }),
+		FALLOW_DETAIL_BUDGETS.summary,
+	);
+}
+
+function trimSummaryNotes(payload: SummaryPayload): void {
+	while (!withinBudget(renderSummary(payload), FALLOW_DETAIL_BUDGETS.summary) && payload.notes.length) {
+		payload.notes.pop();
+		updateSummaryCounts(payload);
+	}
+}
+
+function trimSummaryStats(payload: SummaryPayload): void {
+	while (!withinBudget(renderSummary(payload), FALLOW_DETAIL_BUDGETS.summary) && payload.stats.length) {
+		payload.stats.pop();
+		updateSummaryCounts(payload);
+	}
+}
+
+function updateSummaryCounts(payload: SummaryPayload): void {
+	payload.included_stats = payload.stats.length;
+	payload.omitted_stats = payload.stat_count - payload.included_stats;
+	payload.included_notes = payload.notes.length;
+	payload.omitted_notes = payload.note_count - payload.included_notes;
+}
+
+function isSummaryPayloadTruncated(payload: SummaryPayload): boolean {
+	if (payload.summary_truncated || payload.omitted_stats > 0) return true;
+	return payload.omitted_notes > 0;
+}
+
+function renderSummary(payload: SummaryPayload): string {
+	return `${SUMMARY_HEADER}${JSON.stringify(payload)}`;
+}
+
+function formatFindingsDetail(
+	summary: string,
+	overview: FallowOverview | undefined,
+	fullOutputPath: string,
+): DetailFormatResult {
+	const findingEntries = collectEntries(overview, false);
+	const contextEntries = collectContextEntries(overview, findingEntries);
+	const payload = createFindingsPayload(summary, overview, fullOutputPath, findingEntries.length);
+	fitFindingsMetadata(payload);
+	fitEntries(payload, "findings", findingEntries);
+	fitEntries(payload, "context", contextEntries);
+	return { text: renderFindings(payload), truncated: hasOmittedEntries(payload) };
+}
+
+function collectContextEntries(
+	overview: FallowOverview | undefined,
+	findingEntries: NormalizedFinding[],
+): NormalizedFinding[] {
+	if (findingEntries.length) return [];
+	return collectEntries(overview, true);
+}
+
+function createFindingsPayload(
+	summary: string,
+	overview: FallowOverview | undefined,
+	fullOutputPath: string,
+	findingCount: number,
+): FindingsPayload {
+	const contextCount = countEntries(overview, true);
+	return {
+		detail: "findings",
+		title: normalizeTitle(overview),
+		status: normalizeStatus(overview),
+		summary: compactText(summary, MAX_FINDINGS_SUMMARY_CHARS),
+		stats: normalizeStats(overview),
+		finding_count: findingCount,
+		included_findings: 0,
+		omitted_findings: findingCount,
+		findings: [],
+		context_count: contextCount,
+		included_context: 0,
+		omitted_context: contextCount,
+		context: [],
+		notes: normalizeNotes(overview),
+		complete_output_path: fullOutputPath,
+	};
+}
+
+function normalizeTitle(overview: FallowOverview | undefined): string {
+	return compactText(overview ? overview.title : "Fallow", MAX_SUBJECT_CHARS);
+}
+
+function normalizeStatus(overview: FallowOverview | undefined): SummaryPayload["status"] {
+	return overview ? overview.status : "warning";
+}
+
+function normalizeNotes(overview: FallowOverview | undefined): string[] {
+	const notes = overview ? overview.notes : [];
+	return notes.slice(0, MAX_NOTES).map((note) => compactText(note, MAX_NOTE_CHARS));
+}
+
+function fitFindingsMetadata(payload: FindingsPayload): void {
+	trimFindingsArray(payload, payload.notes);
+	trimFindingsArray(payload, payload.stats);
+	payload.summary = fitStringToBudget(
+		payload.summary,
+		0,
+		(candidate) => renderFindings({ ...payload, summary: candidate }),
+		FALLOW_DETAIL_BUDGETS.findings,
+	);
+	payload.title = fitStringToBudget(
+		payload.title,
+		1,
+		(candidate) => renderFindings({ ...payload, title: candidate }),
+		FALLOW_DETAIL_BUDGETS.findings,
+	);
+}
+
+function trimFindingsArray(payload: FindingsPayload, values: unknown[]): void {
+	while (!withinBudget(renderFindings(payload), FALLOW_DETAIL_BUDGETS.findings) && values.length) values.pop();
+}
+
+function hasOmittedEntries(payload: FindingsPayload): boolean {
+	return payload.omitted_findings > 0 || payload.omitted_context > 0;
+}
+
+function collectEntries(overview: FallowOverview | undefined, context: boolean): NormalizedFinding[] {
+	if (!overview) return [];
+	return overview.sections
+		.filter((section) => (section.role === "context") === context)
+		.flatMap((section) => section.items.map((item) => normalizeFinding(section.title, item)));
+}
+
+function countEntries(overview: FallowOverview | undefined, context: boolean): number {
+	if (!overview) return 0;
+	return overview.sections
+		.filter((section) => (section.role === "context") === context)
+		.reduce((total, section) => total + section.items.length, 0);
+}
+
+function normalizeFinding(section: string, item: FallowIssueLine): NormalizedFinding {
+	const raw = asRecord(item.raw);
+	return {
+		section: compactText(section, MAX_SECTION_CHARS),
+		type: compactText(firstString(raw, ["kind", "type", "issue_type", "rule_id"]) || section, MAX_TYPE_CHARS),
+		id: compactOptional(firstString(raw, ["benchmark_id", "id", "finding_id"]), MAX_ID_CHARS),
+		severity: compactOptional(item.severity || firstString(raw, ["severity"]), MAX_TYPE_CHARS),
+		location: normalizeLocation(item),
+		subject: compactText(item.label, MAX_SUBJECT_CHARS),
+		details: compactOptional(item.meta, MAX_DETAILS_CHARS),
+		evidence: compactOptional(firstText(raw, ["evidence", "reason", "rationale", "message", "description"]), MAX_EVIDENCE_CHARS),
+		action: normalizeAction(item, raw),
+	};
+}
+
+function normalizeLocation(item: FallowIssueLine): NormalizedFinding["location"] {
+	const path = compactOptional(item.path, MAX_PATH_CHARS);
+	if (!path) return undefined;
+	if (item.line === undefined) return { path };
+	return { path, line: item.line };
+}
+
+function normalizeAction(item: FallowIssueLine, raw: Record<string, any> | undefined): string | undefined {
+	const value = item.action || firstAction(raw) || firstText(raw, ["recommendation", "suggested_action"]);
+	return compactOptional(value, MAX_ACTION_CHARS);
+}
+
+function normalizeStats(overview: FallowOverview | undefined): NormalizedStat[] {
+	return (overview?.stats ?? []).slice(0, MAX_STATS).map((stat) => ({
+		label: compactText(stat.label, MAX_SECTION_CHARS),
+		value: typeof stat.value === "number" ? stat.value : compactText(stat.value, MAX_STAT_VALUE_CHARS),
+	}));
+}
+
+function fitEntries(payload: FindingsPayload, key: "findings" | "context", entries: NormalizedFinding[]): void {
+	const target = payload[key];
+	for (const entry of entries) {
+		target.push(entry);
+		updateIncludedCounts(payload);
+		if (withinBudget(renderFindings(payload), FALLOW_DETAIL_BUDGETS.findings)) continue;
+		target.pop();
+		updateIncludedCounts(payload);
+		break;
+	}
+}
+
+function updateIncludedCounts(payload: FindingsPayload): void {
+	payload.included_findings = payload.findings.length;
+	payload.omitted_findings = payload.finding_count - payload.included_findings;
+	payload.included_context = payload.context.length;
+	payload.omitted_context = payload.context_count - payload.included_context;
+}
+
+function renderFindings(payload: FindingsPayload): string {
+	return `${FINDINGS_HEADER}${JSON.stringify(payload)}`;
+}
+
+function withinBudget(text: string, budget: DetailBudget): boolean {
+	if (text.length > budget.characters) return false;
+	// A tokenizer cannot emit more tokens than the non-empty UTF-8 byte sequences it partitions.
+	const tokenUpperBound = Buffer.byteLength(text, "utf8");
+	return Object.values(budget.tokens).every((limit) => tokenUpperBound <= limit);
+}
+
+function fitStringToBudget(
+	value: string,
+	minimumChars: number,
+	render: (candidate: string) => string,
+	budget: DetailBudget,
+): string {
+	if (withinBudget(render(value), budget)) return value;
+	let low = minimumChars;
+	let high = value.length;
+	let best = compactText(value, minimumChars);
+	while (low <= high) {
+		const middle = Math.floor((low + high) / 2);
+		const candidate = compactText(value, middle);
+		if (withinBudget(render(candidate), budget)) {
+			best = candidate;
+			low = middle + 1;
+		} else {
+			high = middle - 1;
+		}
+	}
+	return best;
+}
+
+function firstString(record: Record<string, any> | undefined, keys: string[]): string | undefined {
+	if (!record) return undefined;
+	return keys.map((key) => record[key]).find(isNonEmptyString);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function firstText(record: Record<string, any> | undefined, keys: string[]): string | undefined {
+	const value = firstPresentValue(record, keys);
+	return valueAsText(value);
+}
+
+function firstPresentValue(record: Record<string, any> | undefined, keys: string[]): unknown {
+	if (!record) return undefined;
+	return keys.map((key) => record[key]).find(isPresentValue);
+}
+
+function isPresentValue(value: unknown): boolean {
+	return value !== undefined && value !== null && value !== "";
+}
+
+function valueAsText(value: unknown): string | undefined {
+	if (!isPresentValue(value)) return undefined;
+	if (typeof value === "string") return value;
+	return stringifyValue(value);
+}
+
+function stringifyValue(value: unknown): string {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function firstAction(record: Record<string, any> | undefined): string | undefined {
+	return actionValues(record).map(actionText).find(isNonEmptyString);
+}
+
+function actionValues(record: Record<string, any> | undefined): unknown[] {
+	return Array.isArray(record?.actions) ? record.actions : [];
+}
+
+function actionText(value: unknown): string | undefined {
+	return firstText(asRecord(value), ["description", "type"]);
+}
+
+function compactOptional(value: string | undefined, maxChars: number): string | undefined {
+	return value ? compactText(value, maxChars) : undefined;
+}
+
+function compactText(value: string, maxChars: number): string {
+	if (value.length <= maxChars) return value;
+	if (maxChars <= 1) return value.slice(0, maxChars);
+	return `${safeSlice(value, maxChars - 1)}…`;
+}
+
+function safeSlice(value: string, end: number): string {
+	const sliced = value.slice(0, Math.max(0, end));
+	if (!sliced) return sliced;
+	const finalCode = sliced.charCodeAt(sliced.length - 1);
+	return finalCode >= 0xd800 && finalCode <= 0xdbff ? sliced.slice(0, -1) : sliced;
+}
+
+export const fallowOutputDetail = {
+	budgets: FALLOW_DETAIL_BUDGETS,
+	format: formatSelectedOutputDetail,
+};

--- a/extensions/fallow/output.ts
+++ b/extensions/fallow/output.ts
@@ -4,8 +4,9 @@ import { join } from "node:path";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { asRecord } from "./data";
 import type { ParsedFallowOutput } from "./json";
+import { fallowOutputDetail } from "./output-detail";
 import { buildFallowOverview } from "./overview";
-import type { FallowOverview } from "./types";
+import type { FallowOutputDetail, FallowOverview } from "./types";
 
 function stringifyCompact(value: unknown): string {
 	try {
@@ -106,8 +107,10 @@ export async function formatToolOutput(
 	cwd: string,
 	exitCode = 0,
 	preserveNavigatorDetails = false,
+	outputDetail: FallowOutputDetail = "raw",
 ): Promise<{
 	text: string;
+	errorText: string;
 	summary: string;
 	overview?: FallowOverview;
 	fullOutputPath?: string;
@@ -115,15 +118,51 @@ export async function formatToolOutput(
 }> {
 	const { overview, summary } = buildToolOutputSummary(parsed, exitCode);
 	const rawText = getFormattedRawText(parsed);
-	const truncation = truncateHead(rawText, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES });
-	const fullOutputPath = await writeOutputPathIfNeeded(
-		truncation,
-		rawText,
-		preserveNavigatorDetails && overviewHasFindings(overview),
-	);
-	const text = buildToolOutputText(parsed, summary, truncation, fullOutputPath);
+	const rawTruncation = truncateHead(rawText, { maxLines: DEFAULT_MAX_LINES, maxBytes: DEFAULT_MAX_BYTES });
+	const preserveFullOutput = shouldPreserveFullOutput(outputDetail, rawTruncation.truncated, preserveNavigatorDetails, overview);
+	const fullOutputPath = await writeOutputPathIfNeeded(preserveFullOutput, rawText);
+	const errorText = buildToolOutputText(parsed, summary, rawTruncation, fullOutputPath);
+	const presentation = selectOutputPresentation(outputDetail, parsed, exitCode, summary, overview, fullOutputPath, errorText, rawTruncation.truncated);
+	return { text: presentation.text, errorText, summary, overview, fullOutputPath, truncated: presentation.truncated };
+}
 
-	return { text, summary, overview, fullOutputPath, truncated: truncation.truncated };
+function shouldPreserveFullOutput(
+	outputDetail: FallowOutputDetail,
+	rawTruncated: boolean,
+	preserveNavigatorDetails: boolean,
+	overview: FallowOverview | undefined,
+): boolean {
+	if (rawTruncated || outputDetail !== "raw") return true;
+	return preserveNavigatorDetails && overviewHasFindings(overview);
+}
+
+function selectOutputPresentation(
+	outputDetail: FallowOutputDetail,
+	parsed: ParsedFallowOutput,
+	exitCode: number,
+	summary: string,
+	overview: FallowOverview | undefined,
+	fullOutputPath: string | undefined,
+	rawText: string,
+	rawTruncated: boolean,
+): { text: string; truncated: boolean } {
+	if (outputDetail === "raw") return { text: rawText, truncated: rawTruncated };
+	return formatNonRawOutputDetail(outputDetail, parsed, exitCode, summary, overview, fullOutputPath!);
+}
+
+function formatNonRawOutputDetail(
+	outputDetail: Exclude<FallowOutputDetail, "raw">,
+	parsed: ParsedFallowOutput,
+	exitCode: number,
+	summary: string,
+	overview: FallowOverview | undefined,
+	fullOutputPath: string,
+): ReturnType<typeof fallowOutputDetail.format> {
+	if (outputDetail === "summary" || !parsed.parsed) {
+		return fallowOutputDetail.format(outputDetail, summary, overview, fullOutputPath);
+	}
+	const detailedOverview = buildFallowOverview(parsed.data, exitCode, { includeAllRaw: true });
+	return fallowOutputDetail.format(outputDetail, summary, detailedOverview, fullOutputPath);
 }
 
 function buildToolOutputSummary(
@@ -146,11 +185,10 @@ function overviewHasFindings(overview: FallowOverview | undefined): boolean {
 }
 
 async function writeOutputPathIfNeeded(
-	truncation: ReturnType<typeof truncateHead>,
-	rawText: string,
 	preserveFullOutput: boolean,
+	rawText: string,
 ): Promise<string | undefined> {
-	if (!truncation.truncated && !preserveFullOutput) return undefined;
+	if (!preserveFullOutput) return undefined;
 	const tempDir = await mkdtemp(join(tmpdir(), "pi-fallow-"));
 	const fullOutputPath = join(tempDir, "fallow-output.json");
 	await withFileMutationQueue(fullOutputPath, async () => writeFile(fullOutputPath, rawText, "utf8"));

--- a/extensions/fallow/schema.ts
+++ b/extensions/fallow/schema.ts
@@ -29,7 +29,7 @@ const FallowCommand = StringEnum([
 	"coverage-analyze",
 ] as const);
 
-const OutputDetail = StringEnum(["summary", "findings", "raw"] as const);
+const OutputDetail = StringEnum(["summary", "findings", "raw"] as const, { default: "findings" });
 
 export const fallowRunParams = Type.Object({
 	command: FallowCommand,

--- a/extensions/fallow/types.ts
+++ b/extensions/fallow/types.ts
@@ -1,3 +1,5 @@
+export type FallowOutputDetail = "summary" | "findings" | "raw";
+
 export interface FallowProjectState {
 	configPath?: string;
 	configSource: "file" | "flag" | "none";

--- a/scripts/benchmark-utils.mjs
+++ b/scripts/benchmark-utils.mjs
@@ -38,7 +38,7 @@ export async function populateFallowProject(cwd) {
 	await writeFile(join(cwd, ".fallow", "cache.bin"), "benchmark", "utf8");
 }
 
-export function runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, preserveNavigatorDetails = false }) {
+export function runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, preserveNavigatorDetails = false, outputDetail }) {
 	return fallowEngine.runFallowWithExecutor({
 		pi: {},
 		cwd,
@@ -47,6 +47,7 @@ export function runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, pre
 		timeoutSecs: 120,
 		throwOnExecutionError: false,
 		preserveNavigatorDetails,
+		outputDetail,
 		executor: async (_pi, args) => ({
 			binary: "fallow",
 			args,

--- a/scripts/performance-memory-worker.mjs
+++ b/scripts/performance-memory-worker.mjs
@@ -5,6 +5,8 @@ import { createFallowBenchmarkProject, runFixtureEngine } from "./benchmark-util
 
 const fixtureArg = process.argv[2];
 if (!fixtureArg) throw new Error("A fixture path is required.");
+const outputDetail = process.argv[3];
+if (outputDetail && !["summary", "findings", "raw"].includes(outputDetail)) throw new Error(`Unsupported output detail: ${outputDetail}`);
 const fixturePath = resolve(fixtureArg);
 if (typeof global.gc !== "function") throw new Error("Run the memory worker with --expose-gc.");
 
@@ -35,7 +37,7 @@ process.stdout.write(JSON.stringify({
 
 function runFixture(fixtureText, cwd) {
 	const scenario = { args: ["dead-code", "--format", "json", "--quiet"], exitCode: 0 };
-	return runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd });
+	return runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, outputDetail });
 }
 
 function forceGc() {

--- a/scripts/token-benchmark.mjs
+++ b/scripts/token-benchmark.mjs
@@ -140,28 +140,31 @@ async function measureScenario(scenario, cwd, contract, promptDetail) {
 	const fixtureText = await readFile(fixturePath, "utf8");
 	const fixtureData = JSON.parse(fixtureText);
 	const findings = collectBenchmarkFindings(fixtureData);
-	const commandResult = await runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, preserveNavigatorDetails: true });
+	const [toolResult, commandResult] = await Promise.all([
+		runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, outputDetail: "findings" }),
+		runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, preserveNavigatorDetails: true }),
+	]);
 
-	const fullOutputPath = commandResult.formatted.fullOutputPath;
-	const normalize = (text) => normalizeFullOutputPath(text, fullOutputPath);
+	const toolOutputPath = toolResult.formatted.fullOutputPath;
+	const commandOutputPath = commandResult.formatted.fullOutputPath;
 	const rawReport = JSON.stringify(fixtureData, null, 2);
-	const toolContent = normalize(commandResult.content);
+	const toolContent = normalizeFullOutputPath(toolResult.content, toolOutputPath);
 	const resultPrefix = [
 		formatFallowPrSummaryText(commandResult.prSummary),
 		formatFallowProjectStateText(commandResult.projectState),
 	].filter(Boolean).join("\n");
 	const hasNavigator = !!commandResult.formatted.overview?.sections.some((section) => section.items.length > 0);
-	const slashContent = normalize(buildFallowTranscriptContent(
+	const slashContent = normalizeFullOutputPath(buildFallowTranscriptContent(
 		resultPrefix,
 		commandResult.formatted.summary,
 		commandResult.content,
 		hasNavigator,
-	));
+	), commandOutputPath);
 	const output = [
 		measureText("raw-report", scenario.id, rawReport, findings, { reportFindings: findings.length }),
 		withContextExposure(measureText("tool-result", scenario.id, toolContent, findings, {
 			reportFindings: findings.length,
-			truncated: !!commandResult.formatted.truncated,
+			truncated: !!toolResult.formatted.truncated,
 		}), contract),
 		withContextExposure(measureText("slash-transcript", scenario.id, slashContent, findings, {
 			reportFindings: findings.length,
@@ -175,13 +178,15 @@ async function measureScenario(scenario, cwd, contract, promptDetail) {
 		output.push(...await measurePrompts(
 			scenario,
 			promptOverview,
-			commandResult.formatted.fullOutputPath,
+			commandOutputPath,
 			contract,
 			promptDetail,
 		));
 	}
 
-	if (fullOutputPath) await rm(dirname(fullOutputPath), { recursive: true, force: true });
+	for (const fullOutputPath of new Set([toolOutputPath, commandOutputPath].filter(Boolean))) {
+		await rm(dirname(fullOutputPath), { recursive: true, force: true });
+	}
 	return output;
 }
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -13,6 +13,10 @@ function prepare(params) {
 	return fallowCli.prepareFallowRunParams(params);
 }
 
+function outputDetail(detail) {
+	return fallowCli.resolveFallowOutputDetail(detail);
+}
+
 describe("fallowCli.buildFallowArgs", () => {
 	it("maps compact check-changed args to root --changed-since analysis", () => {
 		assert.deepEqual(build({ command: "check-changed", args: ["--changed-since", "main"] }), [
@@ -93,6 +97,15 @@ describe("fallowCli.buildFallowArgs", () => {
 		assert.throws(() => build({ command: "health", args: ["-f", "human"] }), /must not include --format/);
 		assert.throws(() => build({ command: "fix-preview", args: ["--yes"] }), /must not include --yes/);
 		assert.throws(() => build({ command: "fix-apply", args: ["--dry-run"] }), /must not include --dry-run/);
+	});
+});
+
+describe("fallowCli output detail", () => {
+	it("defaults tool calls to normalized findings", () => {
+		assert.equal(outputDetail(undefined), "findings");
+		assert.equal(outputDetail("summary"), "summary");
+		assert.equal(outputDetail("findings"), "findings");
+		assert.equal(outputDetail("raw"), "raw");
 	});
 });
 

--- a/tests/engine.test.mjs
+++ b/tests/engine.test.mjs
@@ -17,6 +17,7 @@ function runFixture(cwd, data, options = {}) {
 		signal: undefined,
 		timeoutSecs: 10,
 		throwOnExecutionError: options.throwOnExecutionError ?? false,
+		outputDetail: options.outputDetail,
 		executor: async (_pi, args) => ({
 			binary: "fixture-fallow",
 			args,
@@ -71,6 +72,22 @@ describe("Fallow engine result retention", () => {
 			assert.match(result.content, /Raw JSON:/);
 		} finally {
 			await rm(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("applies requested detail without retaining the raw presentation", async () => {
+		const cwd = await mkdtemp(join(tmpdir(), "pi-fallow-engine-detail-"));
+		let fullOutputPath;
+		try {
+			const result = await runFixture(cwd, largeReport(), { outputDetail: "findings", code: 1 });
+			fullOutputPath = result.formatted.fullOutputPath;
+			assert.match(result.content, /Fallow findings:/);
+			assert.doesNotMatch(result.content, /Raw JSON:/);
+			assert.ok(fullOutputPath);
+			assert.equal("errorText" in result.formatted, false);
+		} finally {
+			await rm(cwd, { recursive: true, force: true });
+			if (fullOutputPath) await rm(dirname(fullOutputPath), { recursive: true, force: true });
 		}
 	});
 

--- a/tests/execution.test.mjs
+++ b/tests/execution.test.mjs
@@ -143,6 +143,23 @@ describe("Fallow process execution", () => {
 		}
 	});
 
+	it("uses normalized findings by default for the real tool execution path", async () => {
+		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-tool-detail-"));
+		let fullOutputPath;
+		try {
+			await withFixture("success", async () => {
+				const result = await fallowCli.runFallow({}, { command: "dead-code" }, { cwd: workspace });
+				fullOutputPath = result.details.fullOutputPath;
+				assert.match(result.content[0].text, /Fallow findings:/);
+				assert.doesNotMatch(result.content[0].text, /Raw JSON:/);
+				assert.ok(fullOutputPath);
+			});
+		} finally {
+			await rm(workspace, { recursive: true, force: true });
+			if (fullOutputPath) await rm(dirname(fullOutputPath), { recursive: true, force: true });
+		}
+	});
+
 	it("uses the tool signal instead of an unrelated context signal", async () => {
 		const workspace = await mkdtemp(join(tmpdir(), "pi-fallow-tool-"));
 		try {

--- a/tests/memory.test.mjs
+++ b/tests/memory.test.mjs
@@ -7,29 +7,31 @@ import { describe, it } from "node:test";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const execFileAsync = promisify(execFile);
-const MAX_RETAINED_AMPLIFICATION = 2;
+const DEFAULT_MAX_RETAINED_AMPLIFICATION = 2;
 // V8 coverage retains instrumentation counters globally, so its heap delta is not a product-memory measurement.
 const memoryTest = process.env.NODE_V8_COVERAGE ? it.skip : it;
 
 const scenarios = [
 	["large findings", "benchmarks/fixtures/large-findings.json"],
+	["large normalized findings", "benchmarks/fixtures/large-findings.json", "findings", 2.1],
 	["schema", "benchmarks/fixtures/schema.json"],
 ];
 
 describe("Fallow retained memory", { concurrency: false }, () => {
-	for (const [name, fixture] of scenarios) {
-		memoryTest(`keeps ${name} below two retained full-size copies`, async () => {
+	for (const [name, fixture, outputDetail, configuredMax] of scenarios) {
+		const maxRetainedAmplification = configuredMax ?? DEFAULT_MAX_RETAINED_AMPLIFICATION;
+		memoryTest(`keeps ${name} below ${maxRetainedAmplification}x retained amplification`, async () => {
 			const { stdout } = await execFileAsync(
 				process.execPath,
-				["--expose-gc", "scripts/performance-memory-worker.mjs", fixture],
+				["--expose-gc", "scripts/performance-memory-worker.mjs", fixture, ...(outputDetail ? [outputDetail] : [])],
 				{ cwd: root, encoding: "utf8", maxBuffer: 1024 * 1024 },
 			);
 			const measurement = JSON.parse(stdout);
 			const retainedBytes = measurement.deltaWhileRetained.heapUsedBytes;
 			const amplification = retainedBytes / measurement.fixtureBytes;
 			assert.ok(
-				amplification <= MAX_RETAINED_AMPLIFICATION,
-				`${name} retained amplification ${amplification.toFixed(2)}x exceeds ${MAX_RETAINED_AMPLIFICATION}x`,
+				amplification <= maxRetainedAmplification,
+				`${name} retained amplification ${amplification.toFixed(2)}x exceeds ${maxRetainedAmplification}x`,
 			);
 		});
 	}

--- a/tests/output.test.mjs
+++ b/tests/output.test.mjs
@@ -2,11 +2,19 @@ import assert from "node:assert/strict";
 import { readFile, rm } from "node:fs/promises";
 import { dirname } from "node:path";
 import { describe, it } from "node:test";
+import { getEncoding } from "js-tiktoken";
 import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
 const { parseJson } = await jiti.import("../extensions/fallow/json.ts");
 const { formatToolOutput } = await jiti.import("../extensions/fallow/output.ts");
+const { fallowOutputDetail } = await jiti.import("../extensions/fallow/output-detail.ts");
+const FALLOW_DETAIL_BUDGETS = fallowOutputDetail.budgets;
+const DETAIL_TOKEN_REGRESSION_TARGETS = { summary: 1_200, findings: 2_200 };
+const tokenizers = {
+	o200k_base: getEncoding("o200k_base"),
+	cl100k_base: getEncoding("cl100k_base"),
+};
 
 describe("parseJson", () => {
 	it("parses direct JSON from stdout", () => {
@@ -101,6 +109,49 @@ describe("parseJson", () => {
 	});
 });
 
+function detailedReport(count = 1) {
+	return {
+		kind: "dead-code",
+		total_issues: count,
+		summary: { unused_exports: count },
+		unused_exports: Array.from({ length: count }, (_, index) => ({
+			benchmark_id: `finding-${index}`,
+			kind: "unused-export",
+			export_name: `unusedExport${index}`,
+			path: `src/generated/file-${index}.ts`,
+			line: index + 1,
+			severity: index % 2 ? "medium" : "high",
+			evidence: `No reachable consumer was found for unusedExport${index}.`,
+			actions: [
+				{ type: "suppress-line", description: `Suppress unusedExport${index}.` },
+				{ type: "remove-export", description: `Remove unusedExport${index}.` },
+			],
+			long_detail: "x".repeat(2_000),
+		})),
+	};
+}
+
+async function removeFullOutput(result) {
+	if (result.fullOutputPath) await rm(dirname(result.fullOutputPath), { recursive: true, force: true });
+}
+
+function assertWithinDetailBudgets(detail, text) {
+	const budget = FALLOW_DETAIL_BUDGETS[detail];
+	assert.ok(text.length <= budget.characters, `${detail} output exceeded its character budget.`);
+	for (const [encoding, tokenizer] of Object.entries(tokenizers)) {
+		assert.ok(tokenizer.encode(text).length <= budget.tokens[encoding], `${detail} output exceeded its ${encoding} token budget.`);
+	}
+}
+
+function assertWithinTokenRegressionTarget(detail, text) {
+	for (const [encoding, tokenizer] of Object.entries(tokenizers)) {
+		assert.ok(
+			tokenizer.encode(text).length <= DETAIL_TOKEN_REGRESSION_TARGETS[detail],
+			`${detail} output exceeded its ${encoding} token regression target.`,
+		);
+	}
+}
+
 describe("formatToolOutput", () => {
 	it("builds structured summaries and overview data for parsed output", async () => {
 		const parsed = parseJson(JSON.stringify({
@@ -175,5 +226,139 @@ describe("formatToolOutput", () => {
 		assert.equal(result.summary, "No structured summary available.");
 		assert.equal(result.overview, undefined);
 		assert.match(result.text, /Raw output:\nplain fallow output/);
+	});
+
+	it("returns bounded summary status and counts while retaining the complete report", async () => {
+		const report = detailedReport(20);
+		const result = await formatToolOutput(parseJson(JSON.stringify(report), ""), process.cwd(), 1, false, "summary");
+		try {
+			assert.match(result.text, /^Fallow summary:/);
+			const payload = JSON.parse(result.text.slice("Fallow summary:\n".length));
+			assert.equal(payload.status, "warning");
+			assert.equal(payload.finding_count, 20);
+			assert.equal(payload.complete_output_path, result.fullOutputPath);
+			assert.doesNotMatch(result.text, /unusedExport0/);
+			assert.ok(result.fullOutputPath);
+			assert.equal(await readFile(result.fullOutputPath, "utf8"), JSON.stringify(report, null, 2));
+			assertWithinDetailBudgets("summary", result.text);
+			assertWithinTokenRegressionTarget("summary", result.text);
+		} finally {
+			await removeFullOutput(result);
+		}
+	});
+
+	it("reports different statuses for the same summary body at different exit codes", async () => {
+		const parsed = parseJson(JSON.stringify({ kind: "health", findings: [], summary: { files_analyzed: 1 } }), "");
+		const success = await formatToolOutput(parsed, process.cwd(), 0, false, "summary");
+		const warning = await formatToolOutput(parsed, process.cwd(), 1, false, "summary");
+		try {
+			const successPayload = JSON.parse(success.text.slice("Fallow summary:\n".length));
+			const warningPayload = JSON.parse(warning.text.slice("Fallow summary:\n".length));
+			assert.equal(successPayload.status, "success");
+			assert.equal(warningPayload.status, "warning");
+			assert.equal(successPayload.finding_count, warningPayload.finding_count);
+		} finally {
+			await removeFullOutput(success);
+			await removeFullOutput(warning);
+		}
+	});
+
+	it("truncates oversized summaries within both regression budgets", async () => {
+		const report = { kind: "health", summary: { diagnostic: "x".repeat(20_000) } };
+		const result = await formatToolOutput(parseJson(JSON.stringify(report), ""), process.cwd(), 0, false, "summary");
+		try {
+			const payload = JSON.parse(result.text.slice("Fallow summary:\n".length));
+			assert.equal(result.truncated, true);
+			assert.equal(payload.summary_truncated, true);
+			assert.equal(payload.status, "success");
+			assert.equal(payload.finding_count, 0);
+			assertWithinDetailBudgets("summary", result.text);
+			assertWithinTokenRegressionTarget("summary", result.text);
+		} finally {
+			await removeFullOutput(result);
+		}
+	});
+
+	it("returns bounded normalized findings with locations, evidence, and actions", async () => {
+		const report = detailedReport(100);
+		const result = await formatToolOutput(parseJson(JSON.stringify(report), ""), process.cwd(), 1, false, "findings");
+		try {
+			assert.match(result.text, /^Fallow findings:/);
+			const payload = JSON.parse(result.text.slice("Fallow findings:\n".length));
+			assert.equal(payload.detail, "findings");
+			assert.equal(payload.finding_count, 100);
+			assert.ok(payload.included_findings > 0);
+			assert.ok(payload.omitted_findings > 0);
+			assert.deepEqual(payload.findings[0], {
+				section: "Unused exports",
+				type: "unused-export",
+				id: "finding-0",
+				severity: "high",
+				location: { path: "src/generated/file-0.ts", line: 1 },
+				subject: "unusedExport0",
+				evidence: "No reachable consumer was found for unusedExport0.",
+				action: "Remove unusedExport0.",
+			});
+			assert.equal(payload.complete_output_path, result.fullOutputPath);
+			assert.doesNotMatch(result.text, /long_detail/);
+			assert.equal(result.truncated, true);
+			assert.equal(result.overview.sections[0].items[5].raw, undefined);
+			assert.equal(await readFile(result.fullOutputPath, "utf8"), JSON.stringify(report, null, 2));
+			assertWithinDetailBudgets("findings", result.text);
+			assertWithinTokenRegressionTarget("findings", result.text);
+		} finally {
+			await removeFullOutput(result);
+		}
+	});
+
+	it("returns normalized context when an informational report has no actionable findings", async () => {
+		const report = {
+			kind: "health",
+			findings: [],
+			file_scores: [{ path: "src/risky.ts", maintainability_index: 51, lines: 200, dead_code_ratio: 0.1, crap_max: 20 }],
+		};
+		const result = await formatToolOutput(parseJson(JSON.stringify(report), ""), process.cwd(), 0, false, "findings");
+		try {
+			const payload = JSON.parse(result.text.slice("Fallow findings:\n".length));
+			assert.equal(payload.finding_count, 0);
+			assert.equal(payload.context_count, 1);
+			assert.equal(payload.included_context, 1);
+			assert.equal(payload.context[0].location.path, "src/risky.ts");
+		} finally {
+			await removeFullOutput(result);
+		}
+	});
+
+	it("keeps multilingual summary and findings output valid and within both hard budgets", () => {
+		const overview = {
+			title: "漢".repeat(2_000),
+			status: "warning",
+			stats: Array.from({ length: 20 }, (_, index) => ({ label: `stat-${index}`, value: "漢".repeat(500) })),
+			sections: [],
+			notes: Array.from({ length: 20 }, () => "漢".repeat(1_000)),
+		};
+		for (const detail of ["summary", "findings"]) {
+			const result = fallowOutputDetail.format(detail, "漢".repeat(20_000), overview, "/tmp/fallow-output.json");
+			const payload = JSON.parse(result.text.slice(`Fallow ${detail}:\n`.length));
+			assert.equal(payload.complete_output_path, "/tmp/fallow-output.json");
+			assertWithinDetailBudgets(detail, result.text);
+		}
+	});
+
+	it("keeps raw detail backward compatible and uses raw text for execution errors", async () => {
+		const report = detailedReport(1);
+		const raw = await formatToolOutput(parseJson(JSON.stringify(report), ""), process.cwd(), 1, false, "raw");
+		assert.match(raw.text, /Raw JSON:/);
+		assert.match(raw.text, /long_detail/);
+		assert.equal(raw.fullOutputPath, undefined);
+
+		const summary = await formatToolOutput({ parsed: false, raw: "plain execution failure" }, process.cwd(), 2, false, "summary");
+		try {
+			assert.doesNotMatch(summary.text, /plain execution failure/);
+			assert.match(summary.errorText, /Raw output:\nplain execution failure/);
+			assert.equal(await readFile(summary.fullOutputPath, "utf8"), "plain execution failure");
+		} finally {
+			await removeFullOutput(summary);
+		}
 	});
 });

--- a/tests/tool-contract.test.mjs
+++ b/tests/tool-contract.test.mjs
@@ -13,6 +13,7 @@ describe("fallow_run compact contract", () => {
 			"command", "args", "root", "timeoutSecs", "detail",
 		]);
 		assert.equal(tool.parameters.additionalProperties, false);
+		assert.equal(tool.parameters.properties.detail.default, "findings");
 		assert.equal(tool.promptSnippet, undefined);
 		assert.equal(tool.promptGuidelines, undefined);
 		assert.match(tool.description, /type-aware impact/);


### PR DESCRIPTION
## Summary

- make the public `fallow_run.detail` parameter effective and default tool calls to `findings`
- add bounded structured `summary` and normalized `findings` presentations while preserving the existing bounded `raw` presentation
- retain complete non-raw reports in private OS temporary directories and expose their paths
- keep execution failures on raw diagnostic text and preserve slash-command/navigator behavior
- add hard character/token bounds, tighter tokenizer regression targets, retained-memory coverage, and tool-result benchmark coverage

## User-visible changes

`fallow_run.detail` now behaves as documented:

- `summary` returns structured status, finding/context counts, key stats/notes, omission metadata, and a complete-report path
- `findings` returns normalized actionable findings with type/ID, severity, location, evidence, preferred action, inclusion/omission counts, and a complete-report path; informational context is returned when there are no actionable findings
- `raw` retains the prior bounded raw JSON/output behavior

Tool calls default to `findings`. `/fallow`, the navigator, and TUI rendering remain on the existing raw path and are unchanged.

## Performance and token impact

Frozen-corpus comparison against the v0.2.0 baseline (`o200k_base`):

- tool-result tokens: **45,104 → 8,046** (**82.16% reduction**)
- tool-result maximum: **1,504 tokens**
- slash-transcript tokens: **12,645 → 12,645** (unchanged)
- every omitted tool-result finding set retained a complete-output reference
- all five small findings remained inline; larger reports retained normalized leading findings plus exact omission counts

Hard runtime output budgets use character caps plus a conservative UTF-8 byte upper bound for both `o200k_base` and `cl100k_base`. Representative-output regression targets remain tighter at 1,200 summary tokens and 2,200 findings tokens. Large normalized-result retained heap remains below the explicit 2.1x fixture ceiling.

## Validation

- [x] `npm test` — 142 passed
- [x] `npm run check:bundle`
- [x] `npm run health` — 0 findings, health 85.5/A, maintainability 92
- [x] `npm run dupes` — 0 clone groups
- [x] `npm run dead-code` — 0 issues
- [x] `npm run coverage` — thresholds passed
- [x] `npm run pack:check` — 54 files
- [x] `npm run package:smoke` — Pi 0.84.1 RPC/print/JSON certification passed
- [x] `npm run smoke:fallow`
- [x] `npm run audit:production` — 0 vulnerabilities
- [x] `npm run audit:all` — 0 vulnerabilities
- [x] `npm run check:publish`
- [x] token benchmark and frozen-baseline comparison
- [x] independent two-round review — approved after token-bound, structured-summary, preferred-action, and TUI-isolation corrections

## Security and release considerations

No dependency, lockfile, workflow, permission, peer-range, or packaging changes. Complete reports are written beneath `mkdtemp`-created private OS temporary directories. Pi host packages remain external and the package smoke gate confirms no bundled runtime dependencies or `node_modules`.

This PR does not tag, publish, or create a release.
