### PR TITLE
Centralize Fallow command registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to Pi Fallow are documented here.
 ## [Unreleased]
 
 ### Added
+- Added `architecture` support to `fallow_run` and `/fallow`, backed by Fallow 3.14's stable `guard <file>...` command with required, `@`-normalized path targets.
 - Added an immediate pre-output-detail token benchmark baseline for reproducible before/after release evidence.
 - Documented the Pi 0.84.1 host certification matrix while retaining Pi's recommended wildcard peer dependencies.
 - Added measured `fallow_run` prompt guidance for deletion evidence, fix previews, and routine bounded output detail.
 
 ### Changed
+- Centralized tool commands, compact CLI prefixes, target behavior, overlapping slash metadata, autocomplete, and the `/fallow` argument hint in one typed registry.
 - Upgraded the coordinated Pi development packages to 0.84.0, incorporating the upstream dependency security fix.
 - Removed the temporary development-audit vulnerability acceptance after the upstream fix; CI and release validation now strictly audit the complete dependency tree.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 ## Highlights
 
 - **Compact agent tool:** `fallow_run` uses a small command-plus-args contract while preserving internal validation and older-session compatibility.
+- **Synchronized command contract:** one typed registry drives tool commands, compact CLI prefixes, slash aliases, autocomplete, and the `/fallow` argument hint.
 - **Slash command:** `/fallow ...` runs the Fallow CLI from inside Pi; `/fallow` and `/fallow run` use a configurable default command.
 - **PR shortcut:** `/fallow pr` maps to `audit --base <detected-base> --gate new-only`.
 - **Rerun shortcut:** `/fallow rerun` repeats the last `/fallow` command.
@@ -63,6 +64,7 @@ Ask Pi things like:
 - “Run a Fallow audit for this PR and fix introduced dead code.”
 - “Find duplicate code, trace the largest clone group, then suggest a refactor.”
 - “Inspect this file with Fallow before editing it.”
+- “Show which architecture rules apply to these files before changing them.”
 - “Run Fallow security candidates for the changed files and explain what needs verification.”
 - “Run Fallow health and tell me the safest maintainability improvement.”
 - “Preview Fallow auto-fixes before applying anything.”
@@ -90,6 +92,7 @@ Manual slash command examples:
 /fallow trace-file extensions/fallow/ui.ts
 /fallow trace-export extensions/fallow/ui.ts FallowIssueNavigator
 /fallow security --changed-since main --gate new
+/fallow architecture extensions/fallow/cli.ts extensions/fallow/registry.ts
 /fallow decision-surface --changed-since main
 /fallow workspaces
 /fallow schema
@@ -106,7 +109,9 @@ Arguments after `/fallow run` are appended to the configured default. Explicit c
 
 `/fallow check-changed` is a Pi Fallow convenience alias for Fallow's combined root analysis with `--changed-since`.
 
-The agent-facing `fallow_run` tool passes command-specific flags as separate `args` tokens. For example, a PR audit uses `{ "command": "audit", "args": ["--base", "main", "--gate", "new-only"] }`. Type-aware reports use the existing structured commands, for example `{ "command": "dead-code", "args": ["--type-aware", "--symbol-impact", "src/api.ts:Client"] }` or `{ "command": "health", "args": ["--type-aware", "--type-coupling"] }`. Manual `/fallow` command syntax is unchanged.
+`/fallow architecture <file>...` maps to Fallow 3.14's stable `guard <file>...` command. The first file is required, multiple files and flags are preserved, and Pi's optional leading `@` is removed only from positional path targets (not flag values). Direct raw `/fallow guard ...` access remains available.
+
+The agent-facing `fallow_run` tool passes command-specific flags as separate `args` tokens. For example, a PR audit uses `{ "command": "audit", "args": ["--base", "main", "--gate", "new-only"] }`, while an architecture query uses `{ "command": "architecture", "args": ["src/api.ts", "src/domain.ts"] }`. Type-aware reports use the existing structured commands, for example `{ "command": "dead-code", "args": ["--type-aware", "--symbol-impact", "src/api.ts:Client"] }` or `{ "command": "health", "args": ["--type-aware", "--type-coupling"] }`. Other manual `/fallow` command syntax is unchanged.
 
 `fallow_run.detail` controls model-facing output and defaults to `findings`. Use `summary` for bounded status and counts, `findings` for bounded normalized findings with locations, evidence, and suggested actions, or `raw` for bounded raw Fallow JSON/output. Summary and findings responses always link to a complete report in the operating system's temporary directory; raw responses do so when truncation omits content. This setting does not change `/fallow` slash-command or navigator rendering.
 

--- a/extensions/fallow.ts
+++ b/extensions/fallow.ts
@@ -3,6 +3,7 @@ import { fallowCompletions } from "./fallow/autocomplete";
 import { fallowCli } from "./fallow/cli";
 import { fallowToolContract } from "./fallow/contract";
 import { runFallowCommandHandler } from "./fallow/command/handler";
+import { fallowArgumentHint } from "./fallow/registry";
 import type { FallowCommandState } from "./fallow/command/types";
 import { registerFallowSessionStart } from "./fallow/session";
 import { renderFallowMessageRenderer, renderFallowToolCall, renderFallowToolResult } from "./fallow/tool-render";
@@ -37,7 +38,7 @@ function registerFallowTool(pi: ExtensionAPI): void {
 function registerFallowCommand(pi: ExtensionAPI, commandState: FallowCommandState): void {
 	pi.registerCommand("fallow", {
 		description: "Run fallow with raw CLI args. JSON/quiet are added if no --format is supplied.",
-		argumentHint: "[about|all|pr|rerun|dead-code|dupes|health|audit|inspect|trace|security|decision-surface|workspaces|config|schema|impact|fix|project-info|list|flags|coverage analyze|explain] [options]",
+		argumentHint: fallowArgumentHint,
 		getArgumentCompletions: fallowCompletions.getFallowArgumentCompletions,
 		handler: (rawArgs, ctx) => runFallowCommandHandler(pi, ctx, commandState, rawArgs),
 	});

--- a/extensions/fallow/autocomplete.ts
+++ b/extensions/fallow/autocomplete.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AutocompleteItem } from "@earendil-works/pi-tui";
+import { fallowSlashRootCommands } from "./registry";
 
 type CompletionSpec = {
 	value: string;
@@ -16,42 +17,22 @@ type FlagSpec = {
 	values?: string[] | FlagValueProvider;
 };
 
-const COMMANDS: CompletionSpec[] = [
-	{ value: "pr", label: "pr", description: "Run audit with detected PR base (new-only)" },
-	{ value: "run", label: "run", description: "Run the configured default command (health unless overridden)" },
-	{ value: "rerun", label: "rerun", description: "Rerun the last /fallow command" },
-	{ value: "about", label: "about", description: "Show Pi Fallow version, update, and project links" },
-	{ value: "all", description: "Run full repository checks and checks summary" },
+const COMMAND_TEMPLATES: CompletionSpec[] = [
 	{ value: "audit --base main --gate new-only", label: "audit PR (main)", description: "Report only issues introduced by the PR diff vs main" },
 	{ value: "audit --base origin/main --gate new-only", label: "audit PR (origin/main)", description: "Report only issues introduced by the PR diff vs origin/main" },
 	{ value: "check-changed --changed-since main", label: "check-changed (main)", description: "Run combined changed-file checks since main" },
-	{ value: "dead-code", description: "Find unused exports, files, dependencies, and types" },
 	{ value: "dead-code --type-aware --symbol-impact ", label: "symbol impact", description: "Find exact TypeScript consumers, affected files, and targeted tests" },
-	{ value: "check-changed", description: "Run combined changed-file checks; add --changed-since main/origin/main" },
-	{ value: "project-info", description: "Show project info (entry points/files/plugins/boundaries)" },
-	{ value: "dupes", description: "Find duplicated code and clone groups" },
-	{ value: "health", description: "Show maintainability, complexity, churn, and health metrics" },
 	{ value: "health --type-aware --type-coupling", label: "health type coupling", description: "Show advisory public-signature type coupling" },
-	{ value: "audit", description: "Run a PR/change gate; use --base main --gate new-only for PRs" },
 	{ value: "inspect --file ", label: "inspect file", description: "Inspect one file as a bundled evidence query" },
 	{ value: "inspect --symbol ", label: "inspect symbol", description: "Inspect an exported symbol as file.ts:exportName" },
-	{ value: "trace", description: "Trace a symbol call chain: trace path/to/file.ts:exportName" },
-	{ value: "trace-file", description: "Investigate one file: trace-file path/to/file.ts" },
-	{ value: "trace-export", description: "Trace a specific export: trace-export path/to/file.ts exportName" },
-	{ value: "trace-dependency", description: "Trace a package dependency" },
-	{ value: "trace-clone", description: "Trace a duplication clone at path/to/file.ts:line" },
-	{ value: "security", description: "Surface local security candidates for agent verification" },
 	{ value: "decision-surface --changed-since main", label: "decision-surface (main)", description: "Surface structural decisions embedded in the current change" },
-	{ value: "workspaces", description: "Show monorepo workspace discovery diagnostics" },
-	{ value: "config", description: "Show resolved Fallow config" },
-	{ value: "schema", description: "Dump Fallow's machine-readable CLI capability schema" },
-	{ value: "impact", description: "Show local Fallow impact metrics" },
-	{ value: "fix", description: "Preview/apply safe cleanup fixes; usually add --dry-run first" },
-	{ value: "flags", description: "Analyze feature flags" },
-	{ value: "list", description: "List project info, files, plugins, entry points, boundaries, or workspaces" },
-	{ value: "explain", description: "Explain a Fallow issue type/rule id" },
-	{ value: "coverage analyze", description: "Analyze runtime coverage and cold paths" },
-	{ value: "--help", description: "Show Fallow CLI help" },
+];
+
+const COMMANDS: CompletionSpec[] = [
+	...fallowSlashRootCommands
+		.filter((command) => command.autocomplete !== false)
+		.map(({ value, label, description }) => ({ value, label, description })),
+	...COMMAND_TEMPLATES,
 ];
 
 const STATIC_REF_VALUES = ["main", "master", "HEAD~1", "origin/main", "origin/master"];

--- a/extensions/fallow/cli.ts
+++ b/extensions/fallow/cli.ts
@@ -1,8 +1,9 @@
 import { resolve } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { fallowEngine } from "./engine";
-import { stripAtPrefix } from "./path";
+import { isPositionalCliArg, stripAtPrefix } from "./path";
 import { execFallowProcess } from "./process";
+import { getFallowToolCommandSpec, type FallowToolCommandSpec } from "./registry";
 import { createFallowRunner } from "./runner";
 import type { FallowRunParams as CompactFallowRunParams } from "./schema";
 import type { FallowOutputDetail } from "./types";
@@ -281,39 +282,6 @@ const commandBuilders: Record<string, CommandArgsBuilder> = {
 };
 
 const MANAGED_OUTPUT_ARGS = ["--format", "json", "--quiet"];
-const COMMAND_PREFIXES: Record<CompactFallowRunParams["command"], readonly string[]> = {
-	all: [],
-	"dead-code": ["dead-code"],
-	"check-changed": [],
-	dupes: ["dupes"],
-	health: ["health"],
-	audit: ["audit"],
-	"fix-preview": ["fix", "--dry-run"],
-	"fix-apply": ["fix", "--yes"],
-	flags: ["flags"],
-	inspect: ["inspect"],
-	"trace-symbol": ["trace"],
-	security: ["security"],
-	workspaces: ["workspaces"],
-	config: ["config"],
-	schema: ["schema"],
-	"decision-surface": ["decision-surface"],
-	impact: ["impact"],
-	"project-info": ["list"],
-	"list-boundaries": ["list", "--boundaries"],
-	explain: ["explain"],
-	"trace-export": ["dead-code", "--trace"],
-	"trace-file": ["dead-code", "--trace-file"],
-	"trace-dependency": ["dead-code", "--trace-dependency"],
-	"trace-clone": ["dupes", "--trace"],
-	"coverage-analyze": ["coverage", "analyze"],
-};
-const POSITIONAL_TARGET_COMMANDS = new Set<CompactFallowRunParams["command"]>([
-	"trace-symbol", "explain", "trace-export", "trace-file", "trace-dependency", "trace-clone",
-]);
-const PATH_TARGET_COMMANDS = new Set<CompactFallowRunParams["command"]>([
-	"trace-symbol", "trace-export", "trace-file", "trace-clone",
-]);
 const PATH_OPTION_FLAGS = new Set(["--file", "--symbol"]);
 const FORBIDDEN_FIXED_ARGS: Partial<Record<CompactFallowRunParams["command"], Set<string>>> = {
 	"fix-preview": new Set(["--yes"]),
@@ -342,12 +310,10 @@ function buildLegacyFallowArgs(params: FallowRunParams): string[] {
 function buildFallowArgs(params: CompactFallowRunParams): string[] {
 	rejectFormatOverride(params.args);
 	rejectConflictingFixedArgs(params.command, params.args ?? []);
-	const commandArgs = normalizeCompactArgs(params.command, params.args ?? []);
-	const prefix = commandPrefix(params.command);
-	if (POSITIONAL_TARGET_COMMANDS.has(params.command)) {
-		return buildPositionalCommandArgs(params.command, prefix, commandArgs);
-	}
-	return [...prefix, ...MANAGED_OUTPUT_ARGS, ...commandArgs];
+	const spec = commandSpec(params.command);
+	const commandArgs = normalizeCompactArgs(spec, params.args ?? []);
+	if (spec.positionalTarget) return buildPositionalCommandArgs(spec.name, spec.cliPrefix, commandArgs);
+	return [...spec.cliPrefix, ...MANAGED_OUTPUT_ARGS, ...commandArgs];
 }
 
 function rejectConflictingFixedArgs(command: CompactFallowRunParams["command"], args: string[]): void {
@@ -356,15 +322,19 @@ function rejectConflictingFixedArgs(command: CompactFallowRunParams["command"], 
 	if (conflict) throw new Error(`${command} args must not include ${conflict}.`);
 }
 
-function commandPrefix(command: CompactFallowRunParams["command"]): readonly string[] {
-	const prefix = (COMMAND_PREFIXES as Record<string, readonly string[]>)[command];
-	if (!prefix) throw new Error(`Unsupported fallow command: ${command}`);
-	return prefix;
+function commandSpec(command: string): FallowToolCommandSpec {
+	const spec = getFallowToolCommandSpec(command);
+	if (!spec) throw new Error(`Unsupported fallow command: ${command}`);
+	return spec;
 }
 
-function normalizeCompactArgs(command: CompactFallowRunParams["command"], args: string[]): string[] {
-	const normalized = command === "check-changed" ? normalizeCheckChangedArgs(args) : [...args];
-	return normalizeAtPrefixedTargets(command, normalized);
+function commandPrefix(command: CompactFallowRunParams["command"]): readonly string[] {
+	return commandSpec(command).cliPrefix;
+}
+
+function normalizeCompactArgs(spec: FallowToolCommandSpec, args: string[]): string[] {
+	const normalized = spec.name === "check-changed" ? normalizeCheckChangedArgs(args) : [...args];
+	return normalizeAtPrefixedTargets(spec, normalized);
 }
 
 function normalizeCheckChangedArgs(args: string[]): string[] {
@@ -385,19 +355,24 @@ function hasFlagValue(args: string[], flag: string): boolean {
 	return args.some((arg) => arg.startsWith(`${flag}=`) && arg.length > flag.length + 1);
 }
 
-function normalizeAtPrefixedTargets(command: CompactFallowRunParams["command"], args: string[]): string[] {
-	return args.map((arg, index) => normalizeAtPrefixedTarget(command, args, arg, index));
+function normalizeAtPrefixedTargets(spec: FallowToolCommandSpec, args: string[]): string[] {
+	return args.map((arg, index) => normalizeAtPrefixedTarget(spec, args, arg, index));
 }
 
 function normalizeAtPrefixedTarget(
-	command: CompactFallowRunParams["command"],
+	spec: FallowToolCommandSpec,
 	args: string[],
 	arg: string,
 	index: number,
 ): string {
-	if (index === 0 && PATH_TARGET_COMMANDS.has(command)) return stripAtPrefix(arg);
+	if (isPositionalPathTarget(spec, args, index)) return stripAtPrefix(arg);
 	if (isPathOptionValue(args, index)) return stripAtPrefix(arg);
 	return normalizeInlinePathOption(arg);
+}
+
+function isPositionalPathTarget(spec: FallowToolCommandSpec, args: string[], index: number): boolean {
+	if (spec.pathTargets === "first") return index === 0;
+	return spec.pathTargets === "positionals" && isPositionalCliArg(args, index, spec.positionalFlags ?? []);
 }
 
 function isPathOptionValue(args: string[], index: number): boolean {

--- a/extensions/fallow/command/args.ts
+++ b/extensions/fallow/command/args.ts
@@ -1,3 +1,6 @@
+import { isPositionalCliArg, stripAtPrefix } from "../path";
+import { getFallowSlashAliasSpec, type FallowSlashAliasSpec } from "../registry";
+
 type Notify = (message: string, level: "info" | "warning") => void;
 
 const FALLBACK_DEFAULT_COMMAND = ["health"];
@@ -83,11 +86,8 @@ function hasFlag(args: string[], flag: string): boolean {
 function resolveFallbackArgs(rawArgs: string[]): string[] {
 	const normalized = [...rawArgs];
 	validateRequiredCommandArgs(normalized);
-	const command = normalized[0] ?? "";
-	const alias = commandAliasMap[command];
-	if (alias) return alias(normalized);
-	const translator = traceCommandMap[command];
-	return translator ? translator(normalized) : normalized;
+	const alias = getFallowSlashAliasSpec(normalized[0] ?? "");
+	return alias ? buildFallowSlashAliasArgs(normalized, alias) : normalized;
 }
 
 function validateRequiredCommandArgs(args: string[]): void {
@@ -97,15 +97,14 @@ function validateRequiredCommandArgs(args: string[]): void {
 	throw new Error("explain requires at least one issue type, for example: /fallow explain unused-export");
 }
 
-const commandAliasMap: Record<string, (args: string[]) => string[]> = {
-	all: (args) => args.slice(1),
-	"check-changed": buildCheckChangedFallowArgs,
-	"project-info": (args) => ["list", ...args.slice(1)],
-	"list-boundaries": (args) => ["list", "--boundaries", ...args.slice(1)],
-	"fix-preview": (args) => ["fix", "--dry-run", ...args.slice(1)],
-	"fix-apply": (args) => ["fix", "--yes", ...args.slice(1)],
-	"coverage-analyze": (args) => ["coverage", "analyze", ...args.slice(1)],
-};
+function buildFallowSlashAliasArgs(args: string[], alias: FallowSlashAliasSpec): string[] {
+	if (alias.name === "check-changed") return [...alias.cliPrefix, ...buildCheckChangedFallowArgs(args)];
+	if (alias.name === "trace-export") return buildTraceExportArgs(args, alias.cliPrefix);
+	if (alias.name === "trace-clone") return parseTraceCloneArgs(args, alias.cliPrefix);
+	const aliasArgs = normalizeSlashAliasPathTargets(alias, args.slice(1));
+	validateSlashAliasTarget(alias, aliasArgs);
+	return [...alias.cliPrefix, ...aliasArgs];
+}
 
 function buildCheckChangedFallowArgs(args: string[]): string[] {
 	const changedArgs = args.slice(1);
@@ -116,27 +115,46 @@ function buildCheckChangedFallowArgs(args: string[]): string[] {
 	return changedArgs;
 }
 
-const traceCommandMap: Record<string, (args: string[]) => string[]> = {
-	"trace-file": (args) => {
-		if (!args[1]) throw new Error("trace-file requires file.");
-		return ["dead-code", "--trace-file", ...args.slice(1)];
-	},
-	"trace-export": (args) => {
-		if (!args[1] || !args[2]) throw new Error("trace-export requires file and exportName.");
-		return ["dead-code", "--trace", `${args[1]}:${args[2]}`, ...args.slice(3)];
-	},
-	"trace-dependency": (args) => {
-		if (!args[1]) throw new Error("trace-dependency requires packageName.");
-		return ["dead-code", "--trace-dependency", ...args.slice(1)];
-	},
-	"trace-clone": (args) => parseTraceCloneArgs(args),
-};
+function buildTraceExportArgs(args: string[], prefix: readonly string[]): string[] {
+	if (!args[1] || !args[2]) throw new Error("trace-export requires file and exportName.");
+	return [...prefix, `${args[1]}:${args[2]}`, ...args.slice(3)];
+}
 
-function parseTraceCloneArgs(args: string[]): string[] {
+const SLASH_TARGET_ERRORS = new Map<string, string>([
+	["trace-file", "trace-file requires file."],
+	["trace-dependency", "trace-dependency requires packageName."],
+]);
+
+function validateSlashAliasTarget(alias: FallowSlashAliasSpec, args: string[]): void {
+	const message = slashAliasTargetError(alias, args[0]);
+	if (message) throw new Error(message);
+}
+
+function slashAliasTargetError(alias: FallowSlashAliasSpec, target: string | undefined): string | undefined {
+	if (!alias.positionalTarget) return undefined;
+	if (isSlashTarget(target)) return undefined;
+	return SLASH_TARGET_ERRORS.get(alias.name) ?? `${alias.alias} requires its target as the first argument.`;
+}
+
+function isSlashTarget(target: string | undefined): boolean {
+	return !!target && !target.startsWith("-");
+}
+
+function normalizeSlashAliasPathTargets(alias: FallowSlashAliasSpec, args: string[]): string[] {
+	if (!alias.slashPathTargets) return args;
+	return args.map((arg, index) => isSlashPathTarget(alias, args, index) ? stripAtPrefix(arg) : arg);
+}
+
+function isSlashPathTarget(alias: FallowSlashAliasSpec, args: string[], index: number): boolean {
+	if (alias.slashPathTargets === "first") return index === 0;
+	return isPositionalCliArg(args, index, alias.positionalFlags ?? []);
+}
+
+function parseTraceCloneArgs(args: string[], prefix: readonly string[]): string[] {
 	const { fileOrPath, line } = getTraceCloneInput(args);
-	if (line) return buildTraceCloneFromLine(fileOrPath, line, args);
+	if (line) return buildTraceCloneFromLine(fileOrPath, line, args, prefix);
 	const parsed = parseTraceCloneFromPath(fileOrPath);
-	return buildTraceCloneFromParsed(parsed, args);
+	return buildTraceCloneFromParsed(parsed, args, prefix);
 }
 
 function getTraceCloneInput(args: string[]): { fileOrPath: string; line?: string } {
@@ -150,11 +168,20 @@ function parseTraceCloneFromPath(fileOrPath: string): RegExpMatchArray {
 	return match;
 }
 
-function buildTraceCloneFromLine(fileOrPath: string, line: string, args: string[]): string[] {
+function buildTraceCloneFromLine(
+	fileOrPath: string,
+	line: string,
+	args: string[],
+	prefix: readonly string[],
+): string[] {
 	if (!/^\d+$/.test(line)) throw new Error("trace-clone requires file and numeric line.");
-	return ["dupes", "--trace", `${fileOrPath}:${line}`, ...args.slice(3)];
+	return [...prefix, `${fileOrPath}:${line}`, ...args.slice(3)];
 }
 
-function buildTraceCloneFromParsed(match: RegExpMatchArray, args: string[]): string[] {
-	return ["dupes", "--trace", `${match[1]}:${match[2]}`, ...args.slice(2)];
+function buildTraceCloneFromParsed(
+	match: RegExpMatchArray,
+	args: string[],
+	prefix: readonly string[],
+): string[] {
+	return [...prefix, `${match[1]}:${match[2]}`, ...args.slice(2)];
 }

--- a/extensions/fallow/path.ts
+++ b/extensions/fallow/path.ts
@@ -1,3 +1,17 @@
 export function stripAtPrefix(path: string): string {
 	return path.startsWith("@") ? path.slice(1) : path;
 }
+
+export function isPositionalCliArg(args: string[], index: number, positionalFlags: readonly string[]): boolean {
+	if (index === 0) return true;
+	if (isCliFlag(args[index])) return false;
+	return !isValueTakingCliFlag(args[index - 1]!, positionalFlags);
+}
+
+function isCliFlag(arg: string | undefined): boolean {
+	return arg?.startsWith("-") ?? false;
+}
+
+function isValueTakingCliFlag(arg: string, positionalFlags: readonly string[]): boolean {
+	return isCliFlag(arg) && !arg.includes("=") && !positionalFlags.includes(arg);
+}

--- a/extensions/fallow/registry.ts
+++ b/extensions/fallow/registry.ts
@@ -1,0 +1,301 @@
+export type FallowPathTargets = "first" | "positionals";
+
+export interface FallowToolCommandMetadata {
+	cliPrefix: readonly string[];
+	positionalTarget?: true;
+	pathTargets?: FallowPathTargets;
+	positionalFlags?: readonly string[];
+}
+
+interface FallowSlashRootMetadata {
+	value: string;
+	label?: string;
+	description: string;
+	autocomplete?: boolean;
+	hintOrder?: number;
+}
+
+interface FallowSlashCommandMetadata {
+	alias?: string;
+	normalizePathTargets?: true;
+	root?: FallowSlashRootMetadata;
+}
+
+interface FallowCommandRegistryEntry {
+	name: string;
+	tool?: FallowToolCommandMetadata;
+	slash?: FallowSlashCommandMetadata;
+}
+
+const GUARD_POSITIONAL_FLAGS = [
+	"--allow-remote-extends", "--pretty", "-q", "--quiet", "--no-cache", "--diff-stdin",
+	"--production", "--no-production", "--performance", "--explain", "--explain-skipped", "--summary",
+	"--ci", "--fail-on-issues", "--fail-on-regression", "--dupes-skip-local", "--dupes-cross-language",
+	"--dupes-ignore-imports", "--dupes-no-ignore-imports", "--include-entry-exports", "--type-aware",
+	"--no-type-aware", "-h", "--help",
+] as const;
+
+const fallowCommandRegistry = [
+	{
+		name: "pr",
+		slash: { root: { value: "pr", description: "Run audit with detected PR base (new-only)", hintOrder: 2 } },
+	},
+	{
+		name: "run",
+		slash: { root: { value: "run", description: "Run the configured default command (health unless overridden)" } },
+	},
+	{
+		name: "rerun",
+		slash: { root: { value: "rerun", description: "Rerun the last /fallow command", hintOrder: 3 } },
+	},
+	{
+		name: "about",
+		slash: { root: { value: "about", description: "Show Pi Fallow version, update, and project links", hintOrder: 0 } },
+	},
+	{
+		name: "all",
+		tool: { cliPrefix: [] },
+		slash: {
+			alias: "all",
+			root: { value: "all", description: "Run full repository checks and checks summary", hintOrder: 1 },
+		},
+	},
+	{
+		name: "dead-code",
+		tool: { cliPrefix: ["dead-code"] },
+		slash: { root: { value: "dead-code", description: "Find unused exports, files, dependencies, and types", hintOrder: 4 } },
+	},
+	{
+		name: "check-changed",
+		tool: { cliPrefix: [] },
+		slash: {
+			alias: "check-changed",
+			root: { value: "check-changed", description: "Run combined changed-file checks; add --changed-since main/origin/main" },
+		},
+	},
+	{
+		name: "dupes",
+		tool: { cliPrefix: ["dupes"] },
+		slash: { root: { value: "dupes", description: "Find duplicated code and clone groups", hintOrder: 5 } },
+	},
+	{
+		name: "health",
+		tool: { cliPrefix: ["health"] },
+		slash: { root: { value: "health", description: "Show maintainability, complexity, churn, and health metrics", hintOrder: 6 } },
+	},
+	{
+		name: "audit",
+		tool: { cliPrefix: ["audit"] },
+		slash: { root: { value: "audit", description: "Run a PR/change gate; use --base main --gate new-only for PRs", hintOrder: 7 } },
+	},
+	{
+		name: "fix-preview",
+		tool: { cliPrefix: ["fix", "--dry-run"] },
+		slash: { alias: "fix-preview" },
+	},
+	{
+		name: "fix-apply",
+		tool: { cliPrefix: ["fix", "--yes"] },
+		slash: { alias: "fix-apply" },
+	},
+	{
+		name: "flags",
+		tool: { cliPrefix: ["flags"] },
+		slash: { root: { value: "flags", description: "Analyze feature flags", hintOrder: 20 } },
+	},
+	{
+		name: "inspect",
+		tool: { cliPrefix: ["inspect"] },
+		slash: {
+			root: { value: "inspect", description: "Inspect one file or exported symbol", autocomplete: false, hintOrder: 8 },
+		},
+	},
+	{
+		name: "trace-symbol",
+		tool: { cliPrefix: ["trace"], positionalTarget: true, pathTargets: "first" },
+		slash: { root: { value: "trace", description: "Trace a symbol call chain: trace path/to/file.ts:exportName", hintOrder: 9 } },
+	},
+	{
+		name: "security",
+		tool: { cliPrefix: ["security"] },
+		slash: { root: { value: "security", description: "Surface local security candidates for agent verification", hintOrder: 10 } },
+	},
+	{
+		name: "architecture",
+		tool: {
+			cliPrefix: ["guard"],
+			positionalTarget: true,
+			pathTargets: "positionals",
+			positionalFlags: GUARD_POSITIONAL_FLAGS,
+		},
+		slash: {
+			alias: "architecture",
+			normalizePathTargets: true,
+			root: { value: "architecture", description: "Show which architecture rules apply to files before changing them", hintOrder: 11 },
+		},
+	},
+	{
+		name: "workspaces",
+		tool: { cliPrefix: ["workspaces"] },
+		slash: { root: { value: "workspaces", description: "Show monorepo workspace discovery diagnostics", hintOrder: 13 } },
+	},
+	{
+		name: "config",
+		tool: { cliPrefix: ["config"] },
+		slash: { root: { value: "config", description: "Show resolved Fallow config", hintOrder: 14 } },
+	},
+	{
+		name: "schema",
+		tool: { cliPrefix: ["schema"] },
+		slash: { root: { value: "schema", description: "Dump Fallow's machine-readable CLI capability schema", hintOrder: 15 } },
+	},
+	{
+		name: "decision-surface",
+		tool: { cliPrefix: ["decision-surface"] },
+		slash: {
+			root: { value: "decision-surface", description: "Surface structural decisions embedded in the current change", autocomplete: false, hintOrder: 12 },
+		},
+	},
+	{
+		name: "impact",
+		tool: { cliPrefix: ["impact"] },
+		slash: { root: { value: "impact", description: "Show local Fallow impact metrics", hintOrder: 16 } },
+	},
+	{
+		name: "project-info",
+		tool: { cliPrefix: ["list"] },
+		slash: {
+			alias: "project-info",
+			root: { value: "project-info", description: "Show project info (entry points/files/plugins/boundaries)", hintOrder: 18 },
+		},
+	},
+	{
+		name: "list-boundaries",
+		tool: { cliPrefix: ["list", "--boundaries"] },
+		slash: { alias: "list-boundaries" },
+	},
+	{
+		name: "explain",
+		tool: { cliPrefix: ["explain"], positionalTarget: true },
+		slash: { root: { value: "explain", description: "Explain a Fallow issue type/rule id", hintOrder: 22 } },
+	},
+	{
+		name: "trace-export",
+		tool: { cliPrefix: ["dead-code", "--trace"], positionalTarget: true, pathTargets: "first" },
+		slash: {
+			alias: "trace-export",
+			root: { value: "trace-export", description: "Trace a specific export: trace-export path/to/file.ts exportName" },
+		},
+	},
+	{
+		name: "trace-file",
+		tool: { cliPrefix: ["dead-code", "--trace-file"], positionalTarget: true, pathTargets: "first" },
+		slash: {
+			alias: "trace-file",
+			root: { value: "trace-file", description: "Investigate one file: trace-file path/to/file.ts" },
+		},
+	},
+	{
+		name: "trace-dependency",
+		tool: { cliPrefix: ["dead-code", "--trace-dependency"], positionalTarget: true },
+		slash: {
+			alias: "trace-dependency",
+			root: { value: "trace-dependency", description: "Trace a package dependency" },
+		},
+	},
+	{
+		name: "trace-clone",
+		tool: { cliPrefix: ["dupes", "--trace"], positionalTarget: true, pathTargets: "first" },
+		slash: {
+			alias: "trace-clone",
+			root: { value: "trace-clone", description: "Trace a duplication clone at path/to/file.ts:line" },
+		},
+	},
+	{
+		name: "coverage-analyze",
+		tool: { cliPrefix: ["coverage", "analyze"] },
+		slash: {
+			alias: "coverage-analyze",
+			root: { value: "coverage analyze", description: "Analyze runtime coverage and cold paths", hintOrder: 21 },
+		},
+	},
+	{
+		name: "fix",
+		slash: { root: { value: "fix", description: "Preview/apply safe cleanup fixes; usually add --dry-run first", hintOrder: 17 } },
+	},
+	{
+		name: "list",
+		slash: { root: { value: "list", description: "List project info, files, plugins, entry points, boundaries, or workspaces", hintOrder: 19 } },
+	},
+	{
+		name: "help",
+		slash: { root: { value: "--help", description: "Show Fallow CLI help" } },
+	},
+] as const satisfies readonly FallowCommandRegistryEntry[];
+
+type RegistryEntry = typeof fallowCommandRegistry[number];
+type ToolCommandName<Entry> = Entry extends { name: infer Name extends string; tool: FallowToolCommandMetadata }
+	? Name
+	: never;
+
+export type FallowToolCommand = ToolCommandName<RegistryEntry>;
+
+export interface FallowToolCommandSpec extends FallowToolCommandMetadata {
+	name: FallowToolCommand;
+}
+
+export interface FallowSlashAliasSpec extends FallowToolCommandSpec {
+	alias: string;
+	slashPathTargets?: FallowPathTargets;
+}
+
+interface FallowSlashRootSpec extends FallowSlashRootMetadata {
+	registryName: string;
+}
+
+const toolCommandSpecs = fallowCommandRegistry
+	.filter((entry): entry is RegistryEntry & { tool: FallowToolCommandMetadata } => "tool" in entry)
+	.map((entry) => ({ name: entry.name, ...entry.tool })) as FallowToolCommandSpec[];
+
+const toolCommandSpecsByName = new Map(toolCommandSpecs.map((entry) => [entry.name, entry]));
+
+type SlashAliasRegistryEntry = RegistryEntry & {
+	tool: FallowToolCommandMetadata;
+	slash: FallowSlashCommandMetadata & { alias: string };
+};
+
+const slashAliasSpecs = fallowCommandRegistry
+	.filter(hasSlashAlias)
+	.map(toSlashAliasSpec);
+
+const slashAliasSpecsByName = new Map(slashAliasSpecs.map((entry) => [entry.alias, entry]));
+
+function hasSlashAlias(entry: RegistryEntry): entry is SlashAliasRegistryEntry {
+	return "tool" in entry && "slash" in entry && "alias" in entry.slash;
+}
+
+function toSlashAliasSpec(entry: SlashAliasRegistryEntry): FallowSlashAliasSpec {
+	const slashPathTargets = "normalizePathTargets" in entry.slash ? entry.tool.pathTargets : undefined;
+	return { name: entry.name, alias: entry.slash.alias, slashPathTargets, ...entry.tool } as FallowSlashAliasSpec;
+}
+
+export const fallowToolCommands = toolCommandSpecs.map((entry) => entry.name);
+
+export const fallowSlashRootCommands = fallowCommandRegistry.flatMap((entry): FallowSlashRootSpec[] => {
+	if (!("slash" in entry) || !("root" in entry.slash)) return [];
+	return [{ registryName: entry.name, ...entry.slash.root }];
+});
+
+export const fallowArgumentHint = `[${fallowSlashRootCommands
+	.filter((command) => command.hintOrder !== undefined)
+	.sort((left, right) => left.hintOrder! - right.hintOrder!)
+	.map((command) => command.value)
+	.join("|")}] [options]`;
+
+export function getFallowToolCommandSpec(command: string): FallowToolCommandSpec | undefined {
+	return toolCommandSpecsByName.get(command as FallowToolCommand);
+}
+
+export function getFallowSlashAliasSpec(command: string): FallowSlashAliasSpec | undefined {
+	return slashAliasSpecsByName.get(command);
+}

--- a/extensions/fallow/schema.ts
+++ b/extensions/fallow/schema.ts
@@ -1,33 +1,8 @@
 import { StringEnum } from "@earendil-works/pi-ai";
 import { Type, type Static } from "typebox";
+import { fallowToolCommands } from "./registry";
 
-const FallowCommand = StringEnum([
-	"all",
-	"dead-code",
-	"check-changed",
-	"dupes",
-	"health",
-	"audit",
-	"fix-preview",
-	"fix-apply",
-	"flags",
-	"inspect",
-	"trace-symbol",
-	"security",
-	"workspaces",
-	"config",
-	"schema",
-	"decision-surface",
-	"impact",
-	"project-info",
-	"list-boundaries",
-	"explain",
-	"trace-export",
-	"trace-file",
-	"trace-dependency",
-	"trace-clone",
-	"coverage-analyze",
-] as const);
+const FallowCommand = StringEnum(fallowToolCommands);
 
 const OutputDetail = StringEnum(["summary", "findings", "raw"] as const, { default: "findings" });
 

--- a/scripts/fallow-smoke.mjs
+++ b/scripts/fallow-smoke.mjs
@@ -65,6 +65,10 @@ function assertModeledArgs() {
 		["security", "--format", "json", "--quiet", "--changed-since", "HEAD~1", "--gate", "new", "--surface"],
 	);
 	assertArgs(
+		{ command: "architecture", args: ["@extensions/fallow/cli.ts", "@extensions/fallow/registry.ts", "--no-cache"] },
+		["guard", "extensions/fallow/cli.ts", "--format", "json", "--quiet", "extensions/fallow/registry.ts", "--no-cache"],
+	);
+	assertArgs(
 		{ command: "decision-surface", args: ["--changed-since", "HEAD~1", "--max-decisions", "4"] },
 		["decision-surface", "--format", "json", "--quiet", "--changed-since", "HEAD~1", "--max-decisions", "4"],
 	);
@@ -91,7 +95,7 @@ function assertCurrentFallowSchema(data) {
 	assert.ok(Array.isArray(data.commands));
 	const commands = new Map(data.commands.map((command) => [command.name, command]));
 	for (const command of [
-		"dead-code", "type-aware", "inspect", "trace", "fix", "config", "list", "workspaces", "dupes", "health",
+		"dead-code", "type-aware", "inspect", "trace", "guard", "fix", "config", "list", "workspaces", "dupes", "health",
 		"flags", "explain", "audit", "decision-surface", "impact", "security", "report", "schema", "coverage", "viz",
 	]) {
 		assert.ok(commands.has(command), `Fallow schema is missing ${command}`);
@@ -102,6 +106,13 @@ function assertCurrentFallowSchema(data) {
 	}
 	assert.ok(commands.get("dead-code").flags.some((flag) => flag.name === "--symbol-impact"));
 	assert.ok(commands.get("health").flags.some((flag) => flag.name === "--type-coupling"));
+	assert.match(commands.get("guard").description, /architecture rules apply to files/);
+	assert.deepEqual(commands.get("guard").flags, [{
+		name: "files",
+		type: "string",
+		required: true,
+		description: "Files to report on (root-relative or absolute; may not exist yet)",
+	}]);
 	assert.deepEqual(commands.get("type-aware").flags, []);
 	assert.match(commands.get("report").description, /codeclimate.*sarif/);
 	assert.deepEqual(commands.get("viz").flags.map((flag) => flag.name), ["--out", "--no-open", "--viz-format"]);
@@ -119,6 +130,10 @@ function assertCliSurfaces() {
 	assertFallowJson(["security"], (data) => {
 		assert.equal(data.kind, "security");
 		assert.ok(Array.isArray(data.security_findings));
+	});
+	assertFallowJson(["guard", "extensions/fallow/cli.ts"], (data) => {
+		assert.equal(data.kind, "guard");
+		assert.equal(data.files?.[0]?.path, "extensions/fallow/cli.ts");
 	});
 	assertFallowJson(["workspaces"], (data) => {
 		assert.equal(data.kind, "list-workspaces");

--- a/tests/autocomplete.test.mjs
+++ b/tests/autocomplete.test.mjs
@@ -37,8 +37,11 @@ function git(cwd, args) {
 
 describe("Fallow autocomplete", () => {
 	it("returns command, flag, and fixed-value completions", () => {
-		assert.ok(labels(fallowCompletions.getFallowRootCommandCompletions()).includes("health"));
-		assert.ok(labels(fallowCompletions.getFallowRootCommandCompletions()).includes("run"));
+		const rootCompletions = fallowCompletions.getFallowRootCommandCompletions();
+		assert.ok(labels(rootCompletions).includes("health"));
+		assert.ok(labels(rootCompletions).includes("run"));
+		const architecture = rootCompletions.find((item) => item.label === "architecture");
+		assert.match(architecture?.description ?? "", /architecture rules apply to files before changing them/);
 		assert.ok(completionLabels("").includes("audit PR (main)"));
 		assert.ok(completionLabels("").includes("symbol impact"));
 		assert.ok(completionLabels("").includes("health type coupling"));
@@ -48,6 +51,7 @@ describe("Fallow autocomplete", () => {
 		assert.ok(completionLabels("health --").includes("--type-aware-project"));
 		assert.ok(completionLabels("health --").includes("--type-coupling"));
 		assert.ok(completionLabels("dead-code --").includes("--symbol-impact"));
+		assert.ok(completionLabels("architecture --").includes("--no-cache"));
 		assert.ok(completionLabels("run --").includes("--file-scores"));
 		assert.deepEqual(completionLabels("health --type-aware-require c"), ["complete"]);
 		assert.deepEqual(completionLabels("health --baseline-mode i"), ["identity"]);

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -54,6 +54,24 @@ describe("fallowCli.buildFallowArgs", () => {
 		assert.throws(() => build({ command: "trace-symbol", args: ["--callers"] }), /requires its target/);
 	});
 
+	it("builds architecture guard queries with required normalized path targets", () => {
+		assert.deepEqual(build({
+			command: "architecture",
+			args: ["@src/api.ts", "@src/domain.ts", "--changed-since", "main", "--no-cache"],
+		}), [
+			"guard", "src/api.ts", "--format", "json", "--quiet",
+			"src/domain.ts", "--changed-since", "main", "--no-cache",
+		]);
+		assert.deepEqual(build({ command: "architecture", args: ["@src/api.ts", "--config", "@config/fallow.json"] }), [
+			"guard", "src/api.ts", "--format", "json", "--quiet", "--config", "@config/fallow.json",
+		]);
+		assert.deepEqual(build({ command: "architecture", args: ["@src/api.ts", "--workspace", "@scope/pkg"] }), [
+			"guard", "src/api.ts", "--format", "json", "--quiet", "--workspace", "@scope/pkg",
+		]);
+		assert.throws(() => build({ command: "architecture" }), /architecture requires its target as the first args entry/);
+		assert.throws(() => build({ command: "architecture", args: ["--no-cache"] }), /architecture requires its target/);
+	});
+
 	it("builds command aliases and raw options", () => {
 		assert.deepEqual(build({ command: "security", args: ["--changed-since", "HEAD~1", "--gate", "new", "--surface"] }), [
 			"security", "--format", "json", "--quiet", "--changed-since", "HEAD~1", "--gate", "new", "--surface",

--- a/tests/command-args.test.mjs
+++ b/tests/command-args.test.mjs
@@ -61,6 +61,23 @@ describe("normalizeFallowArgs", () => {
 		assert.deepEqual(normalize(["coverage-analyze"]).result, ["coverage", "analyze"]);
 	});
 
+	it("maps architecture to guard with required normalized path targets", () => {
+		assert.deepEqual(normalize([
+			"architecture", "@src/api.ts", "@src/domain.ts", "--changed-since", "main", "--no-cache",
+		]).result, [
+			"guard", "src/api.ts", "src/domain.ts", "--changed-since", "main", "--no-cache",
+		]);
+		assert.deepEqual(normalize(["architecture", "@src/api.ts", "--config", "@config/fallow.json"]).result, [
+			"guard", "src/api.ts", "--config", "@config/fallow.json",
+		]);
+		assert.deepEqual(normalize(["architecture", "@src/api.ts", "--workspace", "@scope/pkg"]).result, [
+			"guard", "src/api.ts", "--workspace", "@scope/pkg",
+		]);
+		assert.throws(() => normalize(["architecture"]), /architecture requires its target as the first argument/);
+		assert.throws(() => normalize(["architecture", "--no-cache"]), /architecture requires its target/);
+		assert.deepEqual(normalize(["guard", "@src/api.ts"]).result, ["guard", "@src/api.ts"]);
+	});
+
 	it("preserves type-aware report flags for direct Fallow commands", () => {
 		assert.deepEqual(normalize(["dead-code", "--type-aware", "--symbol-impact", "src/api.ts:Client"]).result, [
 			"dead-code", "--type-aware", "--symbol-impact", "src/api.ts:Client",
@@ -83,6 +100,15 @@ describe("normalizeFallowArgs", () => {
 	});
 
 	it("maps trace aliases", () => {
+		assert.deepEqual(normalize(["trace-file", "@extensions/fallow/cli.ts"]).result, [
+			"dead-code", "--trace-file", "@extensions/fallow/cli.ts",
+		]);
+		assert.deepEqual(normalize(["trace-export", "@extensions/fallow/cli.ts", "fallowCli"]).result, [
+			"dead-code", "--trace", "@extensions/fallow/cli.ts:fallowCli",
+		]);
+		assert.deepEqual(normalize(["trace-clone", "@extensions/fallow/cli.ts", "10"]).result, [
+			"dupes", "--trace", "@extensions/fallow/cli.ts:10",
+		]);
 		assert.deepEqual(normalize(["trace-file", "extensions/fallow/cli.ts"]).result, [
 			"dead-code", "--trace-file", "extensions/fallow/cli.ts",
 		]);

--- a/tests/command-registry.test.mjs
+++ b/tests/command-registry.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { default: registerPiFallow } = await jiti.import("../extensions/fallow.ts");
+const { fallowCompletions } = await jiti.import("../extensions/fallow/autocomplete.ts");
+const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
+const { fallowToolContract } = await jiti.import("../extensions/fallow/contract.ts");
+const {
+	fallowArgumentHint,
+	fallowSlashRootCommands,
+	fallowToolCommands,
+	getFallowToolCommandSpec,
+} = await jiti.import("../extensions/fallow/registry.ts");
+
+function argsFor(command, spec) {
+	if (command === "check-changed") return ["--changed-since", "main"];
+	if (!spec.positionalTarget) return [];
+	return [spec.pathTargets ? "@src/example.ts:target" : "target"];
+}
+
+describe("Fallow command registry", () => {
+	it("is the exact source of the public tool command enum", () => {
+		assert.deepEqual(fallowToolContract.parameters.properties.command.enum, fallowToolCommands);
+		assert.equal(new Set(fallowToolCommands).size, fallowToolCommands.length);
+		assert.ok(fallowToolCommands.includes("architecture"));
+	});
+
+	it("provides a compact CLI mapping for every tool command", () => {
+		for (const command of fallowToolCommands) {
+			const spec = getFallowToolCommandSpec(command);
+			assert.ok(spec, `Missing registry spec for ${command}`);
+			const built = fallowCli.buildFallowArgs({ command, args: argsFor(command, spec) });
+			assert.deepEqual(built.slice(0, spec.cliPrefix.length), spec.cliPrefix, command);
+		}
+	});
+
+	it("derives slash autocomplete and the registered argument hint from registry metadata", () => {
+		const completionValues = new Set(
+			fallowCompletions.getFallowRootCommandCompletions().map((item) => item.value),
+		);
+		for (const command of fallowSlashRootCommands) {
+			if (command.autocomplete !== false) {
+				assert.ok(completionValues.has(`fallow ${command.value}`), `Missing completion for ${command.value}`);
+			}
+		}
+
+		const hintedRoots = fallowSlashRootCommands
+			.filter((command) => command.hintOrder !== undefined)
+			.sort((left, right) => left.hintOrder - right.hintOrder)
+			.map((command) => command.value);
+		assert.equal(fallowArgumentHint, `[${hintedRoots.join("|")}] [options]`);
+
+		let registeredCommand;
+		registerPiFallow({
+			registerTool() {},
+			registerCommand(name, command) { if (name === "fallow") registeredCommand = command; },
+			registerMessageRenderer() {},
+			on() {},
+		});
+		assert.equal(registeredCommand.argumentHint, fallowArgumentHint);
+	});
+});


### PR DESCRIPTION
## Summary

- centralize `fallow_run` command names, compact CLI prefixes, target behavior, overlapping slash metadata, autocomplete roots, and the `/fallow` argument hint in one typed registry
- add `architecture` to `fallow_run` and `/fallow`, backed by locked Fallow 3.14.0's stable `guard <FILES>...` command
- keep direct raw `/fallow guard ...` behavior and existing navigator/TUI behavior unchanged
- normalize Pi's optional leading `@` only on architecture file targets, preserving scoped and other flag values
- add registry-parity, architecture, autocomplete, smoke, and compatibility regressions

## Compatibility and scope

- no dependency or lockfile changes
- Pi packages remain external wildcard peers
- no ROADMAP changes in this focused phase
- no tag, publication, or release

## Validation

- `npm test` — 149 passed
- `npm run coverage` — thresholds passed
- `npm run check:publish` — passed
- `npm run check:bundle` — passed
- `npm run health` — no findings
- `npm run dupes` — no clone groups
- `npm run dead-code` — no issues
- `npm run smoke:fallow` — passed, including locked Fallow 3.14 schema/help and real guard JSON
- `npm run audit:production` / complete audit — 0 vulnerabilities
- `npm run package:smoke` — passed with Pi 0.84.1 RPC/print/JSON certification
- changed-file Fallow combined checks — no actionable findings
- Fallow security for the change — no candidates
- `git diff --check` — passed

## Token impact

The active tool contract is 439 tokens under both `o200k_base` and `cl100k_base`. Adding required `architecture` support costs 4 tokens while retaining the existing 440-token total and 90-token guidance ceilings.

## Review

Independent review found one high-severity argument-normalization bug: architecture initially stripped `@` from non-path flag values such as `--workspace @scope/pkg`. The implementation was changed to flag-aware positional normalization and both compact/slash regressions were added. Round two approved.

A separate post-implementation technical probe reran the locked Fallow boundary, tests, bundle, package certification, and audits and approved with no actionable findings.
