### PR TITLE
refactor: centralize normalized report handling

### DIFF
--- a/extensions/fallow/command/navigator.ts
+++ b/extensions/fallow/command/navigator.ts
@@ -1,3 +1,4 @@
+import { getNormalizedFallowReport } from "../normalized-report";
 import type { FallowOverview } from "../types";
 
 const NAVIGATOR_STATIC_ROWS = 17;
@@ -22,7 +23,8 @@ export function resolveFallowNavigatorVisibleRows(terminalRows: number, informat
 }
 
 export function resolveFallowNavigatorMode(overview: FallowOverview | undefined): FallowNavigatorMode {
-	const populatedSections = overview?.sections.filter((section) => section.items.length > 0) ?? [];
-	if (!populatedSections.length) return "none";
-	return populatedSections.some((section) => section.role !== "context") ? "actionable" : "informational";
+	if (!overview) return "none";
+	const report = getNormalizedFallowReport(overview);
+	if (!report.entryCount) return "none";
+	return report.findingCount ? "actionable" : "informational";
 }

--- a/extensions/fallow/normalized-report.ts
+++ b/extensions/fallow/normalized-report.ts
@@ -1,0 +1,405 @@
+import { Buffer } from "node:buffer";
+import { asRecord } from "./data";
+import type { FallowIssueLine, FallowOverview } from "./types";
+
+export type NormalizedFallowEntryRole = "finding" | "context";
+
+export interface NormalizedFallowSource {
+	reportIndex: number;
+	sectionIndex: number;
+	itemIndex: number;
+	sectionTitle: string;
+}
+
+export interface NormalizedFallowEntry {
+	role: NormalizedFallowEntryRole;
+	section: string;
+	type: string;
+	id?: string;
+	severity?: string;
+	path?: string;
+	line?: number;
+	subject: string;
+	details?: string;
+	evidence?: string;
+	action?: string;
+	source: NormalizedFallowSource;
+	raw?: unknown;
+}
+
+export interface NormalizedFallowReport {
+	title: string;
+	status: FallowOverview["status"];
+	stats: FallowOverview["stats"];
+	notes: string[];
+	entryCount: number;
+	findingCount: number;
+	contextCount: number;
+}
+
+interface RetainedSemanticFields {
+	type?: string;
+	id?: string;
+	severity?: string;
+	evidence?: string;
+	action?: string;
+}
+
+interface PackedSemanticFields {
+	text: Buffer;
+	offsets: Int32Array;
+	lengths: Uint32Array;
+}
+
+interface NormalizedReportStorage extends PackedSemanticFields {
+	overview: FallowOverview;
+	sectionIndices: Uint32Array;
+	itemIndices: Uint32Array;
+}
+
+interface NormalizedReportCollector {
+	rows: Array<Array<string | undefined>>;
+	sectionIndices: number[];
+	itemIndices: number[];
+	findingCount: number;
+	contextCount: number;
+}
+
+interface SemanticPackBuilder {
+	offsets: Int32Array;
+	lengths: Uint32Array;
+	chunks: Buffer[];
+	locations: Map<string, { offset: number; length: number }>;
+	textLength: number;
+}
+
+const TYPE_FIELD = 0;
+const ID_FIELD = 1;
+const SEVERITY_FIELD = 2;
+const EVIDENCE_FIELD = 3;
+const ACTION_FIELD = 4;
+const SEMANTIC_FIELD_COUNT = 5;
+const SOURCE_COORDINATE_KEYS = ["reportIndex", "sectionIndex", "itemIndex", "sectionTitle"] as const;
+const SEMANTIC_IDENTITY_KEYS = [
+	"role", "section", "type", "id", "severity", "path", "line", "subject", "details", "evidence", "action",
+] as const;
+
+const retainedSemanticFields = new WeakMap<FallowIssueLine, RetainedSemanticFields>();
+const normalizedReports = new WeakMap<FallowOverview, NormalizedFallowReport>();
+const normalizedReportStorage = new WeakMap<NormalizedFallowReport, NormalizedReportStorage>();
+
+/** Retain only semantic scalars while the overview intentionally drops most raw entry objects. */
+export function retainNormalizedFallowEntry(item: FallowIssueLine, raw: unknown): void {
+	retainedSemanticFields.set(item, extractSemanticFields(asRecord(raw)));
+}
+
+export function getNormalizedFallowReport(overview: FallowOverview): NormalizedFallowReport {
+	const retained = normalizedReports.get(overview);
+	if (retained) return retained;
+	const report = normalizeFallowReport(overview);
+	normalizedReports.set(overview, report);
+	return report;
+}
+
+export function normalizeFallowIssue(
+	section: string,
+	item: FallowIssueLine,
+	role: NormalizedFallowEntryRole = "finding",
+	source: NormalizedFallowSource = { reportIndex: -1, sectionIndex: -1, itemIndex: -1, sectionTitle: section },
+): NormalizedFallowEntry {
+	const retained = retainedSemanticFields.get(item) ?? extractSemanticFields(asRecord(item.raw));
+	retainedSemanticFields.delete(item);
+	return createNormalizedEntry(section, item, role, source, retained);
+}
+
+function getNormalizedFallowEntry(
+	report: NormalizedFallowReport,
+	reportIndex: number,
+): NormalizedFallowEntry {
+	assertNormalizedEntryIndex(report, reportIndex);
+	const storage = requireStorage(report);
+	const { section, item, source } = resolveNormalizedSource(storage, reportIndex);
+	return createNormalizedEntry(
+		section.title,
+		item,
+		section.role === "context" ? "context" : "finding",
+		source,
+		readSemanticFields(storage, reportIndex),
+	);
+}
+
+function assertNormalizedEntryIndex(report: NormalizedFallowReport, reportIndex: number): void {
+	const valid = [Number.isInteger(reportIndex), reportIndex >= 0, reportIndex < report.entryCount].every(Boolean);
+	if (!valid) throw new Error("Normalized Fallow entry index is out of range.");
+}
+
+function resolveNormalizedSource(storage: NormalizedReportStorage, reportIndex: number): {
+	section: FallowOverview["sections"][number];
+	item: FallowIssueLine;
+	source: NormalizedFallowSource;
+} {
+	const sectionIndex = storage.sectionIndices[reportIndex]!;
+	const itemIndex = storage.itemIndices[reportIndex]!;
+	const section = storage.overview.sections[sectionIndex];
+	if (!section) throw new Error("Normalized Fallow section coordinates do not match the overview.");
+	const item = section.items[itemIndex];
+	if (!item) throw new Error("Normalized Fallow item coordinates do not match the overview.");
+	return { section, item, source: { reportIndex, sectionIndex, itemIndex, sectionTitle: section.title } };
+}
+
+function readSemanticFields(storage: PackedSemanticFields, reportIndex: number): RetainedSemanticFields {
+	return {
+		type: readSemanticField(storage, reportIndex, TYPE_FIELD),
+		id: readSemanticField(storage, reportIndex, ID_FIELD),
+		severity: readSemanticField(storage, reportIndex, SEVERITY_FIELD),
+		evidence: readSemanticField(storage, reportIndex, EVIDENCE_FIELD),
+		action: readSemanticField(storage, reportIndex, ACTION_FIELD),
+	};
+}
+
+export function allNormalizedFallowEntries(report: NormalizedFallowReport): NormalizedFallowEntry[] {
+	return Array.from({ length: report.entryCount }, (_, index) => getNormalizedFallowEntry(report, index));
+}
+
+export function entriesForFallowRole(
+	report: NormalizedFallowReport,
+	role: NormalizedFallowEntryRole,
+): NormalizedFallowEntry[] {
+	const entries: NormalizedFallowEntry[] = [];
+	for (let index = 0; index < report.entryCount; index++) {
+		const entry = getNormalizedFallowEntry(report, index);
+		if (entry.role === role) entries.push(entry);
+	}
+	return entries;
+}
+
+export function hydrateNormalizedFallowEntry(
+	report: NormalizedFallowReport,
+	expected: NormalizedFallowEntry,
+): NormalizedFallowEntry {
+	const candidate = getNormalizedFallowEntry(report, expected.source.reportIndex);
+	if (!sameSource(candidate.source, expected.source) || !sameSemantics(candidate, expected)) {
+		throw new Error("Complete report coordinates do not match the selected finding.");
+	}
+	return candidate;
+}
+
+function normalizeFallowReport(overview: FallowOverview): NormalizedFallowReport {
+	const collector = createNormalizedReportCollector();
+	for (const [sectionIndex, section] of overview.sections.entries()) {
+		appendNormalizedSection(collector, section, sectionIndex);
+	}
+	const report = createNormalizedReport(overview, collector);
+	storeNormalizedReport(report, overview, collector);
+	return report;
+}
+
+function createNormalizedReportCollector(): NormalizedReportCollector {
+	return { rows: [], sectionIndices: [], itemIndices: [], findingCount: 0, contextCount: 0 };
+}
+
+function appendNormalizedSection(
+	collector: NormalizedReportCollector,
+	section: FallowOverview["sections"][number],
+	sectionIndex: number,
+): void {
+	const context = section.role === "context";
+	collector.contextCount += context ? section.items.length : 0;
+	collector.findingCount += context ? 0 : section.items.length;
+	for (const [itemIndex, item] of section.items.entries()) appendNormalizedItem(collector, section.title, item, sectionIndex, itemIndex);
+}
+
+function appendNormalizedItem(
+	collector: NormalizedReportCollector,
+	sectionTitle: string,
+	item: FallowIssueLine,
+	sectionIndex: number,
+	itemIndex: number,
+): void {
+	const retained = takeRetainedSemanticFields(item);
+	collector.rows.push(buildSemanticRow(sectionTitle, item, retained));
+	collector.sectionIndices.push(sectionIndex);
+	collector.itemIndices.push(itemIndex);
+}
+
+function takeRetainedSemanticFields(item: FallowIssueLine): RetainedSemanticFields {
+	const retained = retainedSemanticFields.get(item) ?? extractSemanticFields(asRecord(item.raw));
+	retainedSemanticFields.delete(item);
+	return retained;
+}
+
+function buildSemanticRow(
+	sectionTitle: string,
+	item: FallowIssueLine,
+	retained: RetainedSemanticFields,
+): Array<string | undefined> {
+	return [
+		retained.type ?? sectionTitle,
+		retained.id,
+		fallbackSemanticField(item.severity, retained.severity),
+		retained.evidence,
+		fallbackSemanticField(item.action, retained.action),
+	];
+}
+
+function fallbackSemanticField(primary: string | undefined, fallback: string | undefined): string | undefined {
+	return primary ? undefined : fallback;
+}
+
+function createNormalizedReport(overview: FallowOverview, collector: NormalizedReportCollector): NormalizedFallowReport {
+	return {
+		title: overview.title,
+		status: overview.status,
+		stats: overview.stats,
+		notes: overview.notes,
+		entryCount: collector.rows.length,
+		findingCount: collector.findingCount,
+		contextCount: collector.contextCount,
+	};
+}
+
+function storeNormalizedReport(
+	report: NormalizedFallowReport,
+	overview: FallowOverview,
+	collector: NormalizedReportCollector,
+): void {
+	normalizedReportStorage.set(report, {
+		overview,
+		sectionIndices: Uint32Array.from(collector.sectionIndices),
+		itemIndices: Uint32Array.from(collector.itemIndices),
+		...packSemanticFields(collector.rows),
+	});
+}
+
+function createNormalizedEntry(
+	section: string,
+	item: FallowIssueLine,
+	role: NormalizedFallowEntryRole,
+	source: NormalizedFallowSource,
+	retained: RetainedSemanticFields,
+): NormalizedFallowEntry {
+	return {
+		role,
+		section,
+		type: retained.type ?? section,
+		id: retained.id,
+		severity: item.severity || retained.severity,
+		path: item.path,
+		line: item.line,
+		subject: item.label,
+		details: item.meta,
+		evidence: retained.evidence,
+		action: item.action || retained.action,
+		source,
+		raw: item.raw,
+	};
+}
+
+function packSemanticFields(rows: Array<Array<string | undefined>>): PackedSemanticFields {
+	const builder = createSemanticPackBuilder(rows.length);
+	for (const [rowIndex, row] of rows.entries()) packSemanticRow(builder, row, rowIndex);
+	return { text: Buffer.concat(builder.chunks, builder.textLength), offsets: builder.offsets, lengths: builder.lengths };
+}
+
+function createSemanticPackBuilder(rowCount: number): SemanticPackBuilder {
+	const offsets = new Int32Array(rowCount * SEMANTIC_FIELD_COUNT);
+	offsets.fill(-1);
+	return { offsets, lengths: new Uint32Array(offsets.length), chunks: [], locations: new Map(), textLength: 0 };
+}
+
+function packSemanticRow(builder: SemanticPackBuilder, row: Array<string | undefined>, rowIndex: number): void {
+	for (let fieldIndex = 0; fieldIndex < SEMANTIC_FIELD_COUNT; fieldIndex++) {
+		packSemanticValue(builder, row[fieldIndex], rowIndex * SEMANTIC_FIELD_COUNT + fieldIndex);
+	}
+}
+
+function packSemanticValue(builder: SemanticPackBuilder, value: string | undefined, packedIndex: number): void {
+	if (value === undefined) return;
+	let location = builder.locations.get(value);
+	if (!location) location = appendSemanticChunk(builder, value);
+	builder.offsets[packedIndex] = location.offset;
+	builder.lengths[packedIndex] = location.length;
+}
+
+function appendSemanticChunk(builder: SemanticPackBuilder, value: string): { offset: number; length: number } {
+	const chunk = Buffer.from(value, "utf8");
+	const location = { offset: builder.textLength, length: chunk.length };
+	builder.locations.set(value, location);
+	builder.chunks.push(chunk);
+	builder.textLength += chunk.length;
+	return location;
+}
+
+function readSemanticField(
+	storage: PackedSemanticFields,
+	reportIndex: number,
+	fieldIndex: number,
+): string | undefined {
+	const packedIndex = reportIndex * SEMANTIC_FIELD_COUNT + fieldIndex;
+	const offset = storage.offsets[packedIndex]!;
+	if (offset < 0) return undefined;
+	return storage.text.toString("utf8", offset, offset + storage.lengths[packedIndex]!);
+}
+
+function requireStorage(report: NormalizedFallowReport): NormalizedReportStorage {
+	const storage = normalizedReportStorage.get(report);
+	if (!storage) throw new Error("Normalized Fallow report storage is unavailable.");
+	return storage;
+}
+
+function extractSemanticFields(raw: Record<string, any> | undefined): RetainedSemanticFields {
+	return {
+		type: firstString(raw, ["kind", "type", "issue_type", "rule_id"]),
+		id: firstString(raw, ["benchmark_id", "id", "finding_id"]),
+		severity: firstString(raw, ["severity"]),
+		evidence: firstText(raw, ["evidence", "reason", "rationale", "message", "description"]),
+		action: firstAction(raw) || firstText(raw, ["recommendation", "suggested_action"]),
+	};
+}
+
+function firstString(record: Record<string, any> | undefined, keys: string[]): string | undefined {
+	if (!record) return undefined;
+	return keys.map((key) => record[key]).find(isNonEmptyString);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function firstText(record: Record<string, any> | undefined, keys: string[]): string | undefined {
+	if (!record) return undefined;
+	for (const key of keys) {
+		const text = valueAsText(record[key]);
+		if (text) return text;
+	}
+	return undefined;
+}
+
+function valueAsText(value: unknown): string | undefined {
+	if (([undefined, null, ""] as unknown[]).includes(value)) return undefined;
+	if (typeof value === "string") return value;
+	return stringifyText(value);
+}
+
+function stringifyText(value: unknown): string {
+	try {
+		const serialized = JSON.stringify(value);
+		if (typeof serialized === "string") return serialized;
+	} catch {
+		return String(value);
+	}
+	return String(value);
+}
+
+function firstAction(record: Record<string, any> | undefined): string | undefined {
+	const actions = Array.isArray(record?.actions) ? record.actions : [];
+	return actions.map((action) => firstText(asRecord(action), ["description", "type"])).find(isNonEmptyString);
+}
+
+function sameSource(left: NormalizedFallowSource, right: NormalizedFallowSource): boolean {
+	return SOURCE_COORDINATE_KEYS.every((key) => left[key] === right[key]);
+}
+
+function sameSemantics(left: NormalizedFallowEntry, right: NormalizedFallowEntry): boolean {
+	return SEMANTIC_IDENTITY_KEYS.every((key) => left[key] === right[key]);
+}

--- a/extensions/fallow/output-detail.ts
+++ b/extensions/fallow/output-detail.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
-import { asRecord } from "./data";
-import type { FallowIssueLine, FallowOutputDetail, FallowOverview } from "./types";
+import { entriesForFallowRole, getNormalizedFallowReport, type NormalizedFallowEntry, type NormalizedFallowReport } from "./normalized-report";
+import type { FallowOutputDetail, FallowOverview } from "./types";
 
 const FALLOW_DETAIL_BUDGETS = {
 	summary: { characters: 4_096, tokens: { o200k_base: 4_000, cl100k_base: 4_000 } },
@@ -86,16 +86,17 @@ function formatSelectedOutputDetail(
 	overview: FallowOverview | undefined,
 	fullOutputPath: string,
 ): DetailFormatResult {
-	if (detail === "summary") return formatSummaryDetail(summary, overview, fullOutputPath);
-	return formatFindingsDetail(summary, overview, fullOutputPath);
+	const report = overview ? getNormalizedFallowReport(overview) : undefined;
+	if (detail === "summary") return formatSummaryDetail(summary, report, fullOutputPath);
+	return formatFindingsDetail(summary, report, fullOutputPath);
 }
 
 function formatSummaryDetail(
 	summary: string,
-	overview: FallowOverview | undefined,
+	report: NormalizedFallowReport | undefined,
 	fullOutputPath: string,
 ): DetailFormatResult {
-	const payload = createSummaryPayload(summary, overview, fullOutputPath);
+	const payload = createSummaryPayload(summary, report, fullOutputPath);
 	const initiallyTruncated = isSummaryPayloadTruncated(payload);
 	fitSummaryPayload(payload, summary);
 	return { text: renderSummary(payload), truncated: initiallyTruncated || isSummaryPayloadTruncated(payload) };
@@ -103,31 +104,44 @@ function formatSummaryDetail(
 
 function createSummaryPayload(
 	summary: string,
-	overview: FallowOverview | undefined,
+	report: NormalizedFallowReport | undefined,
 	fullOutputPath: string,
 ): SummaryPayload {
-	const stats = normalizeStats(overview);
-	const notes = normalizeNotes(overview);
-	const statCount = overview ? overview.stats.length : 0;
-	const noteCount = overview ? overview.notes.length : 0;
+	const metadata = buildSummaryMetadata(report);
 	const compactSummary = compactText(summary, MAX_FINDINGS_SUMMARY_CHARS);
 	return {
 		detail: "summary",
-		title: normalizeTitle(overview),
-		status: normalizeStatus(overview),
+		title: metadata.title,
+		status: metadata.status,
 		summary: compactSummary,
 		summary_truncated: compactSummary !== summary,
-		finding_count: countEntries(overview, false),
-		context_count: countEntries(overview, true),
-		stat_count: statCount,
-		included_stats: stats.length,
-		omitted_stats: statCount - stats.length,
-		stats,
-		note_count: noteCount,
-		included_notes: notes.length,
-		omitted_notes: noteCount - notes.length,
-		notes,
+		finding_count: metadata.findingCount,
+		context_count: metadata.contextCount,
+		stat_count: metadata.statCount,
+		included_stats: metadata.stats.length,
+		omitted_stats: metadata.statCount - metadata.stats.length,
+		stats: metadata.stats,
+		note_count: metadata.noteCount,
+		included_notes: metadata.notes.length,
+		omitted_notes: metadata.noteCount - metadata.notes.length,
+		notes: metadata.notes,
 		complete_output_path: fullOutputPath,
+	};
+}
+
+function buildSummaryMetadata(report: NormalizedFallowReport | undefined) {
+	if (!report) {
+		return { title: "Fallow", status: "warning" as const, findingCount: 0, contextCount: 0, statCount: 0, stats: [], noteCount: 0, notes: [] };
+	}
+	return {
+		title: normalizeTitle(report),
+		status: report.status,
+		findingCount: report.findingCount,
+		contextCount: report.contextCount,
+		statCount: report.stats.length,
+		stats: normalizeStats(report),
+		noteCount: report.notes.length,
+		notes: normalizeNotes(report),
 	};
 }
 
@@ -181,12 +195,12 @@ function renderSummary(payload: SummaryPayload): string {
 
 function formatFindingsDetail(
 	summary: string,
-	overview: FallowOverview | undefined,
+	report: NormalizedFallowReport | undefined,
 	fullOutputPath: string,
 ): DetailFormatResult {
-	const findingEntries = collectEntries(overview, false);
-	const contextEntries = collectContextEntries(overview, findingEntries);
-	const payload = createFindingsPayload(summary, overview, fullOutputPath, findingEntries.length);
+	const findingEntries = collectEntries(report, "finding");
+	const contextEntries = collectContextEntries(report, findingEntries);
+	const payload = createFindingsPayload(summary, report, fullOutputPath, findingEntries.length);
 	fitFindingsMetadata(payload);
 	fitEntries(payload, "findings", findingEntries);
 	fitEntries(payload, "context", contextEntries);
@@ -194,26 +208,26 @@ function formatFindingsDetail(
 }
 
 function collectContextEntries(
-	overview: FallowOverview | undefined,
+	report: NormalizedFallowReport | undefined,
 	findingEntries: NormalizedFinding[],
 ): NormalizedFinding[] {
 	if (findingEntries.length) return [];
-	return collectEntries(overview, true);
+	return collectEntries(report, "context");
 }
 
 function createFindingsPayload(
 	summary: string,
-	overview: FallowOverview | undefined,
+	report: NormalizedFallowReport | undefined,
 	fullOutputPath: string,
 	findingCount: number,
 ): FindingsPayload {
-	const contextCount = countEntries(overview, true);
+	const contextCount = report?.contextCount ?? 0;
 	return {
 		detail: "findings",
-		title: normalizeTitle(overview),
-		status: normalizeStatus(overview),
+		title: normalizeTitle(report),
+		status: normalizeStatus(report),
 		summary: compactText(summary, MAX_FINDINGS_SUMMARY_CHARS),
-		stats: normalizeStats(overview),
+		stats: normalizeStats(report),
 		finding_count: findingCount,
 		included_findings: 0,
 		omitted_findings: findingCount,
@@ -222,21 +236,21 @@ function createFindingsPayload(
 		included_context: 0,
 		omitted_context: contextCount,
 		context: [],
-		notes: normalizeNotes(overview),
+		notes: normalizeNotes(report),
 		complete_output_path: fullOutputPath,
 	};
 }
 
-function normalizeTitle(overview: FallowOverview | undefined): string {
-	return compactText(overview ? overview.title : "Fallow", MAX_SUBJECT_CHARS);
+function normalizeTitle(report: NormalizedFallowReport | undefined): string {
+	return compactText(report ? report.title : "Fallow", MAX_SUBJECT_CHARS);
 }
 
-function normalizeStatus(overview: FallowOverview | undefined): SummaryPayload["status"] {
-	return overview ? overview.status : "warning";
+function normalizeStatus(report: NormalizedFallowReport | undefined): SummaryPayload["status"] {
+	return report ? report.status : "warning";
 }
 
-function normalizeNotes(overview: FallowOverview | undefined): string[] {
-	const notes = overview ? overview.notes : [];
+function normalizeNotes(report: NormalizedFallowReport | undefined): string[] {
+	const notes = report ? report.notes : [];
 	return notes.slice(0, MAX_NOTES).map((note) => compactText(note, MAX_NOTE_CHARS));
 }
 
@@ -265,49 +279,37 @@ function hasOmittedEntries(payload: FindingsPayload): boolean {
 	return payload.omitted_findings > 0 || payload.omitted_context > 0;
 }
 
-function collectEntries(overview: FallowOverview | undefined, context: boolean): NormalizedFinding[] {
-	if (!overview) return [];
-	return overview.sections
-		.filter((section) => (section.role === "context") === context)
-		.flatMap((section) => section.items.map((item) => normalizeFinding(section.title, item)));
+function collectEntries(
+	report: NormalizedFallowReport | undefined,
+	role: NormalizedFallowEntry["role"],
+): NormalizedFinding[] {
+	if (!report) return [];
+	return entriesForFallowRole(report, role).map(normalizeFinding);
 }
 
-function countEntries(overview: FallowOverview | undefined, context: boolean): number {
-	if (!overview) return 0;
-	return overview.sections
-		.filter((section) => (section.role === "context") === context)
-		.reduce((total, section) => total + section.items.length, 0);
-}
-
-function normalizeFinding(section: string, item: FallowIssueLine): NormalizedFinding {
-	const raw = asRecord(item.raw);
+function normalizeFinding(entry: NormalizedFallowEntry): NormalizedFinding {
 	return {
-		section: compactText(section, MAX_SECTION_CHARS),
-		type: compactText(firstString(raw, ["kind", "type", "issue_type", "rule_id"]) || section, MAX_TYPE_CHARS),
-		id: compactOptional(firstString(raw, ["benchmark_id", "id", "finding_id"]), MAX_ID_CHARS),
-		severity: compactOptional(item.severity || firstString(raw, ["severity"]), MAX_TYPE_CHARS),
-		location: normalizeLocation(item),
-		subject: compactText(item.label, MAX_SUBJECT_CHARS),
-		details: compactOptional(item.meta, MAX_DETAILS_CHARS),
-		evidence: compactOptional(firstText(raw, ["evidence", "reason", "rationale", "message", "description"]), MAX_EVIDENCE_CHARS),
-		action: normalizeAction(item, raw),
+		section: compactText(entry.section, MAX_SECTION_CHARS),
+		type: compactText(entry.type, MAX_TYPE_CHARS),
+		id: compactOptional(entry.id, MAX_ID_CHARS),
+		severity: compactOptional(entry.severity, MAX_TYPE_CHARS),
+		location: normalizeLocation(entry),
+		subject: compactText(entry.subject, MAX_SUBJECT_CHARS),
+		details: compactOptional(entry.details, MAX_DETAILS_CHARS),
+		evidence: compactOptional(entry.evidence, MAX_EVIDENCE_CHARS),
+		action: compactOptional(entry.action, MAX_ACTION_CHARS),
 	};
 }
 
-function normalizeLocation(item: FallowIssueLine): NormalizedFinding["location"] {
-	const path = compactOptional(item.path, MAX_PATH_CHARS);
+function normalizeLocation(entry: NormalizedFallowEntry): NormalizedFinding["location"] {
+	const path = compactOptional(entry.path, MAX_PATH_CHARS);
 	if (!path) return undefined;
-	if (item.line === undefined) return { path };
-	return { path, line: item.line };
+	if (entry.line === undefined) return { path };
+	return { path, line: entry.line };
 }
 
-function normalizeAction(item: FallowIssueLine, raw: Record<string, any> | undefined): string | undefined {
-	const value = item.action || firstAction(raw) || firstText(raw, ["recommendation", "suggested_action"]);
-	return compactOptional(value, MAX_ACTION_CHARS);
-}
-
-function normalizeStats(overview: FallowOverview | undefined): NormalizedStat[] {
-	return (overview?.stats ?? []).slice(0, MAX_STATS).map((stat) => ({
+function normalizeStats(report: NormalizedFallowReport | undefined): NormalizedStat[] {
+	return (report?.stats ?? []).slice(0, MAX_STATS).map((stat) => ({
 		label: compactText(stat.label, MAX_SECTION_CHARS),
 		value: typeof stat.value === "number" ? stat.value : compactText(stat.value, MAX_STAT_VALUE_CHARS),
 	}));
@@ -364,55 +366,6 @@ function fitStringToBudget(
 		}
 	}
 	return best;
-}
-
-function firstString(record: Record<string, any> | undefined, keys: string[]): string | undefined {
-	if (!record) return undefined;
-	return keys.map((key) => record[key]).find(isNonEmptyString);
-}
-
-function isNonEmptyString(value: unknown): value is string {
-	return typeof value === "string" && value.trim().length > 0;
-}
-
-function firstText(record: Record<string, any> | undefined, keys: string[]): string | undefined {
-	const value = firstPresentValue(record, keys);
-	return valueAsText(value);
-}
-
-function firstPresentValue(record: Record<string, any> | undefined, keys: string[]): unknown {
-	if (!record) return undefined;
-	return keys.map((key) => record[key]).find(isPresentValue);
-}
-
-function isPresentValue(value: unknown): boolean {
-	return value !== undefined && value !== null && value !== "";
-}
-
-function valueAsText(value: unknown): string | undefined {
-	if (!isPresentValue(value)) return undefined;
-	if (typeof value === "string") return value;
-	return stringifyValue(value);
-}
-
-function stringifyValue(value: unknown): string {
-	try {
-		return JSON.stringify(value);
-	} catch {
-		return String(value);
-	}
-}
-
-function firstAction(record: Record<string, any> | undefined): string | undefined {
-	return actionValues(record).map(actionText).find(isNonEmptyString);
-}
-
-function actionValues(record: Record<string, any> | undefined): unknown[] {
-	return Array.isArray(record?.actions) ? record.actions : [];
-}
-
-function actionText(value: unknown): string | undefined {
-	return firstText(asRecord(value), ["description", "type"]);
 }
 
 function compactOptional(value: string | undefined, maxChars: number): string | undefined {

--- a/extensions/fallow/output.ts
+++ b/extensions/fallow/output.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead, withFileMutationQueue } from "@earendil-works/pi-coding-agent";
 import { asRecord } from "./data";
 import type { ParsedFallowOutput } from "./json";
+import { getNormalizedFallowReport } from "./normalized-report";
 import { fallowOutputDetail } from "./output-detail";
 import { buildFallowOverview } from "./overview";
 import type { FallowOutputDetail, FallowOverview } from "./types";
@@ -122,7 +123,7 @@ export async function formatToolOutput(
 	const preserveFullOutput = shouldPreserveFullOutput(outputDetail, rawTruncation.truncated, preserveNavigatorDetails, overview);
 	const fullOutputPath = await writeOutputPathIfNeeded(preserveFullOutput, rawText);
 	const errorText = buildToolOutputText(parsed, summary, rawTruncation, fullOutputPath);
-	const presentation = selectOutputPresentation(outputDetail, parsed, exitCode, summary, overview, fullOutputPath, errorText, rawTruncation.truncated);
+	const presentation = selectOutputPresentation(outputDetail, summary, overview, fullOutputPath, errorText, rawTruncation.truncated);
 	return { text: presentation.text, errorText, summary, overview, fullOutputPath, truncated: presentation.truncated };
 }
 
@@ -138,8 +139,6 @@ function shouldPreserveFullOutput(
 
 function selectOutputPresentation(
 	outputDetail: FallowOutputDetail,
-	parsed: ParsedFallowOutput,
-	exitCode: number,
 	summary: string,
 	overview: FallowOverview | undefined,
 	fullOutputPath: string | undefined,
@@ -147,22 +146,16 @@ function selectOutputPresentation(
 	rawTruncated: boolean,
 ): { text: string; truncated: boolean } {
 	if (outputDetail === "raw") return { text: rawText, truncated: rawTruncated };
-	return formatNonRawOutputDetail(outputDetail, parsed, exitCode, summary, overview, fullOutputPath!);
+	return formatNonRawOutputDetail(outputDetail, summary, overview, fullOutputPath!);
 }
 
 function formatNonRawOutputDetail(
 	outputDetail: Exclude<FallowOutputDetail, "raw">,
-	parsed: ParsedFallowOutput,
-	exitCode: number,
 	summary: string,
 	overview: FallowOverview | undefined,
 	fullOutputPath: string,
 ): ReturnType<typeof fallowOutputDetail.format> {
-	if (outputDetail === "summary" || !parsed.parsed) {
-		return fallowOutputDetail.format(outputDetail, summary, overview, fullOutputPath);
-	}
-	const detailedOverview = buildFallowOverview(parsed.data, exitCode, { includeAllRaw: true });
-	return fallowOutputDetail.format(outputDetail, summary, detailedOverview, fullOutputPath);
+	return fallowOutputDetail.format(outputDetail, summary, overview, fullOutputPath);
 }
 
 function buildToolOutputSummary(
@@ -180,8 +173,7 @@ function getFormattedRawText(parsed: ParsedFallowOutput): string {
 }
 
 function overviewHasFindings(overview: FallowOverview | undefined): boolean {
-	if (!overview) return false;
-	return overview.sections.some((section) => section.items.length > 0);
+	return overview ? getNormalizedFallowReport(overview).entryCount > 0 : false;
 }
 
 async function writeOutputPathIfNeeded(

--- a/extensions/fallow/overview.ts
+++ b/extensions/fallow/overview.ts
@@ -1,4 +1,5 @@
 import { asRecord } from "./data";
+import { getNormalizedFallowReport, retainNormalizedFallowEntry } from "./normalized-report";
 import type { FallowIssueLine, FallowOverview, FallowOverviewSection } from "./types";
 
 // Preserve the existing inline raw-detail footprint while normalized rows remain unbounded.
@@ -96,6 +97,7 @@ function makeIssue(kind: string, issue: Record<string, any>, includeRaw = true):
 }
 
 function withOptionalRaw(item: FallowIssueLine, raw: unknown, includeRaw: boolean): FallowIssueLine {
+	retainNormalizedFallowEntry(item, raw);
 	if (includeRaw) item.raw = raw;
 	return item;
 }
@@ -728,13 +730,15 @@ export function buildFallowOverview(
 	applyErrorTitle(root, title);
 	addExitCodeNote(notes, exitCode);
 
-	return {
+	const overview: FallowOverview = {
 		title: title.value,
 		status: buildFallowStatus(root, sections, exitCode),
 		stats,
 		sections,
 		notes,
 	};
+	getNormalizedFallowReport(overview);
+	return overview;
 }
 
 function applyErrorTitle(root: Record<string, any>, title: { value: string }): void {

--- a/extensions/fallow/prompt.ts
+++ b/extensions/fallow/prompt.ts
@@ -1,3 +1,4 @@
+import { normalizeFallowIssue, type NormalizedFallowEntry } from "./normalized-report";
 import type { FallowIssueLine } from "./types";
 
 export type FallowPromptDetail = "compact" | "full";
@@ -5,6 +6,7 @@ export type FallowPromptDetail = "compact" | "full";
 export interface FallowPromptFinding {
 	sectionTitle: string;
 	item: FallowIssueLine;
+	normalized?: NormalizedFallowEntry;
 }
 
 interface FallowPromptOptions {
@@ -21,9 +23,14 @@ const MAX_COMPACT_DETAILS_CHARS = 160;
 
 export function buildFallowPrompt(options: FallowPromptOptions): string {
 	const header = buildPromptHeader(options);
-	const compactFindings = buildCompactFindings(options.findings);
-	const fullDetails = options.detail === "full" ? buildFullFindingDetails(options.findings) : undefined;
+	const findings = options.findings.map(resolvePromptFinding);
+	const compactFindings = buildCompactFindings(findings);
+	const fullDetails = options.detail === "full" ? buildFullFindingDetails(findings) : undefined;
 	return [header, compactFindings, fullDetails].filter(Boolean).join("\n\n");
+}
+
+function resolvePromptFinding(finding: FallowPromptFinding): NormalizedFallowEntry {
+	return finding.normalized ?? normalizeFallowIssue(finding.sectionTitle, finding.item);
 }
 
 function buildPromptHeader(options: FallowPromptOptions): string {
@@ -41,15 +48,15 @@ function buildPromptHeader(options: FallowPromptOptions): string {
 	].filter((part) => part !== undefined).join("\n");
 }
 
-function buildCompactFindings(findings: FallowPromptFinding[]): string {
+function buildCompactFindings(findings: NormalizedFallowEntry[]): string {
 	const lines = [
 		`Selected findings: ${findings.length}`,
 		"Columns: # | type | severity | location | subject | evidence/details | suggested action",
 	];
 	let currentSection: string | undefined;
 	for (const [index, finding] of findings.entries()) {
-		if (finding.sectionTitle !== currentSection) {
-			currentSection = finding.sectionTitle;
+		if (finding.section !== currentSection) {
+			currentSection = finding.section;
 			lines.push(`## ${escapeCompactCell(currentSection)}`);
 		}
 		lines.push(buildCompactFindingLine(finding, index));
@@ -57,133 +64,59 @@ function buildCompactFindings(findings: FallowPromptFinding[]): string {
 	return lines.join("\n");
 }
 
-function buildCompactFindingLine(finding: FallowPromptFinding, index: number): string {
-	const { item } = finding;
-	const raw = asRecord(item.raw);
-	const evidence = compactText(findingEvidence(raw), MAX_COMPACT_EVIDENCE_CHARS);
-	const action = compactText(findingAction(item, raw), MAX_COMPACT_ACTION_CHARS);
+function buildCompactFindingLine(finding: NormalizedFallowEntry, index: number): string {
+	const evidence = compactText(finding.evidence, MAX_COMPACT_EVIDENCE_CHARS);
+	const action = compactText(finding.action, MAX_COMPACT_ACTION_CHARS);
 	const details = joinDistinct([
-		compactIdentifier(findingIdentifier(raw), evidence, action),
-		compactText(item.meta, MAX_COMPACT_DETAILS_CHARS),
+		compactIdentifier(finding.id, evidence, action),
+		compactText(finding.details, MAX_COMPACT_DETAILS_CHARS),
 		evidence,
 	]);
 	const cells = [
 		String(index + 1),
-		findingType(raw, finding.sectionTitle),
-		findingSeverity(item, raw),
-		findingLocation(item),
-		item.label,
+		finding.type,
+		finding.severity ?? "unknown",
+		findingLocation(finding),
+		finding.subject,
 		textOrDash(details),
 		textOrDash(action),
 	];
 	return cells.map(escapeCompactCell).join(" | ");
 }
 
-function findingLocation(item: FallowIssueLine): string {
-	if (!item.path) return "unknown";
-	return item.line ? `${item.path}:${item.line}` : item.path;
-}
-
-function findingSeverity(item: FallowIssueLine, raw: Record<string, any> | undefined): string {
-	return item.severity ?? stringValue(recordValue(raw, "severity")) ?? "unknown";
+function findingLocation(finding: NormalizedFallowEntry): string {
+	if (!finding.path) return "unknown";
+	return finding.line ? `${finding.path}:${finding.line}` : finding.path;
 }
 
 function textOrDash(value: string | undefined): string {
 	return value || "-";
 }
 
-function buildFullFindingDetails(findings: FallowPromptFinding[]): string {
+function buildFullFindingDetails(findings: NormalizedFallowEntry[]): string {
 	const blocks = findings.map((finding, index) => {
-		const raw = finding.item.raw ?? normalizedFindingFallback(finding);
-		return [`### ${index + 1}. ${finding.sectionTitle}: ${finding.item.label}`, "```json", safeJson(raw), "```"].join("\n");
+		const raw = finding.raw ?? normalizedFindingFallback(finding);
+		return [`### ${index + 1}. ${finding.section}: ${finding.subject}`, "```json", safeJson(raw), "```"].join("\n");
 	});
 	return ["## Full raw finding JSON", ...blocks].join("\n\n");
 }
 
-function normalizedFindingFallback(finding: FallowPromptFinding): Record<string, unknown> {
+function normalizedFindingFallback(finding: NormalizedFallowEntry): Record<string, unknown> {
 	return {
-		section: finding.sectionTitle,
-		label: finding.item.label,
-		path: finding.item.path,
-		line: finding.item.line,
-		severity: finding.item.severity,
-		details: finding.item.meta,
-		action: finding.item.action,
+		section: finding.section,
+		label: finding.subject,
+		path: finding.path,
+		line: finding.line,
+		severity: finding.severity,
+		details: finding.details,
+		action: finding.action,
 	};
-}
-
-function findingType(raw: Record<string, any> | undefined, fallback: string): string {
-	return firstString(recordValues(raw, ["kind", "type", "issue_type", "rule_id"])) ?? fallback;
-}
-
-function findingIdentifier(raw: Record<string, any> | undefined): string | undefined {
-	return firstString(recordValues(raw, ["benchmark_id", "id", "finding_id"]));
 }
 
 function compactIdentifier(identifier: string | undefined, evidence: string | undefined, action: string | undefined): string | undefined {
 	if (!identifier) return undefined;
 	if (evidence?.includes(identifier) || action?.includes(identifier)) return undefined;
 	return `id ${identifier}`;
-}
-
-function findingEvidence(raw: Record<string, any> | undefined): string | undefined {
-	return firstText(recordValues(raw, ["evidence", "reason", "rationale", "message", "description"]));
-}
-
-function findingAction(item: FallowIssueLine, raw: Record<string, any> | undefined): string | undefined {
-	if (item.action) return item.action;
-	const action = firstRawAction(raw);
-	if (action) return action;
-	return firstText(recordValues(raw, ["recommendation", "suggested_action"]));
-}
-
-function firstRawAction(raw: Record<string, any> | undefined): string | undefined {
-	for (const action of arrayValue(raw, "actions")) {
-		const text = firstText(recordValues(asRecord(action), ["description", "type"]));
-		if (text) return text;
-	}
-	return undefined;
-}
-
-function firstString(values: unknown[]): string | undefined {
-	for (const value of values) {
-		if (typeof value === "string" && value.trim()) return value;
-	}
-	return undefined;
-}
-
-function firstText(values: unknown[]): string | undefined {
-	for (const value of values) {
-		const text = valueAsText(value);
-		if (text) return text;
-	}
-	return undefined;
-}
-
-function valueAsText(value: unknown): string | undefined {
-	if (!isPresentValue(value)) return undefined;
-	return typeof value === "string" ? value : safeJson(value);
-}
-
-function stringValue(value: unknown): string | undefined {
-	return isPresentValue(value) ? String(value) : undefined;
-}
-
-function isPresentValue(value: unknown): boolean {
-	return value !== undefined && value !== null && value !== "";
-}
-
-function recordValues(raw: Record<string, any> | undefined, keys: string[]): unknown[] {
-	return keys.map((key) => recordValue(raw, key));
-}
-
-function recordValue(raw: Record<string, any> | undefined, key: string): unknown {
-	return raw ? raw[key] : undefined;
-}
-
-function arrayValue(raw: Record<string, any> | undefined, key: string): unknown[] {
-	const value = recordValue(raw, key);
-	return Array.isArray(value) ? value : [];
 }
 
 function compactText(value: string | undefined, maxChars: number): string | undefined {
@@ -197,10 +130,6 @@ function joinDistinct(values: Array<string | undefined>): string {
 
 function escapeCompactCell(value: string): string {
 	return value.replaceAll("\\", "\\\\").replaceAll("|", "\\|").replaceAll("\r", "\\r").replaceAll("\n", "\\n");
-}
-
-function asRecord(value: unknown): Record<string, any> | undefined {
-	return value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, any> : undefined;
 }
 
 function safeJson(value: unknown): string {

--- a/extensions/fallow/ui/navigator.ts
+++ b/extensions/fallow/ui/navigator.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { CURSOR_MARKER, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type Focusable } from "@earendil-works/pi-tui";
+import { allNormalizedFallowEntries, getNormalizedFallowReport, hydrateNormalizedFallowEntry, type NormalizedFallowEntry } from "../normalized-report";
 import { buildFallowOverview } from "../overview";
 import { buildFallowPrompt, type FallowPromptDetail, type FallowPromptFinding } from "../prompt";
 import { renderFallowProjectState } from "../project/render";
@@ -63,6 +64,7 @@ interface FlatIssue {
 	id: number;
 	section: FallowOverviewSection;
 	item: FallowIssueLine;
+	normalized: NormalizedFallowEntry;
 	sectionIndex: number;
 	itemIndex: number;
 }
@@ -92,9 +94,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 		private options: FallowNavigatorOptions = {},
 	) {
 		this.showInformational = options.informationalMode === true;
-		this.issues = overview.sections
-			.flatMap((section, sectionIndex) => section.items.map((item, itemIndex) => ({ section, item, sectionIndex, itemIndex })))
-			.map((entry, id) => ({ ...entry, id }));
+		this.issues = flattenNormalizedIssues(overview);
 	}
 
 	handleInput(data: string): void {
@@ -555,7 +555,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private preparePrompt(issues: FlatIssue[]): void {
-		if (!issues.some((entry) => entry.item.raw === undefined)) {
+		if (!this.includeFullDetails || !issues.some((entry) => entry.normalized.raw === undefined)) {
 			this.emitPrompt(issues);
 			return;
 		}
@@ -581,15 +581,20 @@ export class FallowIssueNavigator implements Component, Focusable {
 		const reportText = await readFile(this.options.fullOutputPath!, "utf8");
 		const hydratedOverview = buildFallowOverview(JSON.parse(reportText), 0, { includeAllRaw: true });
 		if (!hydratedOverview) throw new Error("Complete report has no structured overview.");
+		const hydratedReport = getNormalizedFallowReport(hydratedOverview);
 		return issues.map((entry) => ({
 			...entry,
-			item: hydratedOverview.sections[entry.sectionIndex]?.items[entry.itemIndex] ?? entry.item,
+			normalized: hydrateNormalizedFallowEntry(hydratedReport, entry.normalized),
 		}));
 	}
 
 	private emitPrompt(issues: FlatIssue[], hydrationWarning?: string): void {
 		const detail = this.promptDetail();
-		const findings: FallowPromptFinding[] = issues.map((entry) => ({ sectionTitle: entry.section.title, item: entry.item }));
+		const findings: FallowPromptFinding[] = issues.map((entry) => ({
+			sectionTitle: entry.normalized.section,
+			item: entry.item,
+			normalized: entry.normalized,
+		}));
 		this.onDone({
 			type: "prompt",
 			issueCount: issues.length,
@@ -748,12 +753,25 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 }
 
+function flattenNormalizedIssues(overview: FallowOverview): FlatIssue[] {
+	const report = getNormalizedFallowReport(overview);
+	return allNormalizedFallowEntries(report).map((normalized) => {
+		const { reportIndex, sectionIndex, itemIndex, sectionTitle } = normalized.source;
+		const section = overview.sections[sectionIndex];
+		const item = section?.items[itemIndex];
+		if (!section || !item || section.title !== sectionTitle) {
+			throw new Error("Normalized Fallow source coordinates do not match the overview.");
+		}
+		return { id: reportIndex, section, item, normalized, sectionIndex, itemIndex };
+	});
+}
+
 function isInformational(entry: FlatIssue): boolean {
-	return entry.section.role === "context";
+	return entry.normalized.role === "context";
 }
 
 function issueSeverity(entry: FlatIssue): string {
-	const severity = entry.item.severity?.trim().toLocaleLowerCase();
+	const severity = entry.normalized.severity?.trim().toLocaleLowerCase();
 	return severity || "unspecified";
 }
 

--- a/scripts/performance-memory-worker.mjs
+++ b/scripts/performance-memory-worker.mjs
@@ -14,6 +14,7 @@ const jiti = createJiti(import.meta.url);
 const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
 const fixtureText = await readFile(fixturePath, "utf8");
 const projectDir = await createFallowBenchmarkProject("pi-fallow-memory-");
+await warmProcessingPath(projectDir);
 forceGc();
 const before = memorySnapshot();
 let result = await runFixture(fixtureText, projectDir);
@@ -38,6 +39,15 @@ process.stdout.write(JSON.stringify({
 function runFixture(fixtureText, cwd) {
 	const scenario = { args: ["dead-code", "--format", "json", "--quiet"], exitCode: 0 };
 	return runFixtureEngine(fallowEngine, { scenario, fixtureText, cwd, outputDetail });
+}
+
+async function warmProcessingPath(cwd) {
+	// Keep one-time JIT/module costs out of the retained-report amplification measurement.
+	const fixture = '{"kind":"dead-code","unused_exports":[{"benchmark_id":"warmup","kind":"unused-export","export_name":"warmup","path":"warmup.ts","severity":"low","evidence":"warmup","actions":[{"description":"warmup"}]}]}';
+	let warmup = await runFixture(fixture, cwd);
+	const fullOutputPath = warmup.formatted.fullOutputPath;
+	warmup = undefined;
+	if (fullOutputPath) await rm(dirname(fullOutputPath), { recursive: true, force: true });
 }
 
 function forceGc() {

--- a/tests/navigator.test.mjs
+++ b/tests/navigator.test.mjs
@@ -308,7 +308,7 @@ describe("FallowIssueNavigator prompt generation", () => {
 		assert.match(result.prompt, /Full raw finding JSON/);
 	});
 
-	it("hydrates compact and full prompts from the complete report", async () => {
+	it("keeps compact late-finding prompts independent while full prompts hydrate or warn", async () => {
 		const directory = await mkdtemp(join(tmpdir(), "pi-fallow-prompt-"));
 		const fullOutputPath = join(directory, "fallow-output.json");
 		const report = {
@@ -330,15 +330,68 @@ describe("FallowIssueNavigator prompt generation", () => {
 		try {
 			const overview = buildFallowOverview(report);
 			assert.equal(overview.sections[0].items[11].raw, undefined);
+			await rm(fullOutputPath, { force: true });
 			const compactResult = await loadEndFindingPrompt(overview, fullOutputPath, false);
 			assert.equal(compactResult.detail, "compact");
+			assert.match(compactResult.prompt, /unused-export/);
 			assert.match(compactResult.prompt, /finding-12/);
 			assert.match(compactResult.prompt, /No callers for finding 12\./);
+			assert.match(compactResult.prompt, /Review finding 12\./);
+			assert.doesNotMatch(compactResult.prompt, /Report detail warning/);
 
+			await writeFile(fullOutputPath, JSON.stringify(report, null, 2));
 			const fullResult = await loadEndFindingPrompt(overview, fullOutputPath, true);
 			assert.equal(fullResult.detail, "full");
 			assert.match(fullResult.prompt, /"benchmark_id": "finding-12"/);
 			assert.match(fullResult.prompt, /"evidence": "No callers for finding 12\."/);
+
+			await rm(fullOutputPath, { force: true });
+			const unavailable = await loadEndFindingPrompt(overview, fullOutputPath, true);
+			assert.match(unavailable.prompt, /Report detail warning: Complete report could not be loaded/);
+			assert.match(unavailable.prompt, /finding-12/);
+		} finally {
+			await rm(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("hydrates stable coordinates across sections and rejects a drifted complete report", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "pi-fallow-coordinates-"));
+		const fullOutputPath = join(directory, "fallow-output.json");
+		const report = {
+			kind: "dead-code",
+			unused_files: [{ benchmark_id: "file-1", kind: "unused-file", path: "src/dead.ts" }],
+			unused_exports: Array.from({ length: 12 }, (_, index) => ({
+				benchmark_id: `export-${index + 1}`,
+				kind: "unused-export",
+				export_name: `unused_${index + 1}`,
+				path: `src/export-${index + 1}.ts`,
+				evidence: `Evidence ${index + 1}`,
+			})),
+		};
+		const overview = buildFallowOverview(report);
+		assert.equal(overview.sections[1].items[11].raw, undefined);
+
+		try {
+			await writeFile(fullOutputPath, JSON.stringify(report, null, 2));
+			const hydrated = await loadEndFindingPrompt(overview, fullOutputPath, true);
+			assert.match(hydrated.prompt, /"benchmark_id": "export-12"/);
+			assert.doesNotMatch(hydrated.prompt, /Report detail warning/);
+
+			const drifted = {
+				...report,
+				unused_files: [],
+				unused_exports: [...report.unused_exports, {
+					benchmark_id: "export-13",
+					kind: "unused-export",
+					export_name: "wrong-entry",
+					path: "src/wrong.ts",
+				}],
+			};
+			await writeFile(fullOutputPath, JSON.stringify(drifted, null, 2));
+			const rejected = await loadEndFindingPrompt(overview, fullOutputPath, true);
+			assert.match(rejected.prompt, /Report detail warning: Complete report could not be loaded/);
+			assert.match(rejected.prompt, /export-12/);
+			assert.doesNotMatch(rejected.prompt, /"benchmark_id": "export-13"/);
 		} finally {
 			await rm(directory, { recursive: true, force: true });
 		}

--- a/tests/normalized-report.test.mjs
+++ b/tests/normalized-report.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { buildFallowOverview } = await jiti.import("../extensions/fallow/overview.ts");
+const { allNormalizedFallowEntries, getNormalizedFallowReport, normalizeFallowIssue } = await jiti.import("../extensions/fallow/normalized-report.ts");
+const { fallowOutputDetail } = await jiti.import("../extensions/fallow/output-detail.ts");
+const { buildFallowPrompt } = await jiti.import("../extensions/fallow/prompt.ts");
+
+function parseFindings(text) {
+	return JSON.parse(text.slice("Fallow findings:\n".length));
+}
+
+function parseSummary(text) {
+	return JSON.parse(text.slice("Fallow summary:\n".length));
+}
+
+describe("normalized Fallow reports", () => {
+	it("retains authoritative late-entry semantics without retaining every raw object", () => {
+		const entries = Array.from({ length: 12 }, (_, index) => ({
+			benchmark_id: `benchmark-${index}`,
+			id: `id-${index}`,
+			finding_id: `finding-${index}`,
+			kind: `kind-${index}`,
+			type: `type-${index}`,
+			issue_type: `issue-${index}`,
+			rule_id: `rule-${index}`,
+			export_name: `subject-${index}`,
+			path: `src/file-${index}.ts`,
+			line: index + 1,
+			severity: "high",
+			evidence: `evidence-${index}`,
+			reason: `reason-${index}`,
+			actions: [
+				{ type: "suppress-line", description: `suppression-${index}` },
+				{ type: "review", description: `preferred-${index}` },
+			],
+			recommendation: `recommendation-${index}`,
+		}));
+		const overview = buildFallowOverview({ kind: "dead-code", unused_exports: entries });
+		const report = getNormalizedFallowReport(overview);
+		const normalizedEntries = allNormalizedFallowEntries(report);
+		const late = normalizedEntries[11];
+
+		assert.equal(overview.sections[0].items[11].raw, undefined);
+		assert.equal(normalizedEntries.filter((entry) => entry.raw !== undefined).length, 5);
+		assert.deepEqual({
+			role: late.role,
+			section: late.section,
+			type: late.type,
+			id: late.id,
+			severity: late.severity,
+			path: late.path,
+			line: late.line,
+			subject: late.subject,
+			evidence: late.evidence,
+			action: late.action,
+		}, {
+			role: "finding",
+			section: "Unused exports",
+			type: "kind-11",
+			id: "benchmark-11",
+			severity: "high",
+			path: "src/file-11.ts",
+			line: 12,
+			subject: "subject-11",
+			evidence: "evidence-11",
+			action: "preferred-11",
+		});
+	});
+
+	it("keeps output-detail and compact prompts on the same precedence-selected fields", () => {
+		const entries = Array.from({ length: 6 }, (_, index) => ({
+			benchmark_id: `benchmark-${index}`,
+			id: `id-${index}`,
+			finding_id: `finding-${index}`,
+			kind: `kind-${index}`,
+			type: `type-${index}`,
+			issue_type: `issue-${index}`,
+			rule_id: `rule-${index}`,
+			export_name: `subject-${index}`,
+			path: `src/file-${index}.ts`,
+			line: index + 1,
+			severity: "medium",
+			evidence: `evidence-${index}`,
+			reason: `reason-${index}`,
+			rationale: `rationale-${index}`,
+			message: `message-${index}`,
+			description: `description-${index}`,
+			actions: [
+				{ type: "suppress-file", description: `raw-first-${index}` },
+				{ type: "review", description: `item-preferred-${index}` },
+			],
+			recommendation: `recommendation-${index}`,
+			suggested_action: `suggested-${index}`,
+		}));
+		const overview = buildFallowOverview({ kind: "dead-code", unused_exports: entries });
+		const report = getNormalizedFallowReport(overview);
+		const late = allNormalizedFallowEntries(report)[5];
+		const output = parseFindings(fallowOutputDetail.format("findings", "summary", overview, "/tmp/report.json").text);
+		const prompt = buildFallowPrompt({
+			findings: [{ sectionTitle: late.section, item: overview.sections[0].items[5], normalized: late }],
+			detail: "compact",
+		});
+
+		assert.equal(late.raw, undefined);
+		assert.deepEqual(output.findings[5], {
+			section: "Unused exports",
+			type: "kind-5",
+			id: "benchmark-5",
+			severity: "medium",
+			location: { path: "src/file-5.ts", line: 6 },
+			subject: "subject-5",
+			evidence: "evidence-5",
+			action: "item-preferred-5",
+		});
+		assert.match(prompt, /1 \| kind-5 \| medium \| src\/file-5\.ts:6 \| subject-5 \| id benchmark-5; evidence-5 \| item-preferred-5/);
+		assert.doesNotMatch(prompt, /type-5|id-5|reason-5|raw-first-5|recommendation-5/);
+	});
+
+	it("preserves every raw-field fallback and preferred-action tier", () => {
+		const cases = [
+			{
+				item: { label: "one", action: "item-action", raw: {
+					kind: "kind", type: "type", issue_type: "issue", rule_id: "rule",
+					benchmark_id: "benchmark", id: "id", finding_id: "finding",
+					evidence: "evidence", reason: "reason", rationale: "rationale", message: "message", description: "description",
+					actions: [{ description: "raw-action" }], recommendation: "recommendation", suggested_action: "suggested",
+				} },
+				expected: ["kind", "benchmark", "evidence", "item-action"],
+			},
+			{
+				item: { label: "two", raw: { type: "type", id: "id", reason: "reason", actions: [{ description: "raw-action" }], recommendation: "recommendation" } },
+				expected: ["type", "id", "reason", "raw-action"],
+			},
+			{
+				item: { label: "three", raw: { issue_type: "issue", finding_id: "finding", rationale: "rationale", recommendation: "recommendation" } },
+				expected: ["issue", "finding", "rationale", "recommendation"],
+			},
+			{
+				item: { label: "four", raw: { rule_id: "rule", message: "message", suggested_action: "suggested" } },
+				expected: ["rule", undefined, "message", "suggested"],
+			},
+			{
+				item: { label: "five", raw: { description: "description" } },
+				expected: ["Fallback", undefined, "description", undefined],
+			},
+		];
+
+		for (const { item, expected } of cases) {
+			const entry = normalizeFallowIssue("Fallback", item);
+			assert.deepEqual([entry.type, entry.id, entry.evidence, entry.action], expected);
+		}
+	});
+
+	it("derives finding/context counts and role filtering from the shared report", () => {
+		const overview = buildFallowOverview({
+			kind: "health",
+			findings: [
+				{ kind: "complexity", name: "one", path: "src/one.ts" },
+				{ kind: "complexity", name: "two", path: "src/two.ts" },
+			],
+			file_scores: [
+				{ path: "src/context-one.ts", maintainability_index: 90 },
+				{ path: "src/context-two.ts", maintainability_index: 80 },
+				{ path: "src/context-three.ts", maintainability_index: 70 },
+			],
+		});
+		const report = getNormalizedFallowReport(overview);
+		const normalizedEntries = allNormalizedFallowEntries(report);
+		const summary = parseSummary(fallowOutputDetail.format("summary", "summary", overview, "/tmp/report.json").text);
+		const findings = parseFindings(fallowOutputDetail.format("findings", "summary", overview, "/tmp/report.json").text);
+
+		assert.equal(report.findingCount, 2);
+		assert.equal(report.contextCount, 3);
+		assert.deepEqual(normalizedEntries.map((entry) => entry.role), ["finding", "finding", "context", "context", "context"]);
+		assert.equal(summary.finding_count, report.findingCount);
+		assert.equal(summary.context_count, report.contextCount);
+		assert.equal(findings.finding_count, report.findingCount);
+		assert.equal(findings.context_count, report.contextCount);
+		assert.equal(findings.findings.length, 2);
+		assert.deepEqual(findings.context, []);
+	});
+});

--- a/tests/output.test.mjs
+++ b/tests/output.test.mjs
@@ -299,6 +299,16 @@ describe("formatToolOutput", () => {
 				evidence: "No reachable consumer was found for unusedExport0.",
 				action: "Remove unusedExport0.",
 			});
+			assert.deepEqual(payload.findings[5], {
+				section: "Unused exports",
+				type: "unused-export",
+				id: "finding-5",
+				severity: "medium",
+				location: { path: "src/generated/file-5.ts", line: 6 },
+				subject: "unusedExport5",
+				evidence: "No reachable consumer was found for unusedExport5.",
+				action: "Remove unusedExport5.",
+			});
 			assert.equal(payload.complete_output_path, result.fullOutputPath);
 			assert.doesNotMatch(result.text, /long_detail/);
 			assert.equal(result.truncated, true);


### PR DESCRIPTION
## Summary

- centralize Fallow finding/context semantics in one authoritative normalized-report module
- reuse normalized entries for bounded tool output, prompts, navigator mode/filtering, and hydration
- remove the ordinary findings-only second all-raw overview pass
- preserve bounded inline raw retention with packed semantic storage and stable source coordinates
- let compact late-finding prompts work without the complete report while full prompts still hydrate raw JSON and reject drift

## User-visible changes

No intentional output or interaction changes. `fallow_run` summary/findings/raw JSON, `/fallow` transcripts, TUI/navigator rendering, and compact/full editor prompts remain byte-for-byte unchanged in the benchmark corpus. Compact prompts for late findings are now resilient when the complete-output file is unavailable; full-detail prompts retain the existing warning fallback.

## Performance and token impact

Compared `/tmp/pi-fallow-phase4b-before.json` from base `24c6f6d8` with `/tmp/pi-fallow-phase4b-after.json`:

- all 52 measurements were identical in characters, UTF-8 bytes, lines, both tokenizer counts, and quality metadata
- `o200k_base`: tool contract 439, tool results 8,046, slash transcripts 12,645, editor prompts 30,317 (all delta 0)
- `cl100k_base`: tool contract 439, tool results 7,935, slash transcripts 12,608, editor prompts 30,631 (all delta 0)
- retained memory passed: large default ~1.80x, normalized findings ~1.70x, schema ~0.66x

## Validation

- [x] `npm test` — 154 passed
- [x] `npm run check:bundle`
- [x] `npm run health` — 0 findings
- [x] `npm run dupes` — 0 clones
- [x] `npm run dead-code` — 0 issues
- [x] `npm run coverage` — thresholds passed
- [x] `npm run pack:check` — included through `npm run check:publish`
- [x] `npm run package:smoke` — Pi 0.84.1 RPC/print/JSON certification passed
- [x] `npm run check:publish`
- [x] `npm run audit:production` and complete-tree audit — 0 vulnerabilities
- [x] Fallow changed-file check — 0 issues/findings/clones
- [x] independent implementer/reviewer/probe loop — approved with no actionable findings

## Security and release considerations

No dependency, lockfile, peer, permission, workflow, provenance, roadmap, version, tag, or release changes. Fallow security reported only the two unchanged modeled spawn candidates in `extensions/fallow/process.ts` and `scripts/package-smoke.mjs`; no changed-file security finding was introduced. This PR does not authorize or perform a release.
