### PR TITLE
chore: prepare v0.4.1 candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,23 @@ All notable changes to Pi Fallow are documented here.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-13
+
 ### Added
+- Added isolated installed-tarball, provider-free certification against the lockfile-resolved Pi 0.84.1 host for extension loading and `/fallow health` behavior over RPC, print, and JSON modes.
+- Froze the immediate pre-output-detail benchmark and measured aggregate `o200k_base` tool results at 8,046 versus 45,104 tokens (an 82.16% reduction). Benchmarked slash transcripts remained unchanged, `detail` does not change slash/TUI rendering, and omitted inline findings remain counted with complete-output references.
+- Documented tested Pi 0.84.1 compatibility while retaining host-provided wildcard Pi peer dependencies.
+- Added measured model guidance to inspect or trace before deletion, treat incomplete type-aware evidence as advisory, preview fixes, and prefer bounded detail for routine calls.
 - Added `architecture` support to `fallow_run` and `/fallow`, backed by Fallow 3.14's stable `guard <file>...` command with required, `@`-normalized path targets.
-- Added an immediate pre-output-detail token benchmark baseline for reproducible before/after release evidence.
-- Documented the Pi 0.84.1 host certification matrix while retaining Pi's recommended wildcard peer dependencies.
-- Added measured `fallow_run` prompt guidance for deletion evidence, fix previews, and routine bounded output detail.
 
 ### Changed
 - Centralized tool commands, compact CLI prefixes, target behavior, overlapping slash metadata, autocomplete, and the `/fallow` argument hint in one typed registry.
-- Upgraded the coordinated Pi development packages to 0.84.0, incorporating the upstream dependency security fix.
-- Removed the temporary development-audit vulnerability acceptance after the upstream fix; CI and release validation now strictly audit the complete dependency tree.
+- Made normalized-report handling authoritative across bounded output, compact prompts, and navigator filtering/hydration; compact late-finding prompts no longer depend on complete-report hydration, while full prompts hydrate stable entries or warn on report drift.
+- Updated the coordinated Pi development lock to resolved 0.84.1 packages and the direct TypeBox development lock to 1.3.11.
+- Removed the temporary development-audit acceptance after the upstream fix; CI and release validation again strictly audit the complete dependency tree.
 
 ### Fixed
-- Made `fallow_run.detail` effective: tool calls now default to bounded normalized findings, while `summary` returns bounded status/counts and `raw` preserves the bounded raw-output behavior. Any omitted complete report is retained through a temporary-file reference.
+- Made `fallow_run.detail` effective: `summary` returns bounded status/counts, the default `findings` returns bounded normalized findings, and `raw` preserves bounded raw JSON/output. Summary and findings include complete-output references, as does raw output whenever truncation omits content.
 
 ## [0.4.0] - 2026-08-05
 
@@ -82,7 +86,8 @@ All notable changes to Pi Fallow are documented here.
 - Removed the persistent footer status line (`fallow ready · branch ... · base ...`) while keeping the transient `fallow running…` status during commands.
 - Improved output parsing, overview summaries, and navigator prompt coverage with regression tests.
 
-[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/revazi/pi-fallow/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/revazi/pi-fallow/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/revazi/pi-fallow/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/revazi/pi-fallow/compare/v0.2.0...v0.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fallow",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fallow",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.84.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fallow",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "packageManager": "npm@11.6.2",
   "description": "Pi extension that brings Fallow codebase intelligence into Pi as an agent tool and slash command.",


### PR DESCRIPTION
## Summary

- bump package and root lock metadata to the 0.4.1 candidate version without dependency/resolution changes
- finalize the 0.4.1 changelog for all reviewed work since v0.4.0
- keep an empty Unreleased section and align future compare links
- prepare candidate metadata only; this PR does not tag, publish, or authorize release

## User-visible changes

The candidate changelog records:

- provider-free installed-tarball Pi 0.84.1 certification for RPC, print, and JSON modes
- effective bounded `fallow_run.detail` semantics and complete-output references
- measured model guidance
- typed command registry and architecture/guard support
- authoritative normalized-report handling and hydration behavior
- strict complete-tree audits restored after coordinated Pi remediation

## Performance and token impact

Candidate benchmark against `benchmarks/baselines/v0.4.0-pre-output-detail.json`:

- tool results: 45,104 -> 8,046 `o200k_base` tokens (82.16% reduction)
- secondary tool results: 44,887 -> 7,935 `cl100k_base` tokens (82.32% reduction)
- slash transcripts unchanged at 12,645 `o200k_base`
- compact editor prompts unchanged at 30,317 `o200k_base`
- contract remains 439/440 and guidance 89/90 tokens under both pinned tokenizers
- bounded results preserve retention/omission accounting and complete-output references

## Validation

- [x] `npm test` — 154/154 passed
- [x] `npm run check:bundle`
- [x] `npm run health` — 0 findings
- [x] `npm run dupes` — 0 clones
- [x] `npm run dead-code` — 0 issues
- [x] `npm run coverage` — thresholds passed
- [x] `npm run pack:check` — 0.4.1, 56 files
- [x] `npm run package:smoke` — locked Pi 0.84.1 RPC/print/JSON certification
- [x] `npm run check:publish`
- [x] Node 22.19 and Node 24 candidate package smoke
- [x] strict production and complete-tree audits — 0 vulnerabilities
- [x] token candidate/comparison and quality assertions
- [x] changed-file/release-range Fallow checks
- [x] independent reviewer and technical probe — approved with no blockers

## Security and release considerations

Only `CHANGELOG.md`, `package.json`, and root version fields in `package-lock.json` changed. Lock resolution is structurally identical after excluding those two version fields. The candidate tarball contains no Pi packages, runtime/bundled dependencies, `node_modules`, tests, scripts, workflows, or benchmark files.

Fallow reports no new changed-file security candidate; its two unchanged modeled spawn candidates remain separate from the zero-vulnerability npm audits.

No `v0.4.1` tag, npm publication, GitHub Release, deployment, or release-workflow invocation exists. Publication remains blocked pending a separate release-readiness review and explicit authorization.
