### PR TITLE
Preserve pre-output-detail token baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Pi Fallow are documented here.
 
 ## [Unreleased]
 
+### Added
+- Added an immediate pre-output-detail token benchmark baseline for reproducible before/after release evidence.
+
 ### Changed
 - Upgraded the coordinated Pi development packages to 0.84.0, incorporating the upstream dependency security fix.
 - Removed the temporary development-audit vulnerability acceptance after the upstream fix; CI and release validation now strictly audit the complete dependency tree.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -55,6 +55,33 @@ npm run bench:tokens:compare -- \
   /tmp/pi-fallow-token-candidate.json
 ```
 
+## Immediate baseline before `fallow_run.detail`
+
+[`baselines/v0.4.0-pre-output-detail.json`](./baselines/v0.4.0-pre-output-detail.json) freezes commit `2350b0a5f19abfa51d1fd53fa6abf7d7eb0938da`, immediately before `fallow_run.detail` became effective. Use this baseline for release evidence that isolates the output-detail change from earlier token optimizations:
+
+```bash
+npm run bench:tokens -- \
+  --label release-candidate \
+  --output /tmp/pi-fallow-token-release.json
+npm run bench:tokens:compare -- \
+  benchmarks/baselines/v0.4.0-pre-output-detail.json \
+  /tmp/pi-fallow-token-release.json
+```
+
+The post-change measurement at merge commit `c208eb88ef7d7a276ed56e0c150bc4383d43938a` produced:
+
+| Surface/scenario (`o200k_base`) | Before | After | Inline finding retention after |
+|---|---:|---:|---:|
+| All tool results | 45,104 | 8,046 | bounded per scenario |
+| No-findings tool result | 309 | 233 | not applicable |
+| 5-finding tool result | 1,064 | 738 | 5/5, 100% required raw-field retention |
+| 40-finding tool result | 6,403 | 1,315 | 11/40, 100% required raw-field retention |
+| 300-finding tool result | 12,416 | 1,311 | 11/300, 100% required raw-field retention |
+| Schema tool result | 11,497 | 173 | not applicable |
+| All slash transcripts | 12,645 | 12,645 | unchanged |
+
+This is an **82.16%** aggregate tool-result reduction, not a claim that omitted findings disappeared: bounded results report exact inclusion/omission counts and retain a complete-output reference. The small report remains complete inline, and contract tests separately verify normalized location, evidence, and preferred-action fields.
+
 ## `0.2.0` before findings
 
 Primary `o200k_base` measurements:

--- a/benchmarks/baselines/v0.4.0-pre-output-detail.json
+++ b/benchmarks/baselines/v0.4.0-pre-output-detail.json
@@ -1,0 +1,1838 @@
+{
+  "benchmarkVersion": 1,
+  "label": "v0.4.0-pre-output-detail",
+  "generatedAt": "2026-08-11T09:15:09.454Z",
+  "corpusHash": "sha256:797662e9f1331e272aed39c5b61a600a841018341c15047355add5fc20c2555e",
+  "primaryEncoding": "o200k_base",
+  "promptDetail": "compact",
+  "tokenizers": [
+    {
+      "encoding": "o200k_base",
+      "implementation": "js-tiktoken",
+      "version": "1.0.21"
+    },
+    {
+      "encoding": "cl100k_base",
+      "implementation": "js-tiktoken",
+      "version": "1.0.21"
+    }
+  ],
+  "environment": {
+    "piFallowVersion": "0.4.0",
+    "gitSha": "2350b0a5f19abfa51d1fd53fa6abf7d7eb0938da",
+    "node": "v24.12.0",
+    "platform": "darwin",
+    "arch": "arm64"
+  },
+  "measurements": [
+    {
+      "key": "tool-contract/active",
+      "surface": "tool-contract",
+      "scenario": "active",
+      "characters": 1413,
+      "utf8Bytes": 1413,
+      "lines": 64,
+      "tokens": {
+        "o200k_base": 338,
+        "cl100k_base": 338
+      },
+      "quality": {
+        "expectedFindings": 0,
+        "includedFindings": 0,
+        "omittedFindings": 0,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      }
+    },
+    {
+      "key": "raw-report/no-findings",
+      "surface": "raw-report",
+      "scenario": "no-findings",
+      "characters": 612,
+      "utf8Bytes": 612,
+      "lines": 29,
+      "tokens": {
+        "o200k_base": 185,
+        "cl100k_base": 182
+      },
+      "quality": {
+        "expectedFindings": 0,
+        "includedFindings": 0,
+        "omittedFindings": 0,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 0
+    },
+    {
+      "key": "tool-result/no-findings",
+      "surface": "tool-result",
+      "scenario": "no-findings",
+      "characters": 1012,
+      "utf8Bytes": 1012,
+      "lines": 37,
+      "tokens": {
+        "o200k_base": 309,
+        "cl100k_base": 303
+      },
+      "quality": {
+        "expectedFindings": 0,
+        "includedFindings": 0,
+        "omittedFindings": 0,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 0,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 647,
+          "fiveTurnExposure": 3235
+        },
+        "cl100k_base": {
+          "nextTurnTax": 641,
+          "fiveTurnExposure": 3205
+        }
+      }
+    },
+    {
+      "key": "slash-transcript/no-findings",
+      "surface": "slash-transcript",
+      "scenario": "no-findings",
+      "characters": 1012,
+      "utf8Bytes": 1012,
+      "lines": 37,
+      "tokens": {
+        "o200k_base": 309,
+        "cl100k_base": 303
+      },
+      "quality": {
+        "expectedFindings": 0,
+        "includedFindings": 0,
+        "omittedFindings": 0,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 0,
+      "hasNavigator": false,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 647,
+          "fiveTurnExposure": 3235
+        },
+        "cl100k_base": {
+          "nextTurnTax": 641,
+          "fiveTurnExposure": 3205
+        }
+      }
+    },
+    {
+      "key": "raw-report/small-findings",
+      "surface": "raw-report",
+      "scenario": "small-findings",
+      "characters": 3718,
+      "utf8Bytes": 3718,
+      "lines": 114,
+      "tokens": {
+        "o200k_base": 940,
+        "cl100k_base": 932
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 30,
+        "retainedFields": 30,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 5
+    },
+    {
+      "key": "tool-result/small-findings",
+      "surface": "tool-result",
+      "scenario": "small-findings",
+      "characters": 4118,
+      "utf8Bytes": 4118,
+      "lines": 122,
+      "tokens": {
+        "o200k_base": 1064,
+        "cl100k_base": 1053
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 30,
+        "retainedFields": 30,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 5,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 1402,
+          "fiveTurnExposure": 7010
+        },
+        "cl100k_base": {
+          "nextTurnTax": 1391,
+          "fiveTurnExposure": 6955
+        }
+      }
+    },
+    {
+      "key": "slash-transcript/small-findings",
+      "surface": "slash-transcript",
+      "scenario": "small-findings",
+      "characters": 403,
+      "utf8Bytes": 403,
+      "lines": 6,
+      "tokens": {
+        "o200k_base": 122,
+        "cl100k_base": 119
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 0,
+        "omittedFindings": 5,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 5,
+      "hasNavigator": true,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 460,
+          "fiveTurnExposure": 2300
+        },
+        "cl100k_base": {
+          "nextTurnTax": 457,
+          "fiveTurnExposure": 2285
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/small-findings:1",
+      "surface": "editor-prompt",
+      "scenario": "small-findings:1",
+      "characters": 818,
+      "utf8Bytes": 822,
+      "lines": 14,
+      "tokens": {
+        "o200k_base": 181,
+        "cl100k_base": 180
+      },
+      "quality": {
+        "expectedFindings": 1,
+        "includedFindings": 1,
+        "omittedFindings": 0,
+        "requiredFields": 6,
+        "retainedFields": 4,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 5,
+      "selectedRows": 1,
+      "availableRows": 5,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 519,
+          "fiveTurnExposure": 2595
+        },
+        "cl100k_base": {
+          "nextTurnTax": 518,
+          "fiveTurnExposure": 2590
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/small-findings:5",
+      "surface": "editor-prompt",
+      "scenario": "small-findings:5",
+      "characters": 1777,
+      "utf8Bytes": 1797,
+      "lines": 21,
+      "tokens": {
+        "o200k_base": 412,
+        "cl100k_base": 411
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 30,
+        "retainedFields": 20,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 5,
+      "selectedRows": 5,
+      "availableRows": 5,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 750,
+          "fiveTurnExposure": 3750
+        },
+        "cl100k_base": {
+          "nextTurnTax": 749,
+          "fiveTurnExposure": 3745
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/small-findings:all",
+      "surface": "editor-prompt",
+      "scenario": "small-findings:all",
+      "characters": 1777,
+      "utf8Bytes": 1797,
+      "lines": 21,
+      "tokens": {
+        "o200k_base": 412,
+        "cl100k_base": 411
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 30,
+        "retainedFields": 20,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 5,
+      "selectedRows": 5,
+      "availableRows": 5,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 750,
+          "fiveTurnExposure": 3750
+        },
+        "cl100k_base": {
+          "nextTurnTax": 749,
+          "fiveTurnExposure": 3745
+        }
+      }
+    },
+    {
+      "key": "raw-report/medium-findings",
+      "surface": "raw-report",
+      "scenario": "medium-findings",
+      "characters": 26080,
+      "utf8Bytes": 26080,
+      "lines": 687,
+      "tokens": {
+        "o200k_base": 6279,
+        "cl100k_base": 6236
+      },
+      "quality": {
+        "expectedFindings": 40,
+        "includedFindings": 40,
+        "omittedFindings": 0,
+        "requiredFields": 240,
+        "retainedFields": 240,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 40
+    },
+    {
+      "key": "tool-result/medium-findings",
+      "surface": "tool-result",
+      "scenario": "medium-findings",
+      "characters": 26482,
+      "utf8Bytes": 26482,
+      "lines": 695,
+      "tokens": {
+        "o200k_base": 6403,
+        "cl100k_base": 6357
+      },
+      "quality": {
+        "expectedFindings": 40,
+        "includedFindings": 40,
+        "omittedFindings": 0,
+        "requiredFields": 240,
+        "retainedFields": 240,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 40,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 6741,
+          "fiveTurnExposure": 33705
+        },
+        "cl100k_base": {
+          "nextTurnTax": 6695,
+          "fiveTurnExposure": 33475
+        }
+      }
+    },
+    {
+      "key": "slash-transcript/medium-findings",
+      "surface": "slash-transcript",
+      "scenario": "medium-findings",
+      "characters": 405,
+      "utf8Bytes": 405,
+      "lines": 6,
+      "tokens": {
+        "o200k_base": 122,
+        "cl100k_base": 119
+      },
+      "quality": {
+        "expectedFindings": 40,
+        "includedFindings": 0,
+        "omittedFindings": 40,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 40,
+      "hasNavigator": true,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 460,
+          "fiveTurnExposure": 2300
+        },
+        "cl100k_base": {
+          "nextTurnTax": 457,
+          "fiveTurnExposure": 2285
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/medium-findings:1",
+      "surface": "editor-prompt",
+      "scenario": "medium-findings:1",
+      "characters": 818,
+      "utf8Bytes": 822,
+      "lines": 14,
+      "tokens": {
+        "o200k_base": 181,
+        "cl100k_base": 180
+      },
+      "quality": {
+        "expectedFindings": 1,
+        "includedFindings": 1,
+        "omittedFindings": 0,
+        "requiredFields": 6,
+        "retainedFields": 4,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 40,
+      "selectedRows": 1,
+      "availableRows": 40,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 519,
+          "fiveTurnExposure": 2595
+        },
+        "cl100k_base": {
+          "nextTurnTax": 518,
+          "fiveTurnExposure": 2590
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/medium-findings:5",
+      "surface": "editor-prompt",
+      "scenario": "medium-findings:5",
+      "characters": 1693,
+      "utf8Bytes": 1713,
+      "lines": 18,
+      "tokens": {
+        "o200k_base": 401,
+        "cl100k_base": 400
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 30,
+        "retainedFields": 20,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 40,
+      "selectedRows": 5,
+      "availableRows": 40,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 739,
+          "fiveTurnExposure": 3695
+        },
+        "cl100k_base": {
+          "nextTurnTax": 738,
+          "fiveTurnExposure": 3690
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/medium-findings:20",
+      "surface": "editor-prompt",
+      "scenario": "medium-findings:20",
+      "characters": 5287,
+      "utf8Bytes": 5367,
+      "lines": 36,
+      "tokens": {
+        "o200k_base": 1236,
+        "cl100k_base": 1243
+      },
+      "quality": {
+        "expectedFindings": 20,
+        "includedFindings": 20,
+        "omittedFindings": 0,
+        "requiredFields": 120,
+        "retainedFields": 80,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 40,
+      "selectedRows": 20,
+      "availableRows": 40,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 1574,
+          "fiveTurnExposure": 7870
+        },
+        "cl100k_base": {
+          "nextTurnTax": 1581,
+          "fiveTurnExposure": 7905
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/medium-findings:all",
+      "surface": "editor-prompt",
+      "scenario": "medium-findings:all",
+      "characters": 10043,
+      "utf8Bytes": 10203,
+      "lines": 60,
+      "tokens": {
+        "o200k_base": 2306,
+        "cl100k_base": 2316
+      },
+      "quality": {
+        "expectedFindings": 40,
+        "includedFindings": 40,
+        "omittedFindings": 0,
+        "requiredFields": 240,
+        "retainedFields": 160,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 40,
+      "selectedRows": 40,
+      "availableRows": 40,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 2644,
+          "fiveTurnExposure": 13220
+        },
+        "cl100k_base": {
+          "nextTurnTax": 2654,
+          "fiveTurnExposure": 13270
+        }
+      }
+    },
+    {
+      "key": "raw-report/large-findings",
+      "surface": "raw-report",
+      "scenario": "large-findings",
+      "characters": 185041,
+      "utf8Bytes": 185041,
+      "lines": 4830,
+      "tokens": {
+        "o200k_base": 44062,
+        "cl100k_base": 43759
+      },
+      "quality": {
+        "expectedFindings": 300,
+        "includedFindings": 300,
+        "omittedFindings": 0,
+        "requiredFields": 1800,
+        "retainedFields": 1800,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 300
+    },
+    {
+      "key": "tool-result/large-findings",
+      "surface": "tool-result",
+      "scenario": "large-findings",
+      "characters": 51715,
+      "utf8Bytes": 51715,
+      "lines": 1354,
+      "tokens": {
+        "o200k_base": 12416,
+        "cl100k_base": 12328
+      },
+      "quality": {
+        "expectedFindings": 300,
+        "includedFindings": 84,
+        "omittedFindings": 216,
+        "requiredFields": 504,
+        "retainedFields": 501,
+        "requiredFieldRetentionPct": 99.4,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 300,
+      "truncated": true,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 12754,
+          "fiveTurnExposure": 63770
+        },
+        "cl100k_base": {
+          "nextTurnTax": 12666,
+          "fiveTurnExposure": 63330
+        }
+      }
+    },
+    {
+      "key": "slash-transcript/large-findings",
+      "surface": "slash-transcript",
+      "scenario": "large-findings",
+      "characters": 409,
+      "utf8Bytes": 409,
+      "lines": 6,
+      "tokens": {
+        "o200k_base": 122,
+        "cl100k_base": 119
+      },
+      "quality": {
+        "expectedFindings": 300,
+        "includedFindings": 0,
+        "omittedFindings": 300,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 300,
+      "hasNavigator": true,
+      "truncated": true,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 460,
+          "fiveTurnExposure": 2300
+        },
+        "cl100k_base": {
+          "nextTurnTax": 457,
+          "fiveTurnExposure": 2285
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/large-findings:1",
+      "surface": "editor-prompt",
+      "scenario": "large-findings:1",
+      "characters": 826,
+      "utf8Bytes": 830,
+      "lines": 14,
+      "tokens": {
+        "o200k_base": 180,
+        "cl100k_base": 179
+      },
+      "quality": {
+        "expectedFindings": 1,
+        "includedFindings": 1,
+        "omittedFindings": 0,
+        "requiredFields": 6,
+        "retainedFields": 4,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 300,
+      "selectedRows": 1,
+      "availableRows": 300,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 518,
+          "fiveTurnExposure": 2590
+        },
+        "cl100k_base": {
+          "nextTurnTax": 517,
+          "fiveTurnExposure": 2585
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/large-findings:5",
+      "surface": "editor-prompt",
+      "scenario": "large-findings:5",
+      "characters": 1725,
+      "utf8Bytes": 1745,
+      "lines": 18,
+      "tokens": {
+        "o200k_base": 396,
+        "cl100k_base": 399
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 30,
+        "retainedFields": 20,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 300,
+      "selectedRows": 5,
+      "availableRows": 300,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 734,
+          "fiveTurnExposure": 3670
+        },
+        "cl100k_base": {
+          "nextTurnTax": 737,
+          "fiveTurnExposure": 3685
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/large-findings:all",
+      "surface": "editor-prompt",
+      "scenario": "large-findings:all",
+      "characters": 69225,
+      "utf8Bytes": 70425,
+      "lines": 313,
+      "tokens": {
+        "o200k_base": 16035,
+        "cl100k_base": 16333
+      },
+      "quality": {
+        "expectedFindings": 300,
+        "includedFindings": 300,
+        "omittedFindings": 0,
+        "requiredFields": 1800,
+        "retainedFields": 1200,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 300,
+      "selectedRows": 300,
+      "availableRows": 300,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 16373,
+          "fiveTurnExposure": 81865
+        },
+        "cl100k_base": {
+          "nextTurnTax": 16671,
+          "fiveTurnExposure": 83355
+        }
+      }
+    },
+    {
+      "key": "raw-report/audit-findings",
+      "surface": "raw-report",
+      "scenario": "audit-findings",
+      "characters": 29276,
+      "utf8Bytes": 29276,
+      "lines": 759,
+      "tokens": {
+        "o200k_base": 6755,
+        "cl100k_base": 6748
+      },
+      "quality": {
+        "expectedFindings": 40,
+        "includedFindings": 40,
+        "omittedFindings": 0,
+        "requiredFields": 240,
+        "retainedFields": 240,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 40
+    },
+    {
+      "key": "tool-result/audit-findings",
+      "surface": "tool-result",
+      "scenario": "audit-findings",
+      "characters": 30239,
+      "utf8Bytes": 30239,
+      "lines": 776,
+      "tokens": {
+        "o200k_base": 7037,
+        "cl100k_base": 7026
+      },
+      "quality": {
+        "expectedFindings": 40,
+        "includedFindings": 40,
+        "omittedFindings": 0,
+        "requiredFields": 240,
+        "retainedFields": 240,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 40,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 7375,
+          "fiveTurnExposure": 36875
+        },
+        "cl100k_base": {
+          "nextTurnTax": 7364,
+          "fiveTurnExposure": 36820
+        }
+      }
+    },
+    {
+      "key": "slash-transcript/audit-findings",
+      "surface": "slash-transcript",
+      "scenario": "audit-findings",
+      "characters": 966,
+      "utf8Bytes": 966,
+      "lines": 15,
+      "tokens": {
+        "o200k_base": 280,
+        "cl100k_base": 276
+      },
+      "quality": {
+        "expectedFindings": 40,
+        "includedFindings": 0,
+        "omittedFindings": 40,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 40,
+      "hasNavigator": true,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 618,
+          "fiveTurnExposure": 3090
+        },
+        "cl100k_base": {
+          "nextTurnTax": 614,
+          "fiveTurnExposure": 3070
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/audit-findings:1",
+      "surface": "editor-prompt",
+      "scenario": "audit-findings:1",
+      "characters": 861,
+      "utf8Bytes": 866,
+      "lines": 14,
+      "tokens": {
+        "o200k_base": 191,
+        "cl100k_base": 190
+      },
+      "quality": {
+        "expectedFindings": 1,
+        "includedFindings": 1,
+        "omittedFindings": 0,
+        "requiredFields": 6,
+        "retainedFields": 4,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 40,
+      "selectedRows": 1,
+      "availableRows": 40,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 529,
+          "fiveTurnExposure": 2645
+        },
+        "cl100k_base": {
+          "nextTurnTax": 528,
+          "fiveTurnExposure": 2640
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/audit-findings:5",
+      "surface": "editor-prompt",
+      "scenario": "audit-findings:5",
+      "characters": 1736,
+      "utf8Bytes": 1757,
+      "lines": 18,
+      "tokens": {
+        "o200k_base": 411,
+        "cl100k_base": 410
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 30,
+        "retainedFields": 20,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 40,
+      "selectedRows": 5,
+      "availableRows": 40,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 749,
+          "fiveTurnExposure": 3745
+        },
+        "cl100k_base": {
+          "nextTurnTax": 748,
+          "fiveTurnExposure": 3740
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/audit-findings:20",
+      "surface": "editor-prompt",
+      "scenario": "audit-findings:20",
+      "characters": 5366,
+      "utf8Bytes": 5450,
+      "lines": 36,
+      "tokens": {
+        "o200k_base": 1255,
+        "cl100k_base": 1262
+      },
+      "quality": {
+        "expectedFindings": 20,
+        "includedFindings": 20,
+        "omittedFindings": 0,
+        "requiredFields": 120,
+        "retainedFields": 80,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 40,
+      "selectedRows": 20,
+      "availableRows": 40,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 1593,
+          "fiveTurnExposure": 7965
+        },
+        "cl100k_base": {
+          "nextTurnTax": 1600,
+          "fiveTurnExposure": 8000
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/audit-findings:all",
+      "surface": "editor-prompt",
+      "scenario": "audit-findings:all",
+      "characters": 10170,
+      "utf8Bytes": 10338,
+      "lines": 60,
+      "tokens": {
+        "o200k_base": 2337,
+        "cl100k_base": 2347
+      },
+      "quality": {
+        "expectedFindings": 40,
+        "includedFindings": 40,
+        "omittedFindings": 0,
+        "requiredFields": 240,
+        "retainedFields": 160,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 40,
+      "selectedRows": 40,
+      "availableRows": 40,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 2675,
+          "fiveTurnExposure": 13375
+        },
+        "cl100k_base": {
+          "nextTurnTax": 2685,
+          "fiveTurnExposure": 13425
+        }
+      }
+    },
+    {
+      "key": "raw-report/dupes-findings",
+      "surface": "raw-report",
+      "scenario": "dupes-findings",
+      "characters": 4367,
+      "utf8Bytes": 4367,
+      "lines": 170,
+      "tokens": {
+        "o200k_base": 1154,
+        "cl100k_base": 1148
+      },
+      "quality": {
+        "expectedFindings": 6,
+        "includedFindings": 6,
+        "omittedFindings": 0,
+        "requiredFields": 24,
+        "retainedFields": 24,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 6
+    },
+    {
+      "key": "tool-result/dupes-findings",
+      "surface": "tool-result",
+      "scenario": "dupes-findings",
+      "characters": 4557,
+      "utf8Bytes": 4557,
+      "lines": 177,
+      "tokens": {
+        "o200k_base": 1210,
+        "cl100k_base": 1204
+      },
+      "quality": {
+        "expectedFindings": 6,
+        "includedFindings": 6,
+        "omittedFindings": 0,
+        "requiredFields": 24,
+        "retainedFields": 24,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 6,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 1548,
+          "fiveTurnExposure": 7740
+        },
+        "cl100k_base": {
+          "nextTurnTax": 1542,
+          "fiveTurnExposure": 7710
+        }
+      }
+    },
+    {
+      "key": "slash-transcript/dupes-findings",
+      "surface": "slash-transcript",
+      "scenario": "dupes-findings",
+      "characters": 193,
+      "utf8Bytes": 193,
+      "lines": 5,
+      "tokens": {
+        "o200k_base": 54,
+        "cl100k_base": 54
+      },
+      "quality": {
+        "expectedFindings": 6,
+        "includedFindings": 0,
+        "omittedFindings": 6,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 6,
+      "hasNavigator": true,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 392,
+          "fiveTurnExposure": 1960
+        },
+        "cl100k_base": {
+          "nextTurnTax": 392,
+          "fiveTurnExposure": 1960
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/dupes-findings:1",
+      "surface": "editor-prompt",
+      "scenario": "dupes-findings:1",
+      "characters": 812,
+      "utf8Bytes": 814,
+      "lines": 14,
+      "tokens": {
+        "o200k_base": 189,
+        "cl100k_base": 188
+      },
+      "quality": {
+        "expectedFindings": 1,
+        "includedFindings": 1,
+        "omittedFindings": 0,
+        "requiredFields": 4,
+        "retainedFields": 3,
+        "requiredFieldRetentionPct": 75,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 6,
+      "selectedRows": 1,
+      "availableRows": 6,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 527,
+          "fiveTurnExposure": 2635
+        },
+        "cl100k_base": {
+          "nextTurnTax": 526,
+          "fiveTurnExposure": 2630
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/dupes-findings:5",
+      "surface": "editor-prompt",
+      "scenario": "dupes-findings:5",
+      "characters": 1684,
+      "utf8Bytes": 1694,
+      "lines": 18,
+      "tokens": {
+        "o200k_base": 449,
+        "cl100k_base": 444
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 20,
+        "retainedFields": 15,
+        "requiredFieldRetentionPct": 75,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 6,
+      "selectedRows": 5,
+      "availableRows": 6,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 787,
+          "fiveTurnExposure": 3935
+        },
+        "cl100k_base": {
+          "nextTurnTax": 782,
+          "fiveTurnExposure": 3910
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/dupes-findings:all",
+      "surface": "editor-prompt",
+      "scenario": "dupes-findings:all",
+      "characters": 1903,
+      "utf8Bytes": 1915,
+      "lines": 19,
+      "tokens": {
+        "o200k_base": 514,
+        "cl100k_base": 508
+      },
+      "quality": {
+        "expectedFindings": 6,
+        "includedFindings": 6,
+        "omittedFindings": 0,
+        "requiredFields": 24,
+        "retainedFields": 18,
+        "requiredFieldRetentionPct": 75,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 6,
+      "selectedRows": 6,
+      "availableRows": 6,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 852,
+          "fiveTurnExposure": 4260
+        },
+        "cl100k_base": {
+          "nextTurnTax": 846,
+          "fiveTurnExposure": 4230
+        }
+      }
+    },
+    {
+      "key": "raw-report/health-findings",
+      "surface": "raw-report",
+      "scenario": "health-findings",
+      "characters": 14081,
+      "utf8Bytes": 14081,
+      "lines": 409,
+      "tokens": {
+        "o200k_base": 3607,
+        "cl100k_base": 3586
+      },
+      "quality": {
+        "expectedFindings": 19,
+        "includedFindings": 19,
+        "omittedFindings": 0,
+        "requiredFields": 114,
+        "retainedFields": 114,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 19
+    },
+    {
+      "key": "tool-result/health-findings",
+      "surface": "tool-result",
+      "scenario": "health-findings",
+      "characters": 14362,
+      "utf8Bytes": 14362,
+      "lines": 421,
+      "tokens": {
+        "o200k_base": 3705,
+        "cl100k_base": 3684
+      },
+      "quality": {
+        "expectedFindings": 19,
+        "includedFindings": 19,
+        "omittedFindings": 0,
+        "requiredFields": 114,
+        "retainedFields": 114,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 19,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 4043,
+          "fiveTurnExposure": 20215
+        },
+        "cl100k_base": {
+          "nextTurnTax": 4022,
+          "fiveTurnExposure": 20110
+        }
+      }
+    },
+    {
+      "key": "slash-transcript/health-findings",
+      "surface": "slash-transcript",
+      "scenario": "health-findings",
+      "characters": 284,
+      "utf8Bytes": 284,
+      "lines": 10,
+      "tokens": {
+        "o200k_base": 96,
+        "cl100k_base": 96
+      },
+      "quality": {
+        "expectedFindings": 19,
+        "includedFindings": 0,
+        "omittedFindings": 19,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 19,
+      "hasNavigator": true,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 434,
+          "fiveTurnExposure": 2170
+        },
+        "cl100k_base": {
+          "nextTurnTax": 434,
+          "fiveTurnExposure": 2170
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/health-findings:1",
+      "surface": "editor-prompt",
+      "scenario": "health-findings:1",
+      "characters": 900,
+      "utf8Bytes": 907,
+      "lines": 14,
+      "tokens": {
+        "o200k_base": 203,
+        "cl100k_base": 204
+      },
+      "quality": {
+        "expectedFindings": 1,
+        "includedFindings": 1,
+        "omittedFindings": 0,
+        "requiredFields": 6,
+        "retainedFields": 4,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 9,
+      "selectedRows": 1,
+      "availableRows": 9,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 541,
+          "fiveTurnExposure": 2705
+        },
+        "cl100k_base": {
+          "nextTurnTax": 542,
+          "fiveTurnExposure": 2710
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/health-findings:5",
+      "surface": "editor-prompt",
+      "scenario": "health-findings:5",
+      "characters": 1948,
+      "utf8Bytes": 1979,
+      "lines": 19,
+      "tokens": {
+        "o200k_base": 467,
+        "cl100k_base": 470
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 30,
+        "retainedFields": 20,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 9,
+      "selectedRows": 5,
+      "availableRows": 9,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 805,
+          "fiveTurnExposure": 4025
+        },
+        "cl100k_base": {
+          "nextTurnTax": 808,
+          "fiveTurnExposure": 4040
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/health-findings:10",
+      "surface": "editor-prompt",
+      "scenario": "health-findings:10",
+      "characters": 3003,
+      "utf8Bytes": 3046,
+      "lines": 23,
+      "tokens": {
+        "o200k_base": 687,
+        "cl100k_base": 686
+      },
+      "quality": {
+        "expectedFindings": 9,
+        "includedFindings": 9,
+        "omittedFindings": 0,
+        "requiredFields": 54,
+        "retainedFields": 35,
+        "requiredFieldRetentionPct": 64.81,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 9,
+      "selectedRows": 9,
+      "availableRows": 9,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 1025,
+          "fiveTurnExposure": 5125
+        },
+        "cl100k_base": {
+          "nextTurnTax": 1024,
+          "fiveTurnExposure": 5120
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/health-findings:all",
+      "surface": "editor-prompt",
+      "scenario": "health-findings:all",
+      "characters": 3003,
+      "utf8Bytes": 3046,
+      "lines": 23,
+      "tokens": {
+        "o200k_base": 687,
+        "cl100k_base": 686
+      },
+      "quality": {
+        "expectedFindings": 9,
+        "includedFindings": 9,
+        "omittedFindings": 0,
+        "requiredFields": 54,
+        "retainedFields": 35,
+        "requiredFieldRetentionPct": 64.81,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 9,
+      "selectedRows": 9,
+      "availableRows": 9,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 1025,
+          "fiveTurnExposure": 5125
+        },
+        "cl100k_base": {
+          "nextTurnTax": 1024,
+          "fiveTurnExposure": 5120
+        }
+      }
+    },
+    {
+      "key": "raw-report/security-findings",
+      "surface": "raw-report",
+      "scenario": "security-findings",
+      "characters": 5614,
+      "utf8Bytes": 5614,
+      "lines": 164,
+      "tokens": {
+        "o200k_base": 1418,
+        "cl100k_base": 1408
+      },
+      "quality": {
+        "expectedFindings": 8,
+        "includedFindings": 8,
+        "omittedFindings": 0,
+        "requiredFields": 48,
+        "retainedFields": 48,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 8
+    },
+    {
+      "key": "tool-result/security-findings",
+      "surface": "tool-result",
+      "scenario": "security-findings",
+      "characters": 5764,
+      "utf8Bytes": 5764,
+      "lines": 171,
+      "tokens": {
+        "o200k_base": 1463,
+        "cl100k_base": 1453
+      },
+      "quality": {
+        "expectedFindings": 8,
+        "includedFindings": 8,
+        "omittedFindings": 0,
+        "requiredFields": 48,
+        "retainedFields": 48,
+        "requiredFieldRetentionPct": 100,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 8,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 1801,
+          "fiveTurnExposure": 9005
+        },
+        "cl100k_base": {
+          "nextTurnTax": 1791,
+          "fiveTurnExposure": 8955
+        }
+      }
+    },
+    {
+      "key": "slash-transcript/security-findings",
+      "surface": "slash-transcript",
+      "scenario": "security-findings",
+      "characters": 153,
+      "utf8Bytes": 153,
+      "lines": 5,
+      "tokens": {
+        "o200k_base": 43,
+        "cl100k_base": 43
+      },
+      "quality": {
+        "expectedFindings": 8,
+        "includedFindings": 0,
+        "omittedFindings": 8,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 8,
+      "hasNavigator": true,
+      "truncated": false,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 381,
+          "fiveTurnExposure": 1905
+        },
+        "cl100k_base": {
+          "nextTurnTax": 381,
+          "fiveTurnExposure": 1905
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/security-findings:1",
+      "surface": "editor-prompt",
+      "scenario": "security-findings:1",
+      "characters": 847,
+      "utf8Bytes": 852,
+      "lines": 14,
+      "tokens": {
+        "o200k_base": 182,
+        "cl100k_base": 182
+      },
+      "quality": {
+        "expectedFindings": 1,
+        "includedFindings": 1,
+        "omittedFindings": 0,
+        "requiredFields": 6,
+        "retainedFields": 4,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 8,
+      "selectedRows": 1,
+      "availableRows": 8,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 520,
+          "fiveTurnExposure": 2600
+        },
+        "cl100k_base": {
+          "nextTurnTax": 520,
+          "fiveTurnExposure": 2600
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/security-findings:5",
+      "surface": "editor-prompt",
+      "scenario": "security-findings:5",
+      "characters": 1821,
+      "utf8Bytes": 1846,
+      "lines": 18,
+      "tokens": {
+        "o200k_base": 415,
+        "cl100k_base": 414
+      },
+      "quality": {
+        "expectedFindings": 5,
+        "includedFindings": 5,
+        "omittedFindings": 0,
+        "requiredFields": 30,
+        "retainedFields": 20,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 8,
+      "selectedRows": 5,
+      "availableRows": 8,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 753,
+          "fiveTurnExposure": 3765
+        },
+        "cl100k_base": {
+          "nextTurnTax": 752,
+          "fiveTurnExposure": 3760
+        }
+      }
+    },
+    {
+      "key": "editor-prompt/security-findings:all",
+      "surface": "editor-prompt",
+      "scenario": "security-findings:all",
+      "characters": 2555,
+      "utf8Bytes": 2595,
+      "lines": 21,
+      "tokens": {
+        "o200k_base": 590,
+        "cl100k_base": 588
+      },
+      "quality": {
+        "expectedFindings": 8,
+        "includedFindings": 8,
+        "omittedFindings": 0,
+        "requiredFields": 48,
+        "retainedFields": 32,
+        "requiredFieldRetentionPct": 66.67,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 8,
+      "selectedRows": 8,
+      "availableRows": 8,
+      "detail": "compact",
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 928,
+          "fiveTurnExposure": 4640
+        },
+        "cl100k_base": {
+          "nextTurnTax": 926,
+          "fiveTurnExposure": 4630
+        }
+      }
+    },
+    {
+      "key": "raw-report/schema",
+      "surface": "raw-report",
+      "scenario": "schema",
+      "characters": 240794,
+      "utf8Bytes": 240800,
+      "lines": 6954,
+      "tokens": {
+        "o200k_base": 58329,
+        "cl100k_base": 57832
+      },
+      "quality": {
+        "expectedFindings": 0,
+        "includedFindings": 0,
+        "omittedFindings": 0,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": false
+      },
+      "reportFindings": 0
+    },
+    {
+      "key": "tool-result/schema",
+      "surface": "tool-result",
+      "scenario": "schema",
+      "characters": 51538,
+      "utf8Bytes": 51542,
+      "lines": 1578,
+      "tokens": {
+        "o200k_base": 11497,
+        "cl100k_base": 11479
+      },
+      "quality": {
+        "expectedFindings": 0,
+        "includedFindings": 0,
+        "omittedFindings": 0,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 0,
+      "truncated": true,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 11835,
+          "fiveTurnExposure": 59175
+        },
+        "cl100k_base": {
+          "nextTurnTax": 11817,
+          "fiveTurnExposure": 59085
+        }
+      }
+    },
+    {
+      "key": "slash-transcript/schema",
+      "surface": "slash-transcript",
+      "scenario": "schema",
+      "characters": 51538,
+      "utf8Bytes": 51542,
+      "lines": 1578,
+      "tokens": {
+        "o200k_base": 11497,
+        "cl100k_base": 11479
+      },
+      "quality": {
+        "expectedFindings": 0,
+        "includedFindings": 0,
+        "omittedFindings": 0,
+        "requiredFields": 0,
+        "retainedFields": 0,
+        "requiredFieldRetentionPct": null,
+        "hasFullOutputReference": true
+      },
+      "reportFindings": 0,
+      "hasNavigator": false,
+      "truncated": true,
+      "context": {
+        "o200k_base": {
+          "nextTurnTax": 11835,
+          "fiveTurnExposure": 59175
+        },
+        "cl100k_base": {
+          "nextTurnTax": 11817,
+          "fiveTurnExposure": 59085
+        }
+      }
+    }
+  ],
+  "aggregates": {
+    "tool-contract": {
+      "cases": 1,
+      "characters": {
+        "total": 1413,
+        "median": 1413,
+        "p95": 1413,
+        "max": 1413
+      },
+      "utf8Bytes": {
+        "total": 1413,
+        "median": 1413,
+        "p95": 1413,
+        "max": 1413
+      },
+      "tokens": {
+        "o200k_base": {
+          "total": 338,
+          "median": 338,
+          "p95": 338,
+          "max": 338
+        },
+        "cl100k_base": {
+          "total": 338,
+          "median": 338,
+          "p95": 338,
+          "max": 338
+        }
+      }
+    },
+    "raw-report": {
+      "cases": 9,
+      "characters": {
+        "total": 509583,
+        "median": 14081,
+        "p95": 240794,
+        "max": 240794
+      },
+      "utf8Bytes": {
+        "total": 509589,
+        "median": 14081,
+        "p95": 240800,
+        "max": 240800
+      },
+      "tokens": {
+        "o200k_base": {
+          "total": 122729,
+          "median": 3607,
+          "p95": 58329,
+          "max": 58329
+        },
+        "cl100k_base": {
+          "total": 121831,
+          "median": 3586,
+          "p95": 57832,
+          "max": 57832
+        }
+      }
+    },
+    "tool-result": {
+      "cases": 9,
+      "characters": {
+        "total": 189787,
+        "median": 14362,
+        "p95": 51715,
+        "max": 51715
+      },
+      "utf8Bytes": {
+        "total": 189791,
+        "median": 14362,
+        "p95": 51715,
+        "max": 51715
+      },
+      "tokens": {
+        "o200k_base": {
+          "total": 45104,
+          "median": 3705,
+          "p95": 12416,
+          "max": 12416
+        },
+        "cl100k_base": {
+          "total": 44887,
+          "median": 3684,
+          "p95": 12328,
+          "max": 12328
+        }
+      }
+    },
+    "slash-transcript": {
+      "cases": 9,
+      "characters": {
+        "total": 55363,
+        "median": 405,
+        "p95": 51538,
+        "max": 51538
+      },
+      "utf8Bytes": {
+        "total": 55367,
+        "median": 405,
+        "p95": 51542,
+        "max": 51542
+      },
+      "tokens": {
+        "o200k_base": {
+          "total": 12645,
+          "median": 122,
+          "p95": 11497,
+          "max": 11497
+        },
+        "cl100k_base": {
+          "total": 12608,
+          "median": 119,
+          "p95": 11479,
+          "max": 11479
+        }
+      }
+    },
+    "editor-prompt": {
+      "cases": 24,
+      "characters": {
+        "total": 130598,
+        "median": 1777,
+        "p95": 10170,
+        "max": 69225
+      },
+      "utf8Bytes": {
+        "total": 132626,
+        "median": 1797,
+        "p95": 10338,
+        "max": 70425
+      },
+      "tokens": {
+        "o200k_base": {
+          "total": 30317,
+          "median": 412,
+          "p95": 2337,
+          "max": 16035
+        },
+        "cl100k_base": {
+          "total": 30631,
+          "median": 411,
+          "p95": 2347,
+          "max": 16333
+        }
+      }
+    }
+  }
+}

--- a/tests/token-baseline.test.mjs
+++ b/tests/token-baseline.test.mjs
@@ -8,9 +8,11 @@ import { describe, it } from "node:test";
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const corpusPath = join(root, "benchmarks", "corpus.json");
 const baselinePath = join(root, "benchmarks", "baselines", "v0.2.0.json");
+const preOutputDetailBaselinePath = join(root, "benchmarks", "baselines", "v0.4.0-pre-output-detail.json");
 const corpusText = await readFile(corpusPath, "utf8");
 const corpus = JSON.parse(corpusText);
 const baseline = JSON.parse(await readFile(baselinePath, "utf8"));
+const preOutputDetailBaseline = JSON.parse(await readFile(preOutputDetailBaselinePath, "utf8"));
 
 describe("token benchmark baseline", () => {
 	it("is tied to the frozen fixture corpus", async () => {
@@ -42,6 +44,16 @@ describe("token benchmark baseline", () => {
 		assert.equal(large.quality.includedFindings, 84);
 		assert.equal(large.quality.hasFullOutputReference, true);
 	});
+
+	it("preserves the immediate pre-output-detail release baseline", async () => {
+		assert.equal(preOutputDetailBaseline.label, "v0.4.0-pre-output-detail");
+		assert.equal(preOutputDetailBaseline.environment.gitSha, "2350b0a5f19abfa51d1fd53fa6abf7d7eb0938da");
+		assert.equal(preOutputDetailBaseline.corpusHash, await hashCorpus());
+		assert.equal(preOutputDetailSurfaceTokens("tool-result"), 45_104);
+		assert.equal(preOutputDetailSurfaceTokens("slash-transcript"), 12_645);
+		assert.equal(preOutputDetailMeasurement("tool-result/small-findings").quality.includedFindings, 5);
+		assert.equal(preOutputDetailMeasurement("tool-result/medium-findings").quality.requiredFieldRetentionPct, 100);
+	});
 });
 
 function measurement(key) {
@@ -52,6 +64,18 @@ function measurement(key) {
 
 function tokens(key) {
 	return measurement(key).tokens.o200k_base;
+}
+
+function preOutputDetailMeasurement(key) {
+	const value = preOutputDetailBaseline.measurements.find((entry) => entry.key === key);
+	assert.ok(value, `Missing pre-output-detail baseline measurement: ${key}`);
+	return value;
+}
+
+function preOutputDetailSurfaceTokens(surface) {
+	return preOutputDetailBaseline.measurements
+		.filter((entry) => entry.surface === surface)
+		.reduce((total, entry) => total + entry.tokens.o200k_base, 0);
 }
 
 async function hashCorpus() {


### PR DESCRIPTION
## Summary

- commit an exact token benchmark from `2350b0a5f19abfa51d1fd53fa6abf7d7eb0938da`, immediately before `fallow_run.detail` became effective
- document how to generate a release candidate benchmark and compare it with that immediate baseline
- freeze the artifact identity, corpus hash, surface totals, and finding-retention evidence in tests

## User-visible changes

None. This is benchmark and release-evidence maintenance only.

## Performance and token impact

The committed before artifact was generated from the clean pre-change commit with Node 24.12.0, `js-tiktoken` 1.0.21, and the unchanged frozen corpus.

A post-merge measurement at `c208eb88ef7d7a276ed56e0c150bc4383d43938a` compared cleanly:

- all tool results: **45,104 → 8,046 tokens** (**82.16% reduction**)
- 5-finding result: **1,064 → 738**, retaining **5/5** inline with **100%** required raw-field retention
- 40-finding result: **6,403 → 1,315**, retaining **11/40** inline with **100%** required raw-field retention and a complete-output reference
- 300-finding result: **12,416 → 1,311**, retaining **11/300** inline with **100%** required raw-field retention and a complete-output reference
- slash transcripts: **12,645 → 12,645** (unchanged)

The release candidate can be generated at the eventual release commit and compared against this exact before artifact; no release is being prepared or published here.

## Validation

- [x] `npm test` — 143 passed
- [x] `npm run check:bundle`
- [x] focused baseline integrity test
- [x] generated post-merge benchmark and compared it with the committed immediate-before artifact
- [x] `git diff --check`

## Security and release considerations

No source, dependency, lockfile, workflow, permission, package, or release changes. The artifact contains deterministic benchmark metadata and measurements only. No release, tag, or publication is performed.
