### PR TITLE
chore: prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,10 @@ All notable changes to Pi Fallow are documented here.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-19
+
 ### Added
 - Added `/fallow issues`, an issue-focused aggregate that combines project-wide dead-code, duplication, health, and security candidates in one navigator while omitting informational per-file health rows.
-
-### Changed
-- Made `/fallow` and `/fallow run` default to the aggregate project-issues report instead of plain health; explicit Fallow subcommands and `PI_FALLOW_DEFAULT_COMMAND` overrides remain available.
-- Expanded dead-code navigator coverage to every current Fallow issue array, with a summary-backed fallback for future issue categories.
-
-## [0.4.1] - 2026-08-13
-
-### Added
 - Added isolated installed-tarball, provider-free certification against the lockfile-resolved Pi 0.84.1 host for extension loading and `/fallow health` behavior over RPC, print, and JSON modes.
 - Froze the immediate pre-output-detail benchmark and measured aggregate `o200k_base` tool results at 8,046 versus 45,104 tokens (an 82.16% reduction). Benchmarked slash transcripts remained unchanged, `detail` does not change slash/TUI rendering, and omitted inline findings remain counted with complete-output references.
 - Documented tested Pi 0.84.1 compatibility while retaining host-provided wildcard Pi peer dependencies.
@@ -21,6 +15,8 @@ All notable changes to Pi Fallow are documented here.
 - Added `architecture` support to `fallow_run` and `/fallow`, backed by Fallow 3.14's stable `guard <file>...` command with required, `@`-normalized path targets.
 
 ### Changed
+- Made `/fallow` and `/fallow run` default to the aggregate project-issues report instead of plain health; explicit Fallow subcommands and `PI_FALLOW_DEFAULT_COMMAND` overrides remain available.
+- Expanded dead-code navigator coverage to every current Fallow issue array, with a summary-backed fallback for future issue categories.
 - Centralized tool commands, compact CLI prefixes, target behavior, overlapping slash metadata, autocomplete, and the `/fallow` argument hint in one typed registry.
 - Made normalized-report handling authoritative across bounded output, compact prompts, and navigator filtering/hydration; compact late-finding prompts no longer depend on complete-report hydration, while full prompts hydrate stable entries or warn on report drift.
 - Updated the coordinated Pi development lock to resolved 0.84.1 packages and the direct TypeBox development lock to 1.3.11.
@@ -93,8 +89,8 @@ All notable changes to Pi Fallow are documented here.
 - Removed the persistent footer status line (`fallow ready · branch ... · base ...`) while keeping the transient `fallow running…` status during commands.
 - Improved output parsing, overview summaries, and navigator prompt coverage with regression tests.
 
-[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.4.1...HEAD
-[0.4.1]: https://github.com/revazi/pi-fallow/compare/v0.4.0...v0.4.1
+[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/revazi/pi-fallow/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/revazi/pi-fallow/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/revazi/pi-fallow/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/revazi/pi-fallow/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Plain `fallow health` can return actionable findings alongside informational per
 
 ## Tested compatibility
 
-The current `0.4.x` development line is certified with this host matrix:
+The current `0.5.x` development line is certified with this host matrix:
 
 | Pi coding agent | Matching Pi AI/TUI packages | Node.js | Fallow |
 |---|---|---|---|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,17 +4,17 @@ This roadmap describes the current baseline and likely next work. It is planning
 
 ## Release status and boundaries
 
-- **Published:** the npm registry currently serves `pi-fallow@0.4.0`. Its shipped changes are recorded in the [`0.4.0` changelog](./CHANGELOG.md#040---2026-08-05).
-- **Current, unreleased:** `main` through merge commit `9c24010` still has package version `0.4.0` and includes post-release output-detail, Pi compatibility, model-guidance, command-registry, architecture/guard, and normalized-report work. These changes are not part of the published package; see [`Unreleased`](./CHANGELOG.md#unreleased).
-- **Next boundary:** `0.4.1` is a candidate validation boundary only. It does not exist as a release. Publication remains blocked until all release gates pass, an independent release-readiness review is complete, and a maintainer gives explicit authorization.
-- **Later work:** the priorities below are directional. They carry no date or version commitment beyond the current `0.4.1` candidate boundary.
+- **Current boundary:** `0.5.0` consolidates the post-`0.4.0` output-detail, Pi compatibility, model-guidance, command-registry, architecture/guard, normalized-report, and project-issues work recorded in the [`0.5.0` changelog](./CHANGELOG.md#050---2026-08-19).
+- **Release records:** the npm registry and GitHub releases are authoritative for whether a version has completed publication; a version in source remains a candidate until the protected tag workflow succeeds.
+- **Publication gate:** every boundary remains blocked until all release gates pass, an independent release-readiness review is recorded, and a maintainer gives explicit authorization.
+- **Later work:** the priorities below are directional and carry no date or version commitment.
 
 ## Measured current baseline
 
-Unless noted otherwise, these are repository-specific measurements from `main` at `9c24010`, not universal expectations for other machines, hosts, Fallow installations, or providers.
+Unless noted otherwise, these are repository-specific measurements from the `0.5.0` release candidate, not universal expectations for other machines, hosts, Fallow installations, or providers.
 
-- **Tests and coverage:** 154 tests. All-extension coverage is **87.52% statements/lines**, **86.18% branches**, and **83.75% functions**.
-- **Fallow quality:** Fallow 3.14 reports health **85.4 (A)**, average maintainability **92.0**, and zero threshold findings, dead-code issues, or clone groups.
+- **Tests and coverage:** 169 tests. All-extension coverage is **88.50% statements/lines**, **86.35% branches**, and **85.44% functions**.
+- **Fallow quality:** Fallow 3.14 reports health **85.3 (A)**, average maintainability **91.9**, and zero threshold findings, dead-code issues, or clone groups.
 - **Dependency audits:** strict production and complete-tree npm audits report zero vulnerabilities. These audit results are separate from Fallow's modeled security-candidate analysis.
 - **Host compatibility:** packaged, provider-free Pi **0.84.1** behavior is certified on Node **22.19** and **24**. Pi host libraries intentionally remain external wildcard peers; this is a tested compatibility matrix, not a restrictive peer range or provider-backed/PTY/tmux certification. See the [README compatibility section](./README.md#tested-compatibility).
 - **Token baseline:** the current `fallow_run` tool contract is **439 tokens under both pinned tokenizers**. Across the frozen corpus, bounded tool results total **8,046 `o200k_base` / 7,935 `cl100k_base` tokens**. The output-detail work leaves the benchmarked slash-command and editor-prompt surfaces unchanged and reduces aggregate `o200k_base` tool-result tokens by **82.16%** from the immediate pre-output-detail baseline. These are deterministic corpus measurements, not provider billing claims; see [`benchmarks/README.md`](./benchmarks/README.md).
@@ -31,19 +31,19 @@ The long measurement history belongs in the benchmark documentation rather than 
 - compact-by-default and explicit full-detail prompts, all-finding navigation, search/filter/multi-selection, and responsive navigator scaling;
 - package-boundary certification against Pi 0.84.1 and Fallow 3.14 on the tested Node lines;
 - measured model guidance for deletion evidence, fix previews, advisory type-aware results, and routine bounded detail;
-- a typed command registry shared by tool, slash, autocomplete, and smoke-test surfaces, including architecture-to-`guard` support; and
-- authoritative normalized-report selection shared across output and prompts, with complete-report hydration and drift protection.
+- a typed command registry shared by tool, slash, autocomplete, and smoke-test surfaces, including architecture-to-`guard` support;
+- authoritative normalized-report selection shared across output and prompts, with complete-report hydration and drift protection; and
+- an issue-focused default that combines actionable dead-code, duplication, health, and security candidates without flooding the navigator with informational file scores or hotspots.
 
 See [`benchmarks/README.md`](./benchmarks/README.md), [`benchmarks/PERFORMANCE.md`](./benchmarks/PERFORMANCE.md), [`CHANGELOG.md`](./CHANGELOG.md), and the [README compatibility section](./README.md#tested-compatibility) for authoritative detail.
 
 ## Remaining priorities
 
-1. **Finish the `0.4.1` candidate evidence.** Run the complete candidate gates, verify package contents and both supported Node lines, and conduct a separate independent release-readiness review. Stop before tagging or publication unless explicit authorization is given.
-2. **Keep command and report compatibility honest.** Expand representative command/schema fixtures and add useful command-registry-versus-`fallow schema` drift checks while preserving graceful behavior with separately installed Fallow versions.
-3. **Decide whether user-owned customization is still desired.** If demand remains, design Pi Fallow-specific global/project configuration, prompt templates, and a safe prompt/config preview without taking ownership of Fallow's configuration file.
-4. **Complete navigator workflows.** Add command-aware actions and trace/report history, then make any remaining UI density improvements based on real large-report use rather than decorative churn.
-5. **Improve quality where evidence points.** Raise coverage and maintainability gradually around real execution, command-flow, rendering, project-state, and PR-summary hotspots. Do not split files cosmetically merely to improve a metric.
-6. **Maintain compatibility and supply-chain gates.** Keep Pi, Fallow, Node, and dependency compatibility current with strict production/complete-tree audits and repeatable package-boundary certification.
+1. **Keep command and report compatibility honest.** Expand representative command/schema fixtures and add useful command-registry-versus-`fallow schema` drift checks while preserving graceful behavior with separately installed Fallow versions.
+2. **Decide whether user-owned customization is still desired.** If demand remains, design Pi Fallow-specific global/project configuration, prompt templates, and a safe prompt/config preview without taking ownership of Fallow's configuration file.
+3. **Complete navigator workflows.** Add command-aware actions and trace/report history, then make any remaining UI density improvements based on real large-report use rather than decorative churn.
+4. **Improve quality where evidence points.** Raise coverage and maintainability gradually around real execution, command-flow, rendering, project-state, and PR-summary hotspots. Do not split files cosmetically merely to improve a metric.
+5. **Maintain compatibility and supply-chain gates.** Keep Pi, Fallow, Node, and dependency compatibility current with strict production/complete-tree audits and repeatable package-boundary certification.
 
 ## Invariants
 
@@ -57,7 +57,6 @@ Future work must preserve these boundaries:
 
 ## Suggested delivery order
 
-1. Close the remaining `0.4.1` candidate validation and independent release-readiness review; hold at the publication boundary.
-2. Add fixture/schema compatibility and registry-drift checks needed to keep that evidence reproducible.
-3. Confirm demand and scope before implementing user-owned configuration or prompt customization/preview.
-4. Iterate on command-aware navigator history/actions, hotspot coverage, maintainability, and dependency compatibility in small independently reviewed changes.
+1. Add fixture/schema compatibility and registry-drift checks needed to keep release evidence reproducible.
+2. Confirm demand and scope before implementing user-owned configuration or prompt customization/preview.
+3. Iterate on command-aware navigator history/actions, hotspot coverage, maintainability, and dependency compatibility in small independently reviewed changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fallow",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fallow",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.84.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fallow",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "packageManager": "npm@11.6.2",
   "description": "Pi extension that brings Fallow codebase intelligence into Pi as an agent tool and slash command.",


### PR DESCRIPTION
## Summary

- bump the package and lockfile to `0.5.0`
- consolidate the unpublished `0.4.1` candidate notes and project-issues work into the `0.5.0` changelog
- refresh compatibility and roadmap release-boundary documentation

## Release validation

- `npm run check:publish`
- `npm run coverage`
- Node 24 package smoke through `check:publish`
- `nvm exec 22.19.0 npm run package:smoke`
- inspected `npm pack --dry-run --json`: `pi-fallow-0.5.0.tgz`, 59 intended files

## Security and release considerations

- No dependency or permission changes.
- Publication remains gated on independent release-candidate review, required PR/main checks, protected-tag verification, and the trusted-publishing workflow.
