### PR TITLE
Add measured fallow_run prompt guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Pi Fallow are documented here.
 ### Added
 - Added an immediate pre-output-detail token benchmark baseline for reproducible before/after release evidence.
 - Documented the Pi 0.84.1 host certification matrix while retaining Pi's recommended wildcard peer dependencies.
+- Added measured `fallow_run` prompt guidance for deletion evidence, fix previews, and routine bounded output detail.
 
 ### Changed
 - Upgraded the coordinated Pi development packages to 0.84.0, incorporating the upstream dependency security fix.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The agent-facing `fallow_run` tool passes command-specific flags as separate `ar
 
 `fallow_run.detail` controls model-facing output and defaults to `findings`. Use `summary` for bounded status and counts, `findings` for bounded normalized findings with locations, evidence, and suggested actions, or `raw` for bounded raw Fallow JSON/output. Summary and findings responses always link to a complete report in the operating system's temporary directory; raw responses do so when truncation omits content. This setting does not change `/fallow` slash-command or navigator rendering.
 
+When `fallow_run` is active, its compact Pi prompt guidance tells the model to inspect or trace before deletion, treat incomplete type-aware evidence as advisory, preview fixes before applying them, avoid unrequested changes, and reserve raw detail for necessary diagnostics.
+
 `--type-aware-project` selects a TypeScript project and `--type-aware-require best-effort|complete` controls required completeness. Always inspect the returned type-aware completeness, omissions, and abstentions: incomplete evidence remains advisory and must not be treated as exact delete-safety proof. Fallow 3.14 also supports `--baseline-mode count|identity` for health baselines and `--no-type-aware` to override config for a syntactic-only run.
 
 Some Fallow surfaces deliberately remain direct CLI features rather than Pi Fallow report commands:

--- a/extensions/fallow/contract.ts
+++ b/extensions/fallow/contract.ts
@@ -4,5 +4,11 @@ export const fallowToolContract = {
 	name: "fallow_run",
 	label: "Fallow",
 	description: "Run Fallow audits, dead-code, duplication, health, type-aware impact/coupling, inspect, trace, security, architecture, and fixes. Pass CLI flags and values as separate args items.",
+	promptSnippet: "Run Fallow project analysis, impact tracing, security checks, and fixes",
+	promptGuidelines: [
+		"Use fallow_run inspect or trace-symbol before deletion; incomplete type-aware evidence is advisory.",
+		"Use fallow_run fix-preview before fix-apply; apply only user-requested changes.",
+		"Use fallow_run detail summary or findings routinely; use raw only for necessary diagnostics.",
+	],
 	parameters: fallowRunParams,
 } as const;

--- a/tests/tool-contract.test.mjs
+++ b/tests/tool-contract.test.mjs
@@ -5,7 +5,7 @@ import { createJiti } from "jiti";
 
 const jiti = createJiti(import.meta.url);
 const { fallowToolContract: tool } = await jiti.import("../extensions/fallow/contract.ts");
-const encoder = getEncoding("o200k_base");
+const tokenizers = ["o200k_base", "cl100k_base"].map((name) => [name, getEncoding(name)]);
 
 describe("fallow_run compact contract", () => {
 	it("exposes only the compact public parameters", () => {
@@ -14,14 +14,25 @@ describe("fallow_run compact contract", () => {
 		]);
 		assert.equal(tool.parameters.additionalProperties, false);
 		assert.equal(tool.parameters.properties.detail.default, "findings");
-		assert.equal(tool.promptSnippet, undefined);
-		assert.equal(tool.promptGuidelines, undefined);
+		assert.match(tool.promptSnippet, /Fallow project analysis/);
+		assert.deepEqual(tool.promptGuidelines, [
+			"Use fallow_run inspect or trace-symbol before deletion; incomplete type-aware evidence is advisory.",
+			"Use fallow_run fix-preview before fix-apply; apply only user-requested changes.",
+			"Use fallow_run detail summary or findings routinely; use raw only for necessary diagnostics.",
+		]);
+		assert.ok(tool.promptGuidelines.every((guideline) => guideline.includes("fallow_run")));
 		assert.match(tool.description, /type-aware impact/);
 	});
 
-	it("stays below the fixed contract token budget", () => {
+	it("keeps measured prompt guidance within its fixed token budget", () => {
 		const contract = JSON.stringify(tool, null, 2);
-		const tokens = encoder.encode(contract).length;
-		assert.ok(tokens <= 350, `contract uses ${tokens} tokens`);
+		const { promptSnippet: _snippet, promptGuidelines: _guidelines, ...withoutGuidance } = tool;
+		const baseContract = JSON.stringify(withoutGuidance, null, 2);
+		for (const [name, tokenizer] of tokenizers) {
+			const totalTokens = tokenizer.encode(contract).length;
+			const guidanceTokens = totalTokens - tokenizer.encode(baseContract).length;
+			assert.ok(totalTokens <= 440, `${name} contract uses ${totalTokens} tokens`);
+			assert.ok(guidanceTokens <= 90, `${name} guidance adds ${guidanceTokens} tokens`);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- opt active `fallow_run` into Pi's one-line `Available tools` metadata with `promptSnippet`
- add flat, tool-named `promptGuidelines` for evidence before deletion, valid `trace-symbol` use, fix previews, user-requested changes, and bounded detail selection
- enforce measured fixed-token ceilings under both `o200k_base` and `cl100k_base`
- document the active guidance without changing runtime or slash/TUI behavior

## User-visible changes

When `fallow_run` is active, Pi now tells the model to:

- inspect or use the valid `trace-symbol` command before deletion
- treat incomplete type-aware evidence as advisory
- run `fix-preview` before `fix-apply`
- apply only user-requested changes
- prefer summary/findings detail routinely and reserve raw detail for necessary diagnostics

No command schema, execution, output, slash-command, navigator, or TUI behavior changes.

## Performance and token impact

Exact before/after benchmark from main `6566533` to candidate `c2d4052`, with the same frozen corpus and tokenizer versions:

- active tool contract: **346 → 435 tokens** (**+89**) in both `o200k_base` and `cl100k_base`
- direct tool-result tokens: **8,046 → 8,046**
- slash-transcript tokens: **12,645 → 12,645**
- editor-prompt tokens: **30,317 → 30,317**
- raw-report tokens: **122,729 → 122,729**

The +89 tokens are the measured fixed active-tool guidance cost on each model request; five-turn exposure increases by 445 tokens. Tests fail if guidance exceeds 90 tokens or the complete contract exceeds 440 tokens under either encoding.

## Validation

- [x] `npm test` — 144 passed
- [x] `npm run check:bundle`
- [x] `npm run health` — 0 findings
- [x] `npm run dupes` — 0 clone groups
- [x] `npm run dead-code` — 0 issues
- [x] `npm run coverage` — thresholds passed
- [x] `npm run pack:check`
- [x] `npm run package:smoke` — Pi 0.84.1 RPC/print/JSON certification passed
- [x] `npm run smoke:fallow`
- [x] `npm run audit:production` — 0 vulnerabilities
- [x] `npm run audit:all` — 0 vulnerabilities
- [x] `npm run check:publish`
- [x] exact pre/post token benchmark comparison
- [x] independent two-round review — approved after correcting unsupported `trace` wording to valid `trace-symbol` and restoring the +89 budget

## Security and release considerations

No dependency, lockfile, workflow, permission, package, peer-range, file-mutation, tag, publication, or release changes. Pi host packages remain external wildcard peers. No release is performed.
