### PR TITLE
test: harden release certification controls

### DIFF
--- a/.github/REPOSITORY_SETTINGS.md
+++ b/.github/REPOSITORY_SETTINGS.md
@@ -1,49 +1,81 @@
-# Recommended repository settings
+# Required repository settings
 
-These controls cannot be enforced entirely from files in the repository and should be configured in GitHub and npm after the workflows merge.
+These controls cannot be enforced entirely by tracked files. This document defines the fail-closed GitHub and npm policy for the repository; maintainers must verify the live settings before creating a release tag and must not claim an unavailable control is enabled.
 
-## GitHub ruleset for `main`
+## Protected `main` branch
 
-- Require pull requests before merging.
-- Require at least one approving review from a code owner.
-- Dismiss stale approvals when new commits are pushed.
-- Require conversation resolution.
-- Require linear history.
-- Block force pushes and branch deletion.
-- Require branches to be up to date before merging.
-- Require signed commits if all maintainers can support them.
+Create an active branch ruleset targeting `main` with no bypass actors and all of these settings:
 
-Require these status checks:
+- Require a pull request before merging.
+- Allow squash merging only; disable merge commits and rebase merging.
+- Require linear history and conversation resolution.
+- Block branch deletion and force pushes/non-fast-forward updates.
+- Require the branch to be up to date before merging.
+- Require every status check listed below to succeed:
+  - `Tests (Node 22.19)`
+  - `Tests (Node 24)`
+  - `Dependency audit`
+  - `Dependency review`
+  - `Fallow`
+  - `Coverage`
+  - `Package (Node 22.19)`
+  - `Package (Node 24)`
+  - `Analyze JavaScript and TypeScript`
 
-- `Tests (Node 22.19)`
-- `Tests (Node 24)`
-- `Dependency audit`
-- `Dependency review`
-- `Fallow`
-- `Coverage`
-- `Package (Node 22.19)`
-- `Package (Node 24)`
-- `Analyze JavaScript and TypeScript`
+Do not remove, rename, skip, or make any of these core checks advisory. Configure the repository merge options as well as the ruleset so squash is the only available merge method.
 
-Enable the dependency graph, GitHub's secret scanning, push protection, private vulnerability reporting, and Dependabot security updates.
+### Review policy for one maintainer
+
+`@revazi` is currently the only code owner and eligible collaborator. GitHub does not allow a pull-request author to approve their own pull request, so while that remains true set the required GitHub approval count to zero and do not enable a code-owner-approval gate that would make every merge impossible. Pull requests, required checks, up-to-date branches, conversation resolution, and the no-bypass policy remain mandatory.
+
+Every pull request, including each release candidate, must still have independent read-only agent review recorded as process evidence before merge. An agent report is not a GitHub user approval and must never be represented as one.
+
+When an independent eligible GitHub reviewer and code owner exists, require one approving code-owner review and dismiss stale approvals after new commits. Do not enable that identity gate before the reviewer can actually approve.
+
+## Protected release tags and `npm` environment
+
+Create an active tag ruleset for `v*.*.*` that blocks tag updates, deletion, and force updates. Permit creation only through the maintainer's controlled release process, with no ruleset bypass actor if the repository plan supports that restriction.
+
+Create the `npm` GitHub environment with these deployment protections:
+
+- Select **Selected branches and tags**, allow only tags matching `v*.*.*`, and allow no branch pattern.
+- Reject deployments from tags outside that protected pattern.
+- Disallow administrator bypass of environment protection rules when GitHub exposes that control for the repository/account.
+- While `@revazi` is the only eligible reviewer, configure no required human environment reviewer because GitHub self-review would make release impossible. Add one required reviewer only after an independent eligible human can approve deployments.
+
+Before creating any release tag, the maintainer must perform and record a privileged pre-tag verification that the candidate commit came through protected `main`, every exact required check succeeded on an up-to-date commit, `npm run check:publish` and both supported Node package-smoke runs passed, the version and changelog match the proposed tag, and the inspected tarball is the intended package boundary. A failure or missing result blocks tag creation.
 
 ## npm trusted publishing
 
-In the npm package settings for `pi-fallow`, add a GitHub Actions trusted publisher with:
+In the npm package settings for `pi-fallow`, configure this GitHub Actions trusted publisher identity exactly:
 
 - Organization/user: `revazi`
 - Repository: `pi-fallow`
 - Workflow: `release.yml`
 - Environment: `npm`
 
-Create the `npm` GitHub environment and restrict deployments to protected release tags. Add required reviewers if releases should require manual approval.
+The release workflow intentionally uses GitHub OIDC and must not receive a long-lived `NPM_TOKEN`. Remove legacy publish tokens only after the trusted publisher identity and a controlled publication have been verified.
 
-The release workflow intentionally uses OIDC and does not require a long-lived `NPM_TOKEN`. Remove legacy publish tokens after trusted publishing has been verified.
+## Security features and support exceptions
+
+Enable each of these controls wherever the repository/account exposes it:
+
+- Dependency graph.
+- Dependabot security updates.
+- Private vulnerability reporting.
+- Secret scanning.
+- Secret-scanning push protection.
+
+If GitHub does not support a control for the current repository visibility, plan, or account, record the control name, the GitHub limitation, and the verification date in this section rather than marking it complete or silently omitting it. No support exceptions are currently documented, so every control above remains required pending live verification.
+
+## GitHub Actions policy
+
+Restrict Actions to GitHub-owned actions plus verified or explicitly selected third-party actions needed by the repository. Keep every workflow `uses:` reference pinned to a full commit SHA, including allowlisted third-party actions; a verified publisher or allowlist entry does not replace SHA pinning.
 
 ## Dependabot
 
-Create the `dependencies` and `github-actions` labels used by `.github/dependabot.yml`. Optionally enable auto-merge for patch-only Dependabot PRs after every required check succeeds; do not auto-merge major updates.
+Create the `dependencies` and `github-actions` labels used by `.github/dependabot.yml`. Dependabot pull requests must pass the same review process and every required check; do not auto-merge around the protected-branch policy.
 
 ## CodeQL
 
-Do not enable GitHub's default CodeQL setup at the same time as the repository's advanced `codeql.yml` workflow. Use one configuration to avoid duplicate scans.
+Use the repository's advanced `.github/workflows/codeql.yml` configuration. Do not enable GitHub's default CodeQL setup at the same time, which would create duplicate scans.

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -2,23 +2,31 @@ import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { RpcClient } from "@earendil-works/pi-coding-agent";
 
 const root = resolve(import.meta.dirname, "..");
-const workspace = mkdtempSync(join(tmpdir(), "pi-fallow-package-"));
-const packDir = join(workspace, "pack");
-const installDir = join(workspace, "install");
 
-try {
-	const packResult = packPackage(packDir);
-	validateContents(packResult.files.map((file) => file.path));
-	installTarball(join(packDir, packResult.filename), installDir);
-	const packageRoot = validateInstalledPackage(installDir);
-	const piVersion = await validateInstalledPackageWithPi(packageRoot, join(workspace, "agent-home"));
-	console.log(`Package smoke check passed (${packResult.filename}, ${packResult.files.length} files, Pi ${piVersion} RPC/print/JSON).`);
-} finally {
-	rmSync(workspace, { recursive: true, force: true });
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+	await runPackageSmoke();
+}
+
+async function runPackageSmoke() {
+	const workspace = mkdtempSync(join(tmpdir(), "pi-fallow-package-"));
+	const packDir = join(workspace, "pack");
+	const installDir = join(workspace, "install");
+
+	try {
+		const packResult = packPackage(packDir);
+		validateContents(packResult.files.map((file) => file.path));
+		installTarball(join(packDir, packResult.filename), installDir);
+		const packageRoot = validateInstalledPackage(installDir);
+		const piVersion = await validateInstalledPackageWithPi(packageRoot, join(workspace, "agent-home"));
+		console.log(`Package smoke check passed (${packResult.filename}, ${packResult.files.length} files, Pi ${piVersion} RPC/print/JSON).`);
+	} finally {
+		rmSync(workspace, { recursive: true, force: true });
+	}
 }
 
 function packPackage(destination) {
@@ -135,9 +143,30 @@ function validateNonInteractiveModes(cliPath, packageRoot, agentRoot) {
 		["--print", ...commonArgs, "/pi-fallow-unknown-command"],
 		join(agentRoot, "control"),
 	);
-	assert.equal(controlResult.status, 1, "Unknown print-mode slash command unexpectedly succeeded without credentials.");
-	assert.match(controlResult.stderr, /API key|Authentication failed|No model selected/,
-		"Unknown slash-command control did not reach provider authentication preflight.");
+	assertCredentialFreeControl(controlResult, cliPath);
+}
+
+export function assertCredentialFreeControl(result, cliPath) {
+	const errorLine = "No API key found for the selected model.";
+	const piPackageRoot = dirname(dirname(resolve(cliPath)));
+	const stderrLines = result.stderr.split("\n");
+
+	assert.equal(result.status, 1, "Unknown print-mode slash command did not exit with status 1.");
+	assert.equal(result.stdout, "", "Unknown print-mode slash command unexpectedly wrote to stdout.");
+	assert.equal(stderrLines[0], errorLine, "Unknown print-mode slash command emitted the wrong auth error.");
+	assert.equal(
+		stderrLines.filter((line) => line === errorLine).length,
+		1,
+		"Unknown print-mode slash command did not emit the auth error exactly once.",
+	);
+	assert.deepEqual(stderrLines, [
+		errorLine,
+		"",
+		"Use /login to log into a provider via OAuth or API key. See:",
+		`  ${join(piPackageRoot, "docs", "providers.md")}`,
+		`  ${join(piPackageRoot, "docs", "models.md")}`,
+		"",
+	], "Unknown print-mode slash command emitted unexpected auth guidance.");
 }
 
 function isolatedPiArgs(packageRoot) {

--- a/tests/package-smoke.test.mjs
+++ b/tests/package-smoke.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { dirname, join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import { assertCredentialFreeControl } from "../scripts/package-smoke.mjs";
+
+const cliPath = resolve(import.meta.dirname, "..", "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js");
+const piPackageRoot = dirname(dirname(cliPath));
+const errorLine = "No API key found for the selected model.";
+const validStderr = [
+	errorLine,
+	"",
+	"Use /login to log into a provider via OAuth or API key. See:",
+	`  ${join(piPackageRoot, "docs", "providers.md")}`,
+	`  ${join(piPackageRoot, "docs", "models.md")}`,
+	"",
+].join("\n");
+
+function assertControl(stderr = validStderr, overrides = {}) {
+	assertCredentialFreeControl({ status: 1, stdout: "", stderr, ...overrides }, cliPath);
+}
+
+describe("package-smoke credential-free negative control", () => {
+	it("accepts only the locked Pi 0.84.1 auth-guidance structure", () => {
+		assert.doesNotThrow(() => assertControl());
+	});
+
+	for (const [name, mutate] of [
+		["wrong first line", (stderr) => stderr.replace(errorLine, "Authentication failed.")],
+		["duplicate error line", (stderr) => stderr.replace(`${errorLine}\n`, `${errorLine}\n${errorLine}\n`)],
+		["extra text", (stderr) => `${stderr}Unexpected guidance.\n`],
+		["reversed documentation order", (stderr) => stderr.replace(
+			`  ${join(piPackageRoot, "docs", "providers.md")}\n  ${join(piPackageRoot, "docs", "models.md")}`,
+			`  ${join(piPackageRoot, "docs", "models.md")}\n  ${join(piPackageRoot, "docs", "providers.md")}`,
+		)],
+		["wrong documentation path", (stderr) => stderr.replace("docs/providers.md", "docs/authentication.md")],
+		["missing trailing newline", (stderr) => stderr.slice(0, -1)],
+	]) {
+		it(`rejects ${name}`, () => {
+			assert.throws(() => assertControl(mutate(validStderr)), assert.AssertionError);
+		});
+	}
+
+	it("rejects a different exit status or non-empty stdout", () => {
+		assert.throws(() => assertControl(validStderr, { status: 0 }), assert.AssertionError);
+		assert.throws(() => assertControl(validStderr, { stdout: "unexpected\n" }), assert.AssertionError);
+	});
+});


### PR DESCRIPTION
## Summary

- replace the permissive provider-auth negative-control regex with the exact locked Pi 0.84.1 stderr structure
- add mutation tests for wrong/duplicate/extra/reordered/missing control output
- make the package-smoke helper import-safe without changing normal execution
- document a fail-closed repository/release settings policy that remains operable with one eligible maintainer

## User-visible changes

None to `fallow_run`, `/fallow`, navigator, prompts, or package contents. The certification now accepts only Pi 0.84.1's exact error first line followed by its exact `/login` documentation guidance, paths, and trailing newline.

## Performance and token impact

No model-visible drift. Candidate comparison retained:

- contract 439 tokens
- tool results 8,046 `o200k_base`
- slash transcript 12,645
- editor prompt 30,317
- 82.16% tool-result reduction from the immediate pre-output-detail baseline

## Validation

- [x] `npm test` — 162/162 passed
- [x] `npm run check:bundle`
- [x] `npm run health`
- [x] `npm run dupes`
- [x] `npm run dead-code`
- [x] `npm run coverage` — thresholds passed
- [x] `npm run pack:check`
- [x] `npm run package:smoke`
- [x] Node 22.19 and Node 24 package smoke
- [x] `npm run check:publish`
- [x] production and complete npm audits — 0 vulnerabilities
- [x] focused negative-control tests — 8/8 under both Node lines
- [x] Fallow changed audit/security — no findings/new candidates
- [x] exact-base token comparison — zero model-visible drift
- [x] actual 0.4.1 tarball — unchanged 56-file package boundary
- [x] independent reviewer and probe — approved

## Security and release considerations

Live settings were separately hardened to match the reviewed policy:

- main requires PRs, squash/linear history, conversation resolution, strict up-to-date success for all nine CI/CodeQL checks, and no bypass actors
- release tags have active deletion/non-fast-forward protection
- the `npm` environment permits only `v*.*.*` tags and disallows admin bypass
- Actions are restricted to GitHub-owned actions plus the selected Codecov action; workflows remain SHA-pinned
- secret scanning, push protection, private vulnerability reporting, dependency graph, and Dependabot security updates are enabled

GitHub approvals remain zero only because `@revazi` is the sole eligible collaborator/code owner and GitHub prohibits self-approval. Independent read-only review evidence remains mandatory; one code-owner approval becomes required when an eligible independent reviewer exists.

No version, dependency, workflow, tag, npm publication, GitHub Release, or release-workflow action occurred. A new exact-SHA release-readiness audit is still required.
