### PR TITLE
chore: prepare v0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to Pi Fallow are documented here.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-29
+
 ### Changed
 - Updated the coordinated Pi development lock and package-boundary certification to 0.84.3, including the manifest-declared bundled CLI entrypoint, while retaining host-provided wildcard Pi peer dependencies.
 - Updated the pinned build and analysis tooling to esbuild 0.28.2 and Fallow 3.18.0, including CLI-derived capability and issue-registry coverage, type-aware wire protocol 7 and semantic schema 3 checks, unchanged 3.17 versioned output roots, and packaged host compatibility coverage.
+- Updated the direct TypeBox development lock to 1.3.16 and the fully SHA-pinned CodeQL Action to 4.37.8.
 
 ## [0.5.0] - 2026-08-19
 
@@ -93,7 +96,8 @@ All notable changes to Pi Fallow are documented here.
 - Removed the persistent footer status line (`fallow ready · branch ... · base ...`) while keeping the transient `fallow running…` status during commands.
 - Improved output parsing, overview summaries, and navigator prompt coverage with regression tests.
 
-[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/revazi/pi-fallow/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/revazi/pi-fallow/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/revazi/pi-fallow/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/revazi/pi-fallow/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/revazi/pi-fallow/compare/v0.3.0...v0.3.1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ This roadmap describes the current baseline and likely next work. It is planning
 
 ## Release status and boundaries
 
-- **Current boundary:** `0.5.0` consolidates the post-`0.4.0` output-detail, Pi compatibility, model-guidance, command-registry, architecture/guard, normalized-report, and project-issues work recorded in the [`0.5.0` changelog](./CHANGELOG.md#050---2026-08-19).
+- **Current boundary:** `0.5.1` refreshes the certified Pi, Fallow, TypeBox, and CodeQL tooling on top of the issue-focused `0.5.0` release, as recorded in the [`0.5.1` changelog](./CHANGELOG.md#051---2026-08-29).
 - **Release records:** the npm registry and GitHub releases are authoritative for whether a version has completed publication; a version in source remains a candidate until the protected tag workflow succeeds.
 - **Publication gate:** every boundary remains blocked until all release gates pass, an independent release-readiness review is recorded, and a maintainer gives explicit authorization.
 - **Later work:** the priorities below are directional and carry no date or version commitment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fallow",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fallow",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "devDependencies": {
         "@earendil-works/pi-ai": "^0.84.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fallow",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "packageManager": "npm@11.6.2",
   "description": "Pi extension that brings Fallow codebase intelligence into Pi as an agent tool and slash command.",


### PR DESCRIPTION
## Summary

Prepare the patch release for the completed dependency and compatibility refresh:

- bump `pi-fallow` from 0.5.0 to 0.5.1
- move the current Unreleased dependency notes into the dated 0.5.1 changelog section
- record Pi 0.84.3, Fallow 3.18.0, TypeBox 1.3.16, and CodeQL Action 4.37.8
- update the roadmap's current release boundary

## Validation

- `npm run check:publish`
- 169 tests
- bundle, Fallow health/dead-code/duplication/schema smoke
- complete-tree audit
- isolated 59-file package smoke with Pi 0.84.3 RPC/print/JSON

Independent release-candidate review will be recorded before merge. The release tag will not be created until protected-main checks and privileged pre-tag verification pass.
