### PR TITLE
feat: add navigator action palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Pi Fallow are documented here.
 ## [Unreleased]
 
 ### Added
+- Added a command-aware TUI navigator action palette with safe inspect, explain, trace, symbol-impact, and architecture queries; action results return to preserved navigator state, while fix actions are limited to explicitly previewable project-wide dry runs and can never apply changes.
 - Added explicit opt-in semantic similar-code analysis across `/fallow` and `fallow_run`, with read-only status/discovery/inspect/review flows, reproducible model and input provenance, advisory source-grounded rendering, partial-phase and skip diagnostics, distinct cancellation/timeout metadata, a cold-run timeout allowance, and hard guards against model downloads or cache mutation.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 - **PR shortcut:** `/fallow pr` maps to `audit --base <detected-base> --gate new-only`.
 - **Rerun shortcut:** `/fallow rerun` repeats the last `/fallow` command.
 - **Non-blocking autocomplete:** subcommands, flags, enum values, static refs, and asynchronously discovered project branch refs are suggested without running Git while you type.
-- **Interactive navigator:** every actionable finding remains navigable with search, section/severity filters, multi-selection, tracing, and editor loading; informational file scores/hotspots are classified separately.
+- **Interactive navigator:** every actionable finding remains navigable with search, section/severity filters, multi-selection, command-aware read-only actions, tracing, and editor loading; informational file scores/hotspots are classified separately.
 - **Run-mode support:** `/fallow` executes in TUI, RPC, JSON, and print modes; terminal loaders and navigator overlays are TUI-only, while non-TUI modes retain full transcript output.
 - **Robust output parsing:** direct or noisy embedded JSON is scanned once with nesting, strings, and escapes handled correctly.
 - **Safe defaults:** JSON and quiet output are added when appropriate; complete output is saved to a temp file whenever transcript or navigator data omits fields, and released from retained engine state after formatting. Pi Fallow never automatically deletes saved reports.
@@ -163,9 +163,12 @@ In the interactive navigator:
 - `x` — clear filters; `c` — clear explicit selections
 - `i` — show/hide informational file scores and hotspots; they are hidden by default and never counted as findings
 - `d` — toggle full raw finding JSON in the agent prompt; it is deselected by default
+- `p` — open the current finding's command-aware action palette
 - `e` or `a` — load selected findings into the editor
-- `t` — run a trace for the selected finding when possible
-- `q` / `Esc` — close (`Esc` first cancels an active search)
+- `t` — run the first valid trace action for the selected finding
+- `q` / `Esc` — close (`Esc` first cancels an active search or closes the action palette)
+
+The action palette derives only shell-free argument arrays supported by the current finding evidence: file/symbol inspection, rule explanation, export/file/dependency/clone tracing, type-aware symbol impact, and architecture-rule lookup. Unknown findings retain only generic actions that have sufficient safe inputs. A fix option appears only when Fallow explicitly marks a retained finding action `auto_fixable: true`, and it always runs project-wide `fix --dry-run --no-create-config`; applying a fix is never available from the palette. Closing or cancelling an action result reruns the originating report and restores its search, filters, current row, expansion, selections, informational toggle, and prompt-detail mode.
 
 The navigator defaults to compact prompts. Compact mode includes every selected finding with type, severity, location, subject, concise evidence/details, and suggested action, plus the complete-report path. Selecting the full-details checkbox additionally embeds complete raw JSON for every selected finding; the overlay warns that this can use substantially more model context.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,8 +13,8 @@ This roadmap describes the current baseline and likely next work. It is planning
 
 Unless noted otherwise, these are repository-specific measurements from the `0.5.0` release candidate, not universal expectations for other machines, hosts, Fallow installations, or providers.
 
-- **Tests and coverage:** 179 tests. The `0.5.0` release-candidate snapshot recorded **88.50% statements/lines**, **86.35% branches**, and **85.44% functions**; current subprocess-sensitive reruns can vary slightly by run and Node line while CI continues to enforce the coverage thresholds.
-- **Fallow quality:** Fallow 3.21 reports health **84.4 (B)**, average maintainability **91.6**, and zero threshold findings, dead-code issues, or clone groups.
+- **Tests and coverage:** 190 tests. The `0.5.0` release-candidate snapshot recorded **88.50% statements/lines**, **86.35% branches**, and **85.44% functions**; current subprocess-sensitive reruns can vary slightly by run and Node line while CI continues to enforce the coverage thresholds.
+- **Fallow quality:** Fallow 3.21 reports health **84.4 (B)**, average maintainability **91.7**, and zero threshold findings, dead-code issues, or clone groups.
 - **Dependency audits:** strict production and complete-tree npm audits report zero vulnerabilities. These audit results are separate from Fallow's modeled security-candidate analysis.
 - **Host compatibility:** packaged, provider-free Pi **0.84.3** behavior is certified on Node **22.19** and **24**. Pi host libraries intentionally remain external wildcard peers; this is a tested compatibility matrix, not a restrictive peer range or provider-backed/PTY/tmux certification. See the [README compatibility section](./README.md#tested-compatibility).
 - **Token baseline:** the current `fallow_run` tool contract is **421 tokens under both pinned tokenizers**. Across the frozen corpus, bounded tool results total **8,036 `o200k_base` / 7,925 `cl100k_base` tokens**. The output-detail work leaves the benchmarked slash-command and editor-prompt surfaces unchanged and reduces aggregate `o200k_base` tool-result tokens by **82.16%** from the immediate pre-output-detail baseline. These are deterministic corpus measurements, not provider billing claims; see [`benchmarks/README.md`](./benchmarks/README.md).
@@ -28,7 +28,7 @@ The long measurement history belongs in the benchmark documentation rather than 
 - cancellation and process-tree lifecycle handling, including timeout escalation, plus TUI, RPC, print, and JSON mode paths;
 - asynchronous cached Git completion/base detection and cached, invalidation-aware Fallow runner resolution;
 - bounded summary/findings/raw model output with readable complete-output references whenever data is omitted;
-- compact-by-default and explicit full-detail prompts, all-finding navigation, search/filter/multi-selection, and responsive navigator scaling;
+- compact-by-default and explicit full-detail prompts, all-finding navigation, search/filter/multi-selection, responsive navigator scaling, and command-aware read-only action palettes with stateful return;
 - package-boundary certification against Pi 0.84.3 and Fallow 3.21 on the tested Node lines;
 - measured model guidance for deletion evidence, fix previews, advisory type-aware results, and routine bounded detail;
 - a typed command registry shared by tool, slash, autocomplete, and smoke-test surfaces, including architecture-to-`guard` support;
@@ -42,7 +42,7 @@ See [`benchmarks/README.md`](./benchmarks/README.md), [`benchmarks/PERFORMANCE.m
 
 1. **Keep command and report compatibility honest.** Expand representative command/schema fixtures and add useful command-registry-versus-`fallow schema` drift checks while preserving graceful behavior with separately installed Fallow versions.
 2. **Decide whether user-owned customization is still desired.** If demand remains, design Pi Fallow-specific global/project configuration, prompt templates, and a safe prompt/config preview without taking ownership of Fallow's configuration file.
-3. **Complete navigator workflows.** Add command-aware actions and trace/report history, then make any remaining UI density improvements based on real large-report use rather than decorative churn.
+3. **Complete navigator workflows.** Add trace/report history and comparison, then make any remaining UI density improvements based on real large-report use rather than decorative churn.
 4. **Improve quality where evidence points.** Raise coverage and maintainability gradually around real execution, command-flow, rendering, project-state, and PR-summary hotspots. Do not split files cosmetically merely to improve a metric.
 5. **Maintain compatibility and supply-chain gates.** Keep Pi, Fallow, Node, and dependency compatibility current with strict production/complete-tree audits and repeatable package-boundary certification.
 
@@ -60,4 +60,4 @@ Future work must preserve these boundaries:
 
 1. Add fixture/schema compatibility and registry-drift checks needed to keep release evidence reproducible.
 2. Confirm demand and scope before implementing user-owned configuration or prompt customization/preview.
-3. Iterate on command-aware navigator history/actions, hotspot coverage, maintainability, and dependency compatibility in small independently reviewed changes.
+3. Iterate on navigator history/comparison, hotspot coverage, maintainability, and dependency compatibility in small independently reviewed changes.

--- a/extensions/fallow/command/handler.ts
+++ b/extensions/fallow/command/handler.ts
@@ -1,11 +1,12 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { fallowCli } from "../cli";
 import { detectFallowBaseRef } from "../project/git";
-import type { FallowNavigatorResult } from "../types";
+import type { FallowNavigatorResult, FallowNavigatorState } from "../types";
 import { sendFallowAboutMessage } from "../update-notice";
 import { normalizeFallowArgs, resolveFallowRunArgs } from "./args";
 import { resolveFallowCommandBaseRef } from "./base";
 import { isFallowTuiMode } from "./mode";
+import { runFallowNavigatorLoop } from "./navigator-loop";
 import { executeFallowResult } from "./result-flow";
 import type { FallowCommandContext, FallowCommandState } from "./types";
 
@@ -72,11 +73,9 @@ async function executeFallowCommandLoop(
 	commandState: FallowCommandState,
 	initialArgs: string[],
 ): Promise<FallowNavigatorResult | null | undefined> {
-	let result = await runFallowCommandOnce(pi, ctx, commandState, initialArgs, true);
-	while (isFallowTuiMode(ctx.mode) && result?.type === "trace") {
-		result = await runFallowCommandOnce(pi, ctx, commandState, result.commandArgs, false);
-	}
-	return result;
+	return runFallowNavigatorLoop(initialArgs, isFallowTuiMode(ctx.mode), (args, rememberLast, initialState) => (
+		runFallowCommandOnce(pi, ctx, commandState, args, rememberLast, initialState)
+	));
 }
 
 function runFallowCommandOnce(
@@ -85,10 +84,11 @@ function runFallowCommandOnce(
 	commandState: FallowCommandState,
 	args: string[],
 	rememberLast: boolean,
+	initialNavigatorState?: FallowNavigatorState,
 ): Promise<FallowNavigatorResult | null | undefined> {
 	return executeFallowResult(pi, ctx, args, rememberLast, (updated) => {
 		commandState.lastArgs = updated;
-	});
+	}, initialNavigatorState);
 }
 
 function applyFallowPrompt(ctx: FallowCommandContext, result: FallowNavigatorResult | null | undefined): void {

--- a/extensions/fallow/command/navigator-loop.ts
+++ b/extensions/fallow/command/navigator-loop.ts
@@ -1,0 +1,59 @@
+import type { FallowNavigatorResult, FallowNavigatorReturnTarget, FallowNavigatorState } from "../types";
+
+export type FallowNavigatorRunOnce = (
+	args: string[],
+	rememberLast: boolean,
+	initialState?: FallowNavigatorState,
+) => Promise<FallowNavigatorResult | null | undefined>;
+
+export async function runFallowNavigatorLoop(
+	initialArgs: string[],
+	enabled: boolean,
+	runOnce: FallowNavigatorRunOnce,
+): Promise<FallowNavigatorResult | null | undefined> {
+	const initialResult = await runOnce(initialArgs, true);
+	if (!enabled) return initialResult;
+	return continueNavigatorLoop(initialResult, [], runOnce);
+}
+
+async function continueNavigatorLoop(
+	result: FallowNavigatorResult | null | undefined,
+	returnStack: FallowNavigatorReturnTarget[],
+	runOnce: FallowNavigatorRunOnce,
+): Promise<FallowNavigatorResult | null | undefined> {
+	if (isActionResult(result)) return runAction(result, returnStack, runOnce);
+	if (isPromptResult(result)) return result;
+	return returnToPreviousNavigator(result, returnStack, runOnce);
+}
+
+async function runAction(
+	result: Extract<FallowNavigatorResult, { type: "action" }>,
+	returnStack: FallowNavigatorReturnTarget[],
+	runOnce: FallowNavigatorRunOnce,
+): Promise<FallowNavigatorResult | null | undefined> {
+	const actionResult = await runOnce(result.commandArgs, false);
+	return continueNavigatorLoop(actionResult, [...returnStack, result.returnTo], runOnce);
+}
+
+async function returnToPreviousNavigator(
+	result: null | undefined,
+	returnStack: FallowNavigatorReturnTarget[],
+	runOnce: FallowNavigatorRunOnce,
+): Promise<FallowNavigatorResult | null | undefined> {
+	const returnTo = returnStack.at(-1);
+	if (!returnTo) return result;
+	const restored = await runOnce(returnTo.commandArgs, false, returnTo.state);
+	return continueNavigatorLoop(restored, returnStack.slice(0, -1), runOnce);
+}
+
+function isActionResult(
+	result: FallowNavigatorResult | null | undefined,
+): result is Extract<FallowNavigatorResult, { type: "action" }> {
+	return result?.type === "action";
+}
+
+function isPromptResult(
+	result: FallowNavigatorResult | null | undefined,
+): result is Extract<FallowNavigatorResult, { type: "prompt" }> {
+	return result?.type === "prompt";
+}

--- a/extensions/fallow/command/result-flow.ts
+++ b/extensions/fallow/command/result-flow.ts
@@ -2,7 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { formatFallowProjectStateText } from "../project/text";
 import { formatFallowPrSummaryText } from "../pr-summary/text";
 import { commandDisplay, fallowExitLabel } from "../tool-render";
-import type { FallowNavigatorResult, FallowPrSummary, FallowProjectState } from "../types";
+import type { FallowNavigatorResult, FallowNavigatorState, FallowPrSummary, FallowProjectState } from "../types";
 import { FallowIssueNavigator } from "../ui";
 import { fallowProjectIssues } from "./issues";
 import { buildFallowExecutor, buildFallowFinalArgs, runFallowWithLoaderIfUi, type FallowCommandExecutor, type FallowCommandResult } from "./loader";
@@ -17,13 +17,14 @@ export async function executeFallowResult(
 	rawCommandArgs: string[],
 	rememberLast: boolean,
 	setLastFallowArgs: (args: string[] | null) => void,
+	initialNavigatorState?: FallowNavigatorState,
 ): Promise<FallowNavigatorResult | null | undefined> {
 	if (rawCommandArgs[0] === "issues") {
-		return executeFallowProjectIssuesResult(pi, ctx, rawCommandArgs, rememberLast, setLastFallowArgs);
+		return executeFallowProjectIssuesResult(pi, ctx, rawCommandArgs, rememberLast, setLastFallowArgs, initialNavigatorState);
 	}
 	const finalArgs = buildFallowFinalArgs(rawCommandArgs);
 	if (rememberLast) setLastFallowArgs([...finalArgs]);
-	return runFallowResultFlow(pi, ctx, finalArgs, buildFallowExecutor(pi, ctx, finalArgs));
+	return runFallowResultFlow(pi, ctx, finalArgs, buildFallowExecutor(pi, ctx, finalArgs), initialNavigatorState);
 }
 
 function executeFallowProjectIssuesResult(
@@ -32,9 +33,16 @@ function executeFallowProjectIssuesResult(
 	commandArgs: string[],
 	rememberLast: boolean,
 	setLastFallowArgs: (args: string[] | null) => void,
+	initialNavigatorState?: FallowNavigatorState,
 ): Promise<FallowNavigatorResult | null | undefined> {
 	if (rememberLast) setLastFallowArgs([...commandArgs]);
-	return runFallowResultFlow(pi, ctx, commandArgs, fallowProjectIssues.buildExecutor(pi, ctx, commandArgs));
+	return runFallowResultFlow(
+		pi,
+		ctx,
+		commandArgs,
+		fallowProjectIssues.buildExecutor(pi, ctx, commandArgs),
+		initialNavigatorState,
+	);
 }
 
 async function runFallowResultFlow(
@@ -42,6 +50,7 @@ async function runFallowResultFlow(
 	ctx: FallowCommandContext,
 	finalArgs: string[],
 	executeCommand: FallowCommandExecutor,
+	initialNavigatorState?: FallowNavigatorState,
 ): Promise<FallowNavigatorResult | null | undefined> {
 	const commandResult = await runFallowWithLoaderIfUi(ctx, executeCommand, finalArgs);
 	if (!commandResult) return handleMissingFallowResult(ctx);
@@ -50,7 +59,16 @@ async function runFallowResultFlow(
 	const resultPrefix = buildFallowResultPrefix(projectState, prSummary);
 	notifyFallowCompletion(ctx, execution, binary, executedArgs);
 	renderFallowResultMessage(pi, ctx, commandResult, resultPrefix);
-	return openFallowNavigator(ctx, commandResult, binary, executedArgs, projectState, prSummary);
+	return openFallowNavigator(
+		ctx,
+		commandResult,
+		binary,
+		executedArgs,
+		finalArgs,
+		projectState,
+		prSummary,
+		initialNavigatorState,
+	);
 }
 
 function handleMissingFallowResult(ctx: FallowCommandContext): null {
@@ -109,8 +127,10 @@ function openFallowNavigator(
 	result: FallowCommandResult,
 	binary: string,
 	executedArgs: string[],
+	originCommandArgs: string[],
 	projectState: FallowProjectState,
 	prSummary: FallowPrSummary | undefined,
+	initialState?: FallowNavigatorState,
 ): Promise<FallowNavigatorResult | null> {
 	const { formatted } = result;
 	if (!isFallowTuiMode(ctx.mode) || !formatted.overview) return Promise.resolve(null);
@@ -125,6 +145,8 @@ function openFallowNavigator(
 			() => tui.requestRender(),
 			{
 				command: commandDisplay(binary, executedArgs),
+				commandArgs: [...originCommandArgs],
+				initialState,
 				fullOutputPath: formatted.fullOutputPath,
 				truncated: formatted.truncated,
 				projectState,
@@ -133,7 +155,6 @@ function openFallowNavigator(
 				informationalMode,
 			},
 		);
-		return navigator;
 	}, {
 		overlay: true,
 		overlayOptions: FALLOW_NAVIGATOR_OVERLAY_OPTIONS,

--- a/extensions/fallow/navigator-actions.ts
+++ b/extensions/fallow/navigator-actions.ts
@@ -1,0 +1,218 @@
+import { isAbsolute } from "node:path";
+import { asRecord } from "./data";
+import type { NormalizedFallowEntry } from "./normalized-report";
+
+export type FallowNavigatorActionKind = "read-only" | "preview";
+
+export interface FallowNavigatorAction {
+	id: string;
+	label: string;
+	description: string;
+	commandArgs: string[];
+	kind: FallowNavigatorActionKind;
+}
+
+const EXPORT_TYPES = new Set(["unused-export", "unused-type", "duplicate-export", "invalid-client-export"]);
+const DEPENDENCY_TYPES = new Set([
+	"unused-dependency", "unused-dev-dependency", "unused-optional-dependency", "unlisted-dependency",
+	"type-only-dependency", "test-only-dependency", "dev-dependency-in-production",
+]);
+const NON_EXPLAINABLE_TYPES = new Set(["complexity", "finding", "security", "target"]);
+const SYMBOL_PATH = /\.[cm]?[jt]sx?$/iu;
+const SYMBOL_NAME = /^[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)?$/u;
+const PACKAGE_NAME = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/iu;
+const ISSUE_TYPE = /^(?:fallow\/)?[a-z][a-z0-9-]*$/u;
+
+export function buildFallowNavigatorActions(entry: NormalizedFallowEntry): FallowNavigatorAction[] {
+	if (entry.role !== "finding") return [];
+	const raw = rawFinding(entry.raw);
+	const path = safeReportPath(entry.path);
+	const type = safeIssueType(entry.type);
+	const symbol = symbolForType(type, raw, entry.subject);
+	const packageName = packageForType(type, raw, entry.subject);
+	return deduplicateActions([
+		...inspectFileActions(path),
+		...symbolActions(path, symbol),
+		...symbolImpactActions(path, symbol),
+		...fileTraceActions(path, type),
+		...dependencyTraceActions(packageName),
+		...cloneTraceActions(path, raw, entry),
+		...explainActions(type),
+		...architectureActions(path),
+		...fixPreviewActions(raw),
+	]);
+}
+
+function inspectFileActions(path: string | undefined): FallowNavigatorAction[] {
+	if (!path) return [];
+	return [action("inspect-file", "Inspect file", `Inspect ${path} as a bundled read-only evidence query.`, ["inspect", "--file", path])];
+}
+
+function symbolActions(path: string | undefined, symbol: string | undefined): FallowNavigatorAction[] {
+	if (!path) return [];
+	if (!symbol) return [];
+	const target = `${path}:${symbol}`;
+	return [
+		action("inspect-symbol", "Inspect symbol", `Inspect exported symbol ${target}.`, ["inspect", "--symbol", target]),
+		action("trace-export", "Trace export", `Trace why ${target} is considered used or unused.`, ["dead-code", "--trace", target]),
+	];
+}
+
+function symbolImpactActions(path: string | undefined, symbol: string | undefined): FallowNavigatorAction[] {
+	if (!path || !SYMBOL_PATH.test(path)) return [];
+	if (!symbol) return [];
+	const target = `${path}:${symbol}`;
+	return [action("symbol-impact", "Analyze symbol impact", `Find exact TypeScript consumers and affected tests for ${target}.`, [
+		"dead-code", "--type-aware", "--symbol-impact", target,
+	])];
+}
+
+function fileTraceActions(path: string | undefined, type: string | undefined): FallowNavigatorAction[] {
+	if (!path || type !== "unused-file") return [];
+	return [action("trace-file", "Trace file", `Trace why ${path} is considered used or unused.`, ["dead-code", "--trace-file", path])];
+}
+
+function dependencyTraceActions(packageName: string | undefined): FallowNavigatorAction[] {
+	if (!packageName) return [];
+	return [action("trace-dependency", "Trace dependency", `Trace package evidence for ${packageName}.`, [
+		"dead-code", "--trace-dependency", packageName,
+	])];
+}
+
+function cloneTraceActions(
+	path: string | undefined,
+	raw: Record<string, any>,
+	entry: NormalizedFallowEntry,
+): FallowNavigatorAction[] {
+	if (!path || !cloneCandidate(raw, entry)) return [];
+	return [action("trace-clone", "Trace clone", `Trace the clone containing ${path}:${entry.line}.`, [
+		"dupes", "--trace", `${path}:${entry.line}`,
+	])];
+}
+
+function explainActions(type: string | undefined): FallowNavigatorAction[] {
+	if (!type || NON_EXPLAINABLE_TYPES.has(type)) return [];
+	return [action("explain", "Explain finding type", `Explain Fallow's ${type} rule and interpretation.`, ["explain", type])];
+}
+
+function architectureActions(path: string | undefined): FallowNavigatorAction[] {
+	if (!path) return [];
+	return [action("architecture", "Check architecture rules", `Show architecture rules that apply to ${path}.`, ["guard", path])];
+}
+
+function fixPreviewActions(raw: Record<string, any>): FallowNavigatorAction[] {
+	if (!hasPreviewableFix(raw)) return [];
+	return [action(
+		"fix-preview",
+		"Preview safe fixes",
+		"Run Fallow's project-wide dry-run only; no fix is applied and config creation is disabled.",
+		["fix", "--dry-run", "--no-create-config"],
+		"preview",
+	)];
+}
+
+function action(
+	id: string,
+	label: string,
+	description: string,
+	commandArgs: string[],
+	kind: FallowNavigatorActionKind = "read-only",
+): FallowNavigatorAction {
+	return { id, label, description, commandArgs, kind };
+}
+
+function rawFinding(value: unknown): Record<string, any> {
+	const raw = asRecord(value) ?? {};
+	return asRecord(raw.candidate) ?? raw;
+}
+
+function symbolForType(type: string | undefined, raw: Record<string, any>, subject: string): string | undefined {
+	if (!type || !EXPORT_TYPES.has(type)) return undefined;
+	return safeSymbol(symbolName(raw, subject));
+}
+
+function packageForType(type: string | undefined, raw: Record<string, any>, subject: string): string | undefined {
+	if (!type || !DEPENDENCY_TYPES.has(type)) return undefined;
+	return safePackageName(raw.package_name ?? subject);
+}
+
+function symbolName(raw: Record<string, any>, subject: string): unknown {
+	const className = safeScalar(raw.class_name);
+	const memberName = safeScalar(raw.member_name);
+	if (className && memberName) return `${className}.${memberName}`;
+	return firstScalar([raw.export_name, raw.name, subject]);
+}
+
+function firstScalar(values: unknown[]): string | undefined {
+	for (const value of values) {
+		const scalar = safeScalar(value);
+		if (scalar) return scalar;
+	}
+	return undefined;
+}
+
+function safeReportPath(value: unknown): string | undefined {
+	const path = safeScalar(value);
+	if (!path) return undefined;
+	return isUnsafePath(path) ? undefined : path;
+}
+
+function isUnsafePath(path: string): boolean {
+	if (isAbsolute(path) || /^[A-Za-z]:[\\/]/u.test(path)) return true;
+	return path.split(/[\\/]/u).includes("..");
+}
+
+function safeIssueType(value: unknown): string | undefined {
+	const type = safeScalar(value)?.toLocaleLowerCase().replaceAll("_", "-");
+	return type && ISSUE_TYPE.test(type) ? type : undefined;
+}
+
+function safeSymbol(value: unknown): string | undefined {
+	const symbol = safeScalar(value);
+	return symbol && SYMBOL_NAME.test(symbol) ? symbol : undefined;
+}
+
+function safePackageName(value: unknown): string | undefined {
+	const packageName = safeScalar(value);
+	return packageName && PACKAGE_NAME.test(packageName) ? packageName : undefined;
+}
+
+function safeScalar(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	return validScalar(value.trim());
+}
+
+function validScalar(value: string): string | undefined {
+	if (!value || value.startsWith("-")) return undefined;
+	return /[\0\r\n]/u.test(value) ? undefined : value;
+}
+
+function cloneCandidate(raw: Record<string, any>, entry: NormalizedFallowEntry): boolean {
+	if (!validSourceLine(entry.line)) return false;
+	return hasCloneIdentity(raw, entry);
+}
+
+function validSourceLine(line: number | undefined): boolean {
+	return Number.isInteger(line) && (line ?? 0) > 0;
+}
+
+function hasCloneIdentity(raw: Record<string, any>, entry: NormalizedFallowEntry): boolean {
+	return Array.isArray(raw.instances) || entry.section === "Clone groups" || entry.type === "clone-group";
+}
+
+function hasPreviewableFix(raw: Record<string, any>): boolean {
+	const actions = Array.isArray(raw.actions) ? raw.actions : [];
+	return actions.some((entry) => asRecord(entry)?.auto_fixable === true);
+}
+
+function deduplicateActions(actions: FallowNavigatorAction[]): FallowNavigatorAction[] {
+	const seen = new Set<string>();
+	return actions.filter((entry) => retainNewAction(entry, seen));
+}
+
+function retainNewAction(action: FallowNavigatorAction, seen: Set<string>): boolean {
+	const key = action.commandArgs.join("\0");
+	if (seen.has(key)) return false;
+	seen.add(key);
+	return true;
+}

--- a/extensions/fallow/types.ts
+++ b/extensions/fallow/types.ts
@@ -70,6 +70,23 @@ export interface FallowOverview {
 	notes: string[];
 }
 
+export interface FallowNavigatorState {
+	selectedReportIndex?: number;
+	scrollStart: number;
+	expandedReportIndices: number[];
+	markedReportIndices: number[];
+	query: string;
+	sectionFilter?: number;
+	severityFilter?: string;
+	showInformational: boolean;
+	includeFullDetails: boolean;
+}
+
+export interface FallowNavigatorReturnTarget {
+	commandArgs: string[];
+	state: FallowNavigatorState;
+}
+
 export type FallowNavigatorResult =
 	| { type: "prompt"; prompt: string; issueCount: number; detail: "compact" | "full" }
-	| { type: "trace"; commandArgs: string[] };
+	| { type: "action"; label: string; commandArgs: string[]; returnTo: FallowNavigatorReturnTarget };

--- a/extensions/fallow/ui/navigator.ts
+++ b/extensions/fallow/ui/navigator.ts
@@ -1,11 +1,18 @@
 import { readFile } from "node:fs/promises";
-import { CURSOR_MARKER, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi, type Component, type Focusable } from "@earendil-works/pi-tui";
+import {
+	CURSOR_MARKER, matchesKey, SelectList, truncateToWidth, visibleWidth, wrapTextWithAnsi,
+	type Component, type Focusable, type SelectItem,
+} from "@earendil-works/pi-tui";
+import { buildFallowNavigatorActions, type FallowNavigatorAction } from "../navigator-actions";
 import { allNormalizedFallowEntries, getNormalizedFallowReport, hydrateNormalizedFallowEntry, type NormalizedFallowEntry } from "../normalized-report";
 import { buildFallowOverview } from "../overview";
 import { buildFallowPrompt, type FallowPromptDetail, type FallowPromptFinding } from "../prompt";
 import { renderFallowProjectState } from "../project/render";
 import { renderFallowPrSummary } from "../pr-summary/render";
-import type { FallowIssueLine, FallowNavigatorResult, FallowOverview, FallowOverviewSection, FallowPrSummary, FallowProjectState } from "../types";
+import type {
+	FallowIssueLine, FallowNavigatorResult, FallowNavigatorState, FallowOverview, FallowOverviewSection,
+	FallowPrSummary, FallowProjectState,
+} from "../types";
 import { amber, cyan, getOverviewStatusColor, pill, pink, purple, violet } from "./shared";
 
 const FRAME_BORDER_WIDTH = 4;
@@ -52,6 +59,8 @@ function buildInformationHeader(text: string | undefined, theme: any): string {
 
 interface FallowNavigatorOptions {
 	command?: string;
+	commandArgs?: string[];
+	initialState?: FallowNavigatorState;
 	fullOutputPath?: string;
 	truncated?: boolean;
 	projectState?: FallowProjectState;
@@ -83,6 +92,8 @@ export class FallowIssueNavigator implements Component, Focusable {
 	private showInformational = false;
 	private includeFullDetails = false;
 	private preparingPrompt = false;
+	private actionPalette?: { list: SelectList };
+	private actionNotice?: string;
 	private cachedWidth?: number;
 	private cachedLines?: string[];
 
@@ -95,6 +106,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	) {
 		this.showInformational = options.informationalMode === true;
 		this.issues = flattenNormalizedIssues(overview);
+		this.restoreState(options.initialState);
 	}
 
 	handleInput(data: string): void {
@@ -114,6 +126,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 			{ matches: (value) => value === "c", action: () => this.clearMarked() },
 			{ matches: (value) => value === "i", action: () => this.toggleInformational() },
 			{ matches: (value) => value === "d", action: () => this.togglePromptDetail() },
+			{ matches: (value) => value === "p", action: () => this.openActionPalette() },
 			{ matches: (value) => value === "e" || value === "a", action: () => this.finishWithPrompt() },
 			{ matches: (value) => value === "t", action: () => this.finishWithTrace() },
 			{ matches: (value) => matchesKey(value, "enter") || matchesKey(value, "space") || matchesKey(value, "right") || value === "l", action: () => this.toggleExpanded() },
@@ -128,8 +141,17 @@ export class FallowIssueNavigator implements Component, Focusable {
 
 	private routeModalInput(data: string): boolean {
 		if (this.preparingPrompt) return true;
+		if (this.routeActionPaletteInput(data)) return true;
 		if (!this.editingSearch) return false;
 		this.handleSearchInput(data);
+		return true;
+	}
+
+	private routeActionPaletteInput(data: string): boolean {
+		const palette = this.actionPalette;
+		if (!palette) return false;
+		palette.list.handleInput(data);
+		if (this.actionPalette === palette) this.changed();
 		return true;
 	}
 
@@ -150,6 +172,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 	invalidate(): void {
 		this.cachedWidth = undefined;
 		this.cachedLines = undefined;
+		this.actionPalette?.list.invalidate();
 	}
 
 	private handleSearchInput(data: string): void {
@@ -265,12 +288,22 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private renderBody(frameWidth: number, innerWidth: number, visible: FlatIssue[], lines: string[]): void {
+		if (this.actionPalette) {
+			this.renderActionPaletteBody(frameWidth, innerWidth, lines);
+			return;
+		}
 		const empty = this.emptyBodyMessage(visible);
 		if (empty) {
 			lines.push(this.frame(this.theme.fg(empty.tone, empty.text), frameWidth));
 			return;
 		}
 		this.renderIssues(frameWidth, innerWidth, visible, lines);
+	}
+
+	private renderActionPaletteBody(frameWidth: number, innerWidth: number, lines: string[]): void {
+		const subject = this.currentIssue()?.normalized.subject ?? "current finding";
+		lines.push(this.frame(`${violet("●")} ${this.theme.fg("accent", this.theme.bold(`Actions for ${subject}`))}`, frameWidth));
+		for (const line of this.actionPalette!.list.render(innerWidth)) lines.push(this.frame(line, frameWidth));
 	}
 
 	private emptyBodyMessage(visible: FlatIssue[]): { text: string; tone: "success" | "warning" } | undefined {
@@ -324,6 +357,15 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private renderFooterControls(frameWidth: number, innerWidth: number, lines: string[]): void {
+		if (this.actionPalette) {
+			this.appendWrappedFooter(
+				this.theme.fg("muted", "Actions are read-only except the explicitly labelled dry-run preview; fix application is never available here."),
+				frameWidth,
+				innerWidth,
+				lines,
+			);
+			return;
+		}
 		if (this.isInformationalMode()) {
 			this.appendWrappedFooter(this.informationalImplicationLine(), frameWidth, innerWidth, lines);
 			return;
@@ -345,7 +387,8 @@ export class FallowIssueNavigator implements Component, Focusable {
 	}
 
 	private footerSelectionLine(): string {
-		return `${pill(this.selectionStatus(), purple)} ${this.theme.fg("muted", "e/a loads prompt into editor for your comments")}`;
+		const notice = this.actionNotice ? ` ${this.theme.fg("warning", this.actionNotice)}` : "";
+		return `${pill(this.selectionStatus(), purple)} ${this.theme.fg("muted", "e/a loads prompt; p opens safe actions")}${notice}`;
 	}
 
 	private selectionStatus(): string {
@@ -403,6 +446,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 
 	private select(index: number): void {
 		this.selected = clampSelection(index, this.visibleIssues().length);
+		this.actionNotice = undefined;
 		this.changed();
 	}
 
@@ -468,6 +512,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 		this.selected = 0;
 		this.scrollStart = 0;
 		this.expanded.clear();
+		this.actionNotice = undefined;
 		this.changed();
 	}
 
@@ -543,6 +588,43 @@ export class FallowIssueNavigator implements Component, Focusable {
 		this.changed();
 	}
 
+	private openActionPalette(): void {
+		if (this.isInformationalMode()) return;
+		const current = this.currentIssue();
+		if (!current) return;
+		const actions = buildFallowNavigatorActions(current.normalized);
+		if (!actions.length) {
+			this.actionNotice = "No safe Fallow action is available for this finding.";
+			this.changed();
+			return;
+		}
+		const items: SelectItem[] = actions.map((entry) => ({
+			value: entry.id,
+			label: entry.kind === "preview" ? `${entry.label} (dry-run)` : entry.label,
+			description: entry.description,
+		}));
+		const list = new SelectList(items, Math.min(items.length, 10), {
+			selectedPrefix: (text) => this.theme.fg("accent", text),
+			selectedText: (text) => this.theme.fg("accent", text),
+			description: (text) => this.theme.fg("muted", text),
+			scrollInfo: (text) => this.theme.fg("dim", text),
+			noMatch: (text) => this.theme.fg("warning", text),
+		});
+		list.onSelect = (item) => {
+			const selected = actions.find((entry) => entry.id === item.value);
+			if (!selected) return;
+			this.actionPalette = undefined;
+			this.finishWithAction(selected);
+		};
+		list.onCancel = () => {
+			this.actionPalette = undefined;
+			this.changed();
+		};
+		this.actionNotice = undefined;
+		this.actionPalette = { list };
+		this.changed();
+	}
+
 	private promptDetail(): FallowPromptDetail {
 		return this.includeFullDetails ? "full" : "compact";
 	}
@@ -611,28 +693,57 @@ export class FallowIssueNavigator implements Component, Focusable {
 
 	private finishWithTrace(): void {
 		if (this.isInformationalMode()) return;
-		const trace = this.currentTraceCandidate();
-		if (!trace) return;
-		this.onDone({ type: "trace", commandArgs: ["dead-code", "--trace-file", trace] });
+		const current = this.currentIssue();
+		if (!current) return;
+		const trace = buildFallowNavigatorActions(current.normalized).find((entry) => entry.id.startsWith("trace-"));
+		if (trace) this.finishWithAction(trace);
 	}
 
-	private currentTraceCandidate(): string | null {
-		const selected = this.currentIssue();
-		if (!selected) return null;
-		const path = selected.item.path ? this.stripTraceSuffix(selected.item.path) : this.pathFromAction(selected.item.action);
-		return path ?? null;
+	private finishWithAction(action: FallowNavigatorAction): void {
+		if (!this.options.commandArgs?.length) {
+			this.actionPalette = undefined;
+			this.actionNotice = "The originating command is unavailable; rerun /fallow before using actions.";
+			this.changed();
+			return;
+		}
+		this.onDone({
+			type: "action",
+			label: action.label,
+			commandArgs: [...action.commandArgs],
+			returnTo: {
+				commandArgs: [...this.options.commandArgs],
+				state: this.snapshotState(),
+			},
+		});
 	}
 
-	private pathFromAction(action: string | undefined): string | null {
-		if (!action) return null;
-		const pathWithLine = pickPathFromText(action, /(?:^|\s)([^\s"'`]+?\.[A-Za-z0-9_./+-]+:\d+)(?:\s|$)/);
-		if (pathWithLine) return this.stripTraceSuffix(pathWithLine);
-		const barePath = pickPathFromText(action, /(?:^|\s)([^\s"'`]+?\.[A-Za-z0-9_./+-]+)(?:\s|$)/);
-		return barePath ? this.stripTraceSuffix(barePath) : null;
+	private snapshotState(): FallowNavigatorState {
+		return {
+			selectedReportIndex: this.currentIssue()?.id,
+			scrollStart: this.scrollStart,
+			expandedReportIndices: [...this.expanded],
+			markedReportIndices: [...this.marked],
+			query: this.query,
+			sectionFilter: this.sectionFilter,
+			severityFilter: this.severityFilter,
+			showInformational: this.showInformational,
+			includeFullDetails: this.includeFullDetails,
+		};
 	}
 
-	private stripTraceSuffix(path: string): string {
-		return path.replace(/[\]\)>,.;:!?]+$/u, "").replace(/:\d+$/, "");
+	private restoreState(state: FallowNavigatorState | undefined): void {
+		if (!state) return;
+		const validIds = new Set(this.issues.map((entry) => entry.id));
+		this.query = state.query;
+		this.sectionFilter = validSectionFilter(state.sectionFilter, this.overview);
+		this.severityFilter = state.severityFilter;
+		this.showInformational = restoredInformationalVisibility(state.showInformational, this.isInformationalMode());
+		this.includeFullDetails = state.includeFullDetails;
+		this.marked = retainedStateIds(state.markedReportIndices, validIds);
+		this.expanded = retainedStateIds(state.expandedReportIndices, validIds);
+		const visible = this.visibleIssues();
+		this.selected = restoredSelection(state.selectedReportIndex, visible);
+		this.scrollStart = Math.max(0, state.scrollStart);
 	}
 
 	private statLines(width: number): string[] {
@@ -650,6 +761,13 @@ export class FallowIssueNavigator implements Component, Focusable {
 
 	private helpLine(): string {
 		const key = (text: string) => pill(text, violet);
+		if (this.actionPalette) {
+			return [
+				`${key("↑↓")} ${this.theme.fg("muted", "choose action")}`,
+				`${key("enter")} ${this.theme.fg("muted", "run")}`,
+				`${key("esc")} ${this.theme.fg("muted", "back")}`,
+			].join("  ");
+		}
 		const common = [
 			`${key("↑↓/jk")} ${this.theme.fg("muted", "navigate")}`,
 			`${key("/")} ${this.theme.fg("muted", "search")}`,
@@ -667,8 +785,9 @@ export class FallowIssueNavigator implements Component, Focusable {
 			`${key("c")} ${this.theme.fg("muted", "clear selected")}`,
 			`${key("i")} ${this.theme.fg("muted", "informational files")}`,
 			`${key("d")} ${this.theme.fg("muted", "prompt detail")}`,
+			`${key("p")} ${this.theme.fg("muted", "actions")}`,
 			`${key("e/a")} ${this.theme.fg("muted", "load")}`,
-			`${key("t")} ${this.theme.fg("muted", "trace")}`,
+			`${key("t")} ${this.theme.fg("muted", "quick trace")}`,
 			`${key("q")} ${this.theme.fg("muted", "close")}`,
 		].join("  ");
 	}
@@ -802,16 +921,29 @@ function clampSelection(index: number, visibleCount: number): number {
 	return Math.max(0, Math.min(Math.max(0, visibleCount - 1), index));
 }
 
+function validSectionFilter(sectionFilter: number | undefined, overview: FallowOverview): number | undefined {
+	if (sectionFilter === undefined) return undefined;
+	return overview.sections[sectionFilter] ? sectionFilter : undefined;
+}
+
+function restoredInformationalVisibility(showInformational: boolean, informationalMode: boolean): boolean {
+	return showInformational || informationalMode;
+}
+
+function retainedStateIds(ids: number[], validIds: Set<number>): Set<number> {
+	return new Set(ids.filter((id) => validIds.has(id)));
+}
+
+function restoredSelection(reportIndex: number | undefined, visible: FlatIssue[]): number {
+	const selected = visible.findIndex((entry) => entry.id === reportIndex);
+	return clampSelection(Math.max(0, selected), visible.length);
+}
+
 function removeLastCharacter(value: string): string {
 	return [...value].slice(0, -1).join("");
 }
 
 function isPrintableCharacter(value: string): boolean {
 	return [...value].length === 1 && value >= " ";
-}
-
-function pickPathFromText(text: string, pattern: RegExp): string | null {
-	const match = text.match(pattern);
-	return match?.[1] ?? null;
 }
 

--- a/tests/navigator-actions.test.mjs
+++ b/tests/navigator-actions.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { buildFallowNavigatorActions } = await jiti.import("../extensions/fallow/navigator-actions.ts");
+
+function finding(overrides = {}) {
+	return {
+		role: "finding",
+		section: "Findings",
+		type: "future-finding",
+		path: "src/example.ts",
+		line: 7,
+		subject: "example",
+		source: { reportIndex: 0, sectionIndex: 0, itemIndex: 0, sectionTitle: "Findings" },
+		...overrides,
+	};
+}
+
+function byId(entry) {
+	return new Map(buildFallowNavigatorActions(entry).map((action) => [action.id, action]));
+}
+
+describe("Fallow navigator actions", () => {
+	it("derives inspect, trace, impact, explanation, and guard actions for exports", () => {
+		const actions = byId(finding({
+			type: "unused-export",
+			subject: "renderWidget",
+			raw: { kind: "unused-export", export_name: "renderWidget", path: "src/widget.ts" },
+		}));
+
+		assert.deepEqual([...actions.keys()], [
+			"inspect-file", "inspect-symbol", "trace-export", "symbol-impact", "explain", "architecture",
+		]);
+		assert.deepEqual(actions.get("inspect-symbol").commandArgs, ["inspect", "--symbol", "src/example.ts:renderWidget"]);
+		assert.deepEqual(actions.get("trace-export").commandArgs, ["dead-code", "--trace", "src/example.ts:renderWidget"]);
+		assert.deepEqual(actions.get("symbol-impact").commandArgs, [
+			"dead-code", "--type-aware", "--symbol-impact", "src/example.ts:renderWidget",
+		]);
+	});
+
+	it("offers the specialized file, dependency, and clone traces", () => {
+		const fileActions = byId(finding({ type: "unused-file", path: "src/dead.ts", subject: "unused-file" }));
+		assert.deepEqual(fileActions.get("trace-file").commandArgs, ["dead-code", "--trace-file", "src/dead.ts"]);
+
+		const dependencyActions = byId(finding({
+			type: "unused-dependency",
+			path: undefined,
+			subject: "@scope/package",
+			raw: { kind: "unused-dependency", package_name: "@scope/package" },
+		}));
+		assert.deepEqual(dependencyActions.get("trace-dependency").commandArgs, [
+			"dead-code", "--trace-dependency", "@scope/package",
+		]);
+
+		const cloneActions = byId(finding({
+			section: "Clone groups",
+			type: "Clone groups",
+			path: "src/clone.ts",
+			line: 42,
+			raw: { instances: [{ file: "src/clone.ts", start_line: 42 }] },
+		}));
+		assert.deepEqual(cloneActions.get("trace-clone").commandArgs, ["dupes", "--trace", "src/clone.ts:42"]);
+	});
+
+	it("keeps security and unknown future findings conservative", () => {
+		const security = byId(finding({
+			type: "security",
+			path: "src/run.ts",
+			raw: { kind: "security", rule_id: "security/sink", actions: [{ auto_fixable: false }] },
+		}));
+		assert.deepEqual([...security.keys()], ["inspect-file", "architecture"]);
+
+		const future = byId(finding({ type: "future-rule", raw: undefined }));
+		assert.deepEqual([...future.keys()], ["inspect-file", "explain", "architecture"]);
+		assert.equal([...future.values()].some((action) => action.commandArgs.includes("--yes")), false);
+	});
+
+	it("offers only a project-wide dry-run for explicitly previewable fixes", () => {
+		const previewable = byId(finding({
+			type: "unused-export",
+			subject: "helper",
+			raw: { kind: "unused-export", export_name: "helper", actions: [{ type: "remove-export", auto_fixable: true }] },
+		}));
+		assert.deepEqual(previewable.get("fix-preview"), {
+			id: "fix-preview",
+			label: "Preview safe fixes",
+			description: "Run Fallow's project-wide dry-run only; no fix is applied and config creation is disabled.",
+			commandArgs: ["fix", "--dry-run", "--no-create-config"],
+			kind: "preview",
+		});
+		assert.equal([...previewable.values()].some((action) => action.commandArgs.includes("--yes")), false);
+
+		const unverified = byId(finding({ raw: { actions: [{ type: "remove-export", auto_fixable: false }] } }));
+		assert.equal(unverified.has("fix-preview"), false);
+	});
+
+	it("rejects unsafe report-derived targets and informational entries", () => {
+		assert.deepEqual(buildFallowNavigatorActions(finding({
+			path: "../../outside.ts",
+			type: "unused-export",
+			subject: "--help",
+			raw: { export_name: "--help", actions: [{ auto_fixable: false }] },
+		})).map((action) => action.id), ["explain"]);
+		assert.deepEqual(buildFallowNavigatorActions(finding({ role: "context" })), []);
+	});
+});

--- a/tests/navigator-loop.test.mjs
+++ b/tests/navigator-loop.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { runFallowNavigatorLoop } = await jiti.import("../extensions/fallow/command/navigator-loop.ts");
+
+const state = {
+	selectedReportIndex: 4,
+	scrollStart: 2,
+	expandedReportIndices: [4],
+	markedReportIndices: [4, 7],
+	query: "unused",
+	sectionFilter: 1,
+	severityFilter: "high",
+	showInformational: false,
+	includeFullDetails: true,
+};
+
+function actionResult(commandArgs = ["inspect", "--file", "src/a.ts"]) {
+	return {
+		type: "action",
+		label: "Inspect file",
+		commandArgs,
+		returnTo: { commandArgs: ["issues"], state },
+	};
+}
+
+describe("Fallow navigator action loop", () => {
+	it("runs an action and restores the originating navigator after close or cancellation", async () => {
+		const responses = [actionResult(), null, { type: "prompt", prompt: "restored", issueCount: 1, detail: "compact" }];
+		const calls = [];
+		const result = await runFallowNavigatorLoop(["issues"], true, async (args, rememberLast, initialState) => {
+			calls.push({ args, rememberLast, initialState });
+			return responses.shift();
+		});
+
+		assert.equal(result?.type, "prompt");
+		assert.deepEqual(calls, [
+			{ args: ["issues"], rememberLast: true, initialState: undefined },
+			{ args: ["inspect", "--file", "src/a.ts"], rememberLast: false, initialState: undefined },
+			{ args: ["issues"], rememberLast: false, initialState: state },
+		]);
+	});
+
+	it("supports nested read-only actions and unwinds each preserved navigator", async () => {
+		const nestedState = { ...state, selectedReportIndex: 1 };
+		const nested = {
+			type: "action",
+			label: "Check architecture rules",
+			commandArgs: ["guard", "src/a.ts"],
+			returnTo: { commandArgs: ["inspect", "--file", "src/a.ts"], state: nestedState },
+		};
+		const responses = [actionResult(), nested, null, null, null];
+		const calls = [];
+		const result = await runFallowNavigatorLoop(["issues"], true, async (args, rememberLast, initialState) => {
+			calls.push({ args, rememberLast, initialState });
+			return responses.shift();
+		});
+
+		assert.equal(result, null);
+		assert.deepEqual(calls.map((entry) => entry.args), [
+			["issues"],
+			["inspect", "--file", "src/a.ts"],
+			["guard", "src/a.ts"],
+			["inspect", "--file", "src/a.ts"],
+			["issues"],
+		]);
+		assert.equal(calls[3].initialState, nestedState);
+		assert.equal(calls[4].initialState, state);
+	});
+
+	it("does not execute navigator actions outside TUI mode", async () => {
+		const calls = [];
+		const result = await runFallowNavigatorLoop(["issues"], false, async (args, rememberLast) => {
+			calls.push({ args, rememberLast });
+			return actionResult();
+		});
+
+		assert.equal(result?.type, "action");
+		assert.deepEqual(calls, [{ args: ["issues"], rememberLast: true }]);
+	});
+});

--- a/tests/navigator.test.mjs
+++ b/tests/navigator.test.mjs
@@ -410,6 +410,86 @@ describe("FallowIssueNavigator prompt generation", () => {
 		assert.match(rendered, /Include full finding JSON/);
 	});
 
+	it("opens a command-aware action palette and emits shell-free return state", () => {
+		let result = null;
+		const overview = buildFallowOverview({
+			kind: "dead-code",
+			unused_exports: [{
+				kind: "unused-export",
+				export_name: "renderWidget",
+				path: "src/widget.ts",
+				line: 7,
+				actions: [{ type: "remove-export", auto_fixable: false, description: "Remove export." }],
+			}],
+		});
+		const navigator = new FallowIssueNavigator(overview, theme, (value) => {
+			result = value;
+		}, () => {}, { commandArgs: ["dead-code", "--format", "json", "--quiet"] });
+
+		navigator.handleInput("p");
+		const palette = navigator.render(100).join("\n");
+		assert.match(palette, /Actions for renderWidget/);
+		assert.match(palette, /Inspect file/);
+		assert.match(palette, /Trace export/);
+		assert.match(palette, /Analyze symbol impact/);
+		assert.doesNotMatch(palette, /Preview safe fixes/);
+		assert.match(palette, /fix application is never/);
+		assert.match(palette, /available here/);
+		for (const line of navigator.render(60)) assert.ok(visibleWidth(line) <= 60, line);
+		navigator.handleInput("\u001b");
+		assert.match(navigator.render(100).join("\n"), /Include full finding JSON/);
+		assert.equal(result, null);
+		navigator.handleInput("p");
+		navigator.handleInput("\r");
+
+		assert.ok(result);
+		assert.equal(result.type, "action");
+		assert.equal(result.label, "Inspect file");
+		assert.deepEqual(result.commandArgs, ["inspect", "--file", "src/widget.ts"]);
+		assert.deepEqual(result.returnTo.commandArgs, ["dead-code", "--format", "json", "--quiet"]);
+		assert.equal(result.returnTo.state.selectedReportIndex, 0);
+	});
+
+	it("restores filters, selection, marks, expansion, and prompt detail after an action", () => {
+		const overview = createFilterOverview();
+		let actionResult = null;
+		const navigator = new FallowIssueNavigator(overview, theme, (value) => {
+			actionResult = value;
+		}, () => {}, { commandArgs: ["health", "--format", "json", "--quiet"] });
+		navigator.handleInput("j");
+		navigator.handleInput("s");
+		navigator.handleInput("d");
+		navigator.handleInput("/");
+		for (const character of "dead") navigator.handleInput(character);
+		navigator.handleInput("\r");
+		navigator.handleInput("\r");
+		navigator.handleInput("p");
+		navigator.handleInput("\r");
+
+		assert.equal(actionResult?.type, "action");
+		const restored = new FallowIssueNavigator(overview, theme, () => {}, () => {}, {
+			initialState: actionResult.returnTo.state,
+			commandArgs: actionResult.returnTo.commandArgs,
+		});
+		const rendered = restored.render(100).join("\n");
+		assert.match(rendered, /2\/3 findings/);
+		assert.match(rendered, /search: dead/);
+		assert.match(rendered, /1 selected/);
+		assert.match(rendered, /☑ Include full finding JSON/);
+	});
+
+	it("keeps the trace shortcut on the safe action path", () => {
+		let result = null;
+		const navigator = new FallowIssueNavigator(createOverview(), theme, (value) => {
+			result = value;
+		}, () => {}, { commandArgs: ["dead-code"] });
+		navigator.handleInput("j");
+		navigator.handleInput("t");
+
+		assert.equal(result?.type, "action");
+		assert.deepEqual(result?.commandArgs, ["dead-code", "--trace-file", "src/dead.ts"]);
+	});
+
 	it("renders within the width provided by the overlay", () => {
 		const navigator = new FallowIssueNavigator(createOverview(), theme, () => {}, () => {});
 		const width = 60;


### PR DESCRIPTION
## Summary

- add a `p` action palette to the TUI finding navigator using Pi's built-in `SelectList`
- derive only evidence-backed inspect, explain, export/file/dependency/clone trace, symbol-impact, and architecture commands
- pass every report-derived target as a shell-free argument-array element and reject unsafe paths, symbols, and package names
- preserve search, filters, current row, expansion, selections, informational visibility, and prompt-detail mode when returning from action results
- keep the existing `t` shortcut as the first valid trace action
- expose only project-wide `fix --dry-run --no-create-config` when Fallow explicitly marks a retained action auto-fixable; fix application is never available

## Behavior boundaries

- action execution remains TUI-only because RPC, print, and JSON modes never open the navigator
- each action result uses the existing loader, bounded report, transcript, complete-output, and navigator flow
- closing or cancelling an action unwinds to the exact originating command and restored navigator state
- informational entries and unsafe report-derived targets cannot launch actions
- unknown/future finding types receive only generic actions supported by their available safe inputs

## Verification

- 190 tests pass
- coverage: 89.50% statements/lines, 86.66% branches, 87.95% functions
- `npm run check:publish`
- health 84.4 (B), maintainability 91.7, zero threshold findings
- zero dead-code issues or clone groups
- package smoke passes with a 64-file tarball on Pi 0.84.3
- Fallow audit passes; changed-file security gate reports zero new findings
- production and complete-tree npm audits pass; signatures and attestations verify
- token and performance benchmark comparisons complete

Closes #75
