### PR TITLE
Document tested Pi 0.84.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Pi Fallow are documented here.
 
 ### Added
 - Added an immediate pre-output-detail token benchmark baseline for reproducible before/after release evidence.
+- Documented the Pi 0.84.1 host certification matrix while retaining Pi's recommended wildcard peer dependencies.
 
 ### Changed
 - Upgraded the coordinated Pi development packages to 0.84.0, incorporating the upstream dependency security fix.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ The navigator defaults to compact prompts. Compact mode includes every selected 
 
 Plain `fallow health` can return actionable findings alongside informational per-file scores and hotspots. Pi Fallow hides those informational records by default and reports their count separately. Explicit informational commands such as `health --file-scores` and `flags` show their records directly without finding-selection or agent-prompt controls. The overlay stays centered at 90% terminal width, can use up to 95% of terminal height, and expands large virtualized result sets to as many as 30 visible rows.
 
+## Tested compatibility
+
+The current `0.4.x` development line is certified with this host matrix:
+
+| Pi coding agent | Matching Pi AI/TUI packages | Node.js | Fallow |
+|---|---|---|---|
+| 0.84.1 | 0.84.1 | 22.19 and 24 | 3.14.0 |
+
+Certification installs the generated Pi Fallow tarball in isolation and uses the exact Pi version locked by this repository. It verifies offline extension loading, `/fallow` discovery, provider-free `/fallow health` execution over RPC, print and JSON modes, empty Pi stderr, and the absence of extension/provider-turn errors. Package checks run on both supported Node lines.
+
+This matrix records tested compatibility; it is not an installation constraint or a claim about untested Pi versions. Pi packages intentionally remain host-provided wildcard peer dependencies, following Pi's package guidance. Other Pi versions may work, but are not certified until they pass the same package smoke checks.
+
 ## Requirements
 
 - Node.js 22.19+
@@ -156,7 +168,7 @@ Plain `fallow health` can return actionable findings alongside informational per
 
 Runner resolution is refreshed when `FALLOW_BIN` or `PATH` changes. The npx fallback locates the installed package once and invokes its executable directly for later commands. If an automatically resolved executable disappears, Pi Fallow invalidates it and retries the next route once. An invalid explicit `FALLOW_BIN`, cancellation, timeout, or a command that already started never falls through to another installation.
 
-The Pi package declares Pi libraries as peer dependencies, as recommended for Pi extensions.
+The Pi package declares Pi libraries as wildcard peer dependencies, as recommended for Pi extensions; see the tested matrix above for the currently certified host version.
 
 ## Package manifest
 

--- a/tests/package-metadata.test.mjs
+++ b/tests/package-metadata.test.mjs
@@ -6,6 +6,8 @@ import { describe, it } from "node:test";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const manifest = JSON.parse(await readFile(join(root, "package.json"), "utf8"));
+const lockfile = JSON.parse(await readFile(join(root, "package-lock.json"), "utf8"));
+const readme = await readFile(join(root, "README.md"), "utf8");
 const workflowNames = ["ci.yml", "codeql.yml", "release.yml"];
 const workflows = Object.fromEntries(await Promise.all(
 	workflowNames.map(async (name) => [name, await readFile(join(root, ".github", "workflows", name), "utf8")]),
@@ -16,6 +18,21 @@ describe("package and automation metadata", () => {
 	it("matches the minimum Node version required by current Pi peers", () => {
 		assert.equal(manifest.engines.node, ">=22.19");
 		assert.equal(manifest.packageManager, "npm@11.6.2");
+	});
+
+	it("documents the locked Pi host certification without narrowing wildcard peers", () => {
+		const piPackages = [
+			"@earendil-works/pi-ai",
+			"@earendil-works/pi-coding-agent",
+			"@earendil-works/pi-tui",
+		];
+		for (const name of piPackages) {
+			assert.equal(manifest.peerDependencies[name], "*");
+			assert.equal(lockfile.packages[`node_modules/${name}`].version, "0.84.1");
+		}
+		assert.match(readme, /\| 0\.84\.1 \| 0\.84\.1 \| 22\.19 and 24 \| 3\.14\.0 \|/);
+		assert.match(readme, /tested compatibility; it is not an installation constraint/);
+		assert.match(readme, /wildcard peer dependencies/);
 	});
 
 	it("pins analysis tooling and enables npm provenance", () => {


### PR DESCRIPTION
## Summary

- document the exact Pi 0.84.1 host certification matrix for the current 0.4.x development line
- describe what the installed-tarball RPC/print/JSON package smoke actually certifies
- make clear that tested compatibility is not an install constraint and retain Pi's recommended wildcard peer dependencies
- add a regression test tying the documented matrix to the locked coordinated Pi versions and wildcard peer metadata

## User-visible changes

README requirements now distinguish the certified host version from the package's intentionally broad peer compatibility. Users can see that Pi 0.84.1 with matching Pi AI/TUI packages is tested on Node 22.19 and 24 against Fallow 3.14.0, while other Pi versions remain unverified rather than blocked.

## Performance and token impact

Not applicable. No extension output, prompt, tool contract, or runtime behavior changes.

## Validation

- [x] `npm test` — 144 passed
- [x] `npm run check:bundle`
- [x] `npm run package:smoke` — installed tarball certified with locked Pi 0.84.1 RPC/print/JSON
- [x] focused package-metadata regression test
- [x] `git diff --check`

## Security and release considerations

No package, lockfile, dependency, workflow, runtime, permission, peer-range, tag, publication, or release changes. Pi packages remain host-provided wildcard peers and are not bundled.
