### PR TITLE
test: certify command registry against Fallow schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Pi Fallow are documented here.
 - Added explicit opt-in semantic similar-code analysis across `/fallow` and `fallow_run`, with read-only status/discovery/inspect/review flows, reproducible model and input provenance, advisory source-grounded rendering, partial-phase and skip diagnostics, distinct cancellation/timeout metadata, a cold-run timeout allowance, and hard guards against model downloads or cache mutation.
 
 ### Changed
+- Added frozen capability-schema certification and mutation tests for every tool registry prefix, managed output flags, positional targets, and selected type-aware flags; the live CLI smoke suite shares these checks without adding runtime version constraints.
 - Updated the pinned Fallow compatibility target to 3.21.0 and re-certified the current command/schema, MCP-resource, type-aware, quality, and packaged host surfaces, including the 3.20 strict-exit and project-reference resolution changes plus the 3.21 runtime-coverage and hidden-source diagnostic fixes.
 
 ## [0.5.1] - 2026-08-29

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ What these cover:
 - `npm run health` runs Fallow health checks.
 - `npm run dupes` checks for duplicate code.
 - `npm run dead-code` checks for unused files/exports and stale suppressions.
-- `npm run smoke:fallow` smoke-tests modeled Fallow CLI surfaces.
+- `npm run smoke:fallow` smoke-tests modeled Fallow CLI surfaces and checks every tool registry prefix against the live capability schema. Offline fixture and mutation tests run with `npm test`; see [`tests/fixtures/fallow/README.md`](./tests/fixtures/fallow/README.md) for certification scope and regeneration.
 - `npm run coverage` generates text/lcov reports and enforces gradual all-file thresholds.
 - `npm run audit:production` and `npm run audit:all` check the shipped and complete dependency trees.
 - `npm run package:smoke` packs, installs, and validates the npm tarball in an isolated project.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ This roadmap describes the current baseline and likely next work. It is planning
 
 Unless noted otherwise, these are repository-specific measurements from the `0.5.0` release candidate, not universal expectations for other machines, hosts, Fallow installations, or providers.
 
-- **Tests and coverage:** 206 tests; current coverage is **90.24% statements/lines**, **86.88% branches**, and **88.94% functions**. The `0.5.0` release-candidate snapshot recorded **88.50% statements/lines**, **86.35% branches**, and **85.44% functions**; subprocess-sensitive reruns can vary slightly by run and Node line while CI continues to enforce the coverage thresholds.
+- **Tests and coverage:** 214 tests; current coverage is **90.24% statements/lines**, **86.88% branches**, and **88.94% functions**. The `0.5.0` release-candidate snapshot recorded **88.50% statements/lines**, **86.35% branches**, and **85.44% functions**; subprocess-sensitive reruns can vary slightly by run and Node line while CI continues to enforce the coverage thresholds.
 - **Fallow quality:** Fallow 3.21 reports health **83.4 (B)**, average maintainability **91.6**, and zero threshold findings, dead-code issues, or clone groups.
 - **Dependency audits:** strict production and complete-tree npm audits report zero vulnerabilities. These audit results are separate from Fallow's modeled security-candidate analysis.
 - **Host compatibility:** packaged, provider-free Pi **0.84.3** behavior is certified on Node **22.19** and **24**. Pi host libraries intentionally remain external wildcard peers; this is a tested compatibility matrix, not a restrictive peer range or provider-backed/PTY/tmux certification. See the [README compatibility section](./README.md#tested-compatibility).
@@ -41,7 +41,7 @@ See [`benchmarks/README.md`](./benchmarks/README.md), [`benchmarks/PERFORMANCE.m
 
 ## Remaining priorities
 
-1. **Keep command and report compatibility honest.** Expand representative command/schema fixtures and add useful command-registry-versus-`fallow schema` drift checks while preserving graceful behavior with separately installed Fallow versions.
+1. **Keep command and report compatibility honest.** Frozen capability-schema and live registry-prefix checks now cover managed output, positional targets, and selected type-aware flags (see [`fixture scope`](./tests/fixtures/fallow/README.md)). Expand representative report fixtures and nested-command coverage next; installed-capability diagnostics remain separate work, preserving graceful behavior with separately installed Fallow versions.
 2. **Decide whether user-owned customization is still desired.** If demand remains, design Pi Fallow-specific global/project configuration, prompt templates, and a safe prompt/config preview without taking ownership of Fallow's configuration file.
 3. **Refine navigator workflows from evidence.** Make any remaining history, comparison, or UI density improvements only when real large-report use identifies a concrete need.
 4. **Improve quality where evidence points.** Raise coverage and maintainability gradually around real execution, command-flow, rendering, project-state, and PR-summary hotspots. Do not split files cosmetically merely to improve a metric.
@@ -59,6 +59,6 @@ Future work must preserve these boundaries:
 
 ## Suggested delivery order
 
-1. Add fixture/schema compatibility and registry-drift checks needed to keep release evidence reproducible.
+1. Extend the fixture/schema and registry-drift foundation with representative report and nested-command coverage needed to keep release evidence reproducible.
 2. Confirm demand and scope before implementing user-owned configuration or prompt customization/preview.
 3. Iterate on navigator density, hotspot coverage, maintainability, and dependency compatibility in small independently reviewed changes.

--- a/scripts/fallow-smoke.mjs
+++ b/scripts/fallow-smoke.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { createJiti } from "jiti";
+import { assertRegistrySchema } from "./schema-registry-check.mjs";
 
 const jiti = createJiti(import.meta.url);
 const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
+const { fallowToolCommands, getFallowToolCommandSpec } = await jiti.import("../extensions/fallow/registry.ts");
 
 function assertArgs(params, expected) {
 	assert.deepEqual(fallowCli.buildFallowArgs(params), expected, params.command);
@@ -90,6 +92,7 @@ function assertModeledArgs() {
 }
 
 function assertCurrentFallowSchema(data) {
+	assertRegistrySchema(data, fallowToolCommands.map(getFallowToolCommandSpec));
 	assert.equal(data.name, "fallow");
 	assert.equal(data.version, "3.21.0");
 	assert.equal(data.manifest_version, "1");
@@ -146,6 +149,9 @@ function assertCurrentFallowSchema(data) {
 }
 
 function assertCliSurfaces() {
+	// Manifest v1 omits nested coverage commands; verify this registry prefix
+	// through read-only help instead of pretending schema certifies it.
+	assert.match(runFallow(["coverage", "analyze", "--help"]), /Usage: fallow coverage analyze\b/);
 	assertFallowJson([], (data) => {
 		assert.equal(data.kind, "combined");
 		assert.equal(data.schema_version, 11);

--- a/scripts/schema-registry-check.mjs
+++ b/scripts/schema-registry-check.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+
+function requireFlag(flags, name, type, context) {
+	const flag = flags.find((entry) => entry.name === name || entry.short === name);
+	assert.ok(flag, `${context}: schema is missing ${name}`);
+	assert.equal(flag.type, type, `${context}: ${name} must remain ${type}`);
+	return flag;
+}
+
+// Development certification only: this does not run during extension loading or
+// constrain the version of a separately installed Fallow executable.
+export function assertRegistrySchema(schema, specs) {
+	assert.equal(schema.name, "fallow");
+	assert.equal(schema.manifest_version, "1", "Review the changed capability manifest format");
+	assert.ok(Array.isArray(schema.commands), "schema.commands must be an array");
+	assert.ok(Array.isArray(schema.global_flags), "schema.global_flags must be an array");
+	assert.ok(schema.output_formats?.includes("json"), "schema must support JSON output");
+	const commands = new Map(schema.commands.map((command) => [command.name, command]));
+	assert.equal(commands.size, schema.commands.length, "schema contains duplicate command names");
+
+	for (const spec of specs) assertCommandSchema(schema, commands, spec);
+}
+
+function resolveCommand(schema, commands, root, context) {
+	if (!root) {
+		assert.equal(schema.default_command, null, `${context}: review changed default command`);
+		return { flags: [] };
+	}
+	const command = commands.get(root);
+	assert.ok(command, `${context}: schema is missing command ${root}`);
+	assert.ok(Array.isArray(command.flags), `${context}: command flags must be an array`);
+	return command;
+}
+
+function assertCommandSchema(schema, commands, spec) {
+	const [root, ...suffix] = spec.cliPrefix;
+	const context = `${spec.name} -> ${root ?? "(default)"}`;
+	const command = resolveCommand(schema, commands, root, context);
+	// Local definitions take precedence, so an incompatible shadow of a
+	// managed global flag cannot silently pass this check.
+	const flags = [...command.flags, ...schema.global_flags];
+	assertManagedOutput(flags, context);
+	assertPrefix(suffix, flags, spec, context);
+	assertTarget(command, suffix, spec, context);
+	assertPositionalFlags(flags, spec, context);
+	if (spec.name === "check-changed") requireFlag(flags, "--changed-since", "string", context);
+	if (["dead-code", "health"].includes(spec.name)) assertTypeAwareFlags(flags, spec.name, context);
+}
+
+function assertManagedOutput(flags, context) {
+	const format = requireFlag(flags, "--format", "string", context);
+	assert.ok(format.possible_values?.includes("json"), `${context}: --format must accept json`);
+	requireFlag(flags, "--quiet", "bool", context);
+}
+
+function assertPrefix(suffix, flags, spec, context) {
+	for (const [index, token] of suffix.entries()) {
+		const takesTarget = spec.positionalTarget && index === suffix.length - 1;
+		assertPrefixToken(token, flags, takesTarget, spec, context);
+	}
+}
+
+function assertPrefixToken(token, flags, takesTarget, spec, context) {
+	if (!token.startsWith("-")) {
+		// Manifest v1 lists coverage but omits its nested commands. Keep this
+		// sole exception explicit; smoke:fallow separately checks analyze help.
+		assert.deepEqual(spec.cliPrefix, ["coverage", "analyze"], `${context}: unverified nested CLI prefix`);
+		return;
+	}
+	requireFlag(flags, token, takesTarget ? "string" : "bool", context);
+}
+
+function assertTarget(command, suffix, spec, context) {
+	if (!spec.positionalTarget || suffix.at(-1)?.startsWith("-")) return;
+	const positionals = command.flags.filter((flag) => !flag.name.startsWith("-"));
+	assert.equal(positionals.length, 1, `${context}: expected one positional target`);
+	assert.equal(positionals[0].type, "string", `${context}: positional target must remain string`);
+	assert.equal(positionals[0].required, true, `${context}: review changed positional target requirement`);
+}
+
+function assertPositionalFlags(flags, spec, context) {
+	for (const flag of spec.positionalFlags ?? []) {
+		// Clap's built-in help flags are not advertised in manifest v1.
+		if (["--help", "-h"].includes(flag)) continue;
+		requireFlag(flags, flag, "bool", context);
+	}
+}
+
+function assertTypeAwareFlags(flags, name, context) {
+	for (const [flag, type] of [
+		["--type-aware", "bool"], ["--no-type-aware", "bool"],
+		["--type-aware-project", "string"], ["--type-aware-require", "string"],
+		["--baseline-mode", "string"],
+		[name === "dead-code" ? "--symbol-impact" : "--type-coupling", name === "dead-code" ? "string" : "bool"],
+	]) requireFlag(flags, flag, type, context);
+}

--- a/tests/fixtures/fallow/README.md
+++ b/tests/fixtures/fallow/README.md
@@ -1,0 +1,56 @@
+# Fallow capability certification fixture
+
+`schema-3.21.0.json` is a deterministic projection of the repository-pinned
+Fallow 3.21.0 `schema --format json --quiet` output. It retains command names,
+global/local flag names, short aliases, types, requiredness, allowed values,
+output formats, and manifest/default-command identity. Descriptions and unrelated
+resources are intentionally omitted; this is not a complete capability manifest
+or a report-schema fixture.
+
+The original single-line stdout has SHA-256
+`ca397e67666058ccb74068811576baef6bdfbeb80579589d093242b7e1e6ec53`.
+
+## Regeneration
+
+From the repository root, after installing the pinned development dependencies:
+
+```sh
+./node_modules/.bin/fallow schema --format json --quiet > /tmp/pi-fallow-certified-schema.json
+node --input-type=module <<'NODE'
+import fs from "node:fs";
+const schema = JSON.parse(fs.readFileSync("/tmp/pi-fallow-certified-schema.json", "utf8"));
+const flag = ({name, short, type, required, possible_values}) => ({name, short, type, required, possible_values});
+const {name, version, manifest_version, default_command, output_formats} = schema;
+const fixture = {
+  name, version, manifest_version, default_command, output_formats,
+  global_flags: schema.global_flags.map(flag),
+  commands: schema.commands.map(({name, flags}) => ({name, flags: flags.map(flag)})),
+};
+fs.writeFileSync(`tests/fixtures/fallow/schema-${version}.json`, JSON.stringify(fixture, null, 2) + "\n");
+NODE
+```
+
+Review the diff and update the test fixture reference and source hash deliberately
+when changing the certified target. Tests require the fixture version to match
+`package.json`'s pinned Fallow development dependency.
+
+## Scope and limits
+
+`tests/schema-registry-check.test.mjs` checks every tool registry entry against this
+fixture, with mutation tests for missing commands, fixed flags, target metadata,
+managed JSON output, architecture's boolean-flag scanner, and selected type-aware
+flags. `npm run smoke:fallow` runs the same checks against the actual CLI schema
+alongside the existing report, issue-type, resource, and version assertions.
+
+Manifest v1 does **not** describe nested `coverage analyze` or built-in help flags.
+The checker explicitly exempts only the known nested prefix and help flags;
+the live smoke check separately verifies `coverage analyze --help`. This does
+not certify the nested command's full argument or output contract.
+
+Extra commands, optional flags, issue types, and output formats do not fail the
+registry check. This is scoped development certification, not a general semantic
+compatibility detector: it does not validate arbitrary forwarded flags, all
+allowed values, new required arguments, all slash-only flows, or report layouts.
+No schema probing or version gate is added to startup, autocomplete, or runtime
+execution. Independently installed older/newer Fallow versions remain usable;
+user-facing installed-capability diagnostics remain separate work (#77).

--- a/tests/fixtures/fallow/schema-3.21.0.json
+++ b/tests/fixtures/fallow/schema-3.21.0.json
@@ -1,0 +1,1863 @@
+{
+  "name": "fallow",
+  "version": "3.21.0",
+  "manifest_version": "1",
+  "default_command": null,
+  "output_formats": [
+    "human",
+    "json",
+    "sarif",
+    "compact",
+    "markdown",
+    "md",
+    "codeclimate",
+    "gitlab-codequality",
+    "gitlab-code-quality",
+    "pr-comment-github",
+    "pr-comment-gitlab",
+    "review-github",
+    "review-gitlab",
+    "badge",
+    "github-annotations",
+    "github-summary"
+  ],
+  "global_flags": [
+    {
+      "name": "--root",
+      "short": "-r",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--config",
+      "short": "-c",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--allow-remote-extends",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--format",
+      "short": "-f",
+      "type": "string",
+      "required": false,
+      "possible_values": [
+        "human",
+        "json",
+        "sarif",
+        "compact",
+        "markdown",
+        "codeclimate",
+        "pr-comment-github",
+        "pr-comment-gitlab",
+        "review-github",
+        "review-gitlab",
+        "badge",
+        "github-annotations",
+        "github-summary"
+      ]
+    },
+    {
+      "name": "--pretty",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--quiet",
+      "short": "-q",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--no-cache",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--threads",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--changed-since",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--diff-file",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--diff-stdin",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--churn-file",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--max-file-size",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--baseline",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--baseline-mode",
+      "type": "string",
+      "required": false,
+      "possible_values": [
+        "count",
+        "identity"
+      ]
+    },
+    {
+      "name": "--parent-run",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--save-baseline",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--production",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--no-production",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--production-dead-code",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--production-health",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--production-dupes",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--workspace",
+      "short": "-w",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--changed-workspaces",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--group-by",
+      "type": "string",
+      "required": false,
+      "possible_values": [
+        "owner",
+        "directory",
+        "package",
+        "section"
+      ]
+    },
+    {
+      "name": "--performance",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--explain",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--explain-skipped",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--summary",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--ci",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--fail-on-issues",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--sarif-file",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--output-file",
+      "short": "-o",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--report-path-prefix",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--fail-on-regression",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--tolerance",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--regression-baseline",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--save-regression-baseline",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--only",
+      "type": "string",
+      "required": false,
+      "possible_values": [
+        "dead-code",
+        "dupes",
+        "health"
+      ]
+    },
+    {
+      "name": "--skip",
+      "type": "string",
+      "required": false,
+      "possible_values": [
+        "dead-code",
+        "dupes",
+        "health"
+      ]
+    },
+    {
+      "name": "--dupes-mode",
+      "type": "string",
+      "required": false,
+      "possible_values": [
+        "strict",
+        "mild",
+        "weak",
+        "semantic"
+      ]
+    },
+    {
+      "name": "--dupes-near",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--dupes-threshold",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--dupes-min-tokens",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--dupes-min-lines",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--dupes-min-occurrences",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--dupes-skip-local",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--dupes-cross-language",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--dupes-ignore-imports",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--dupes-no-ignore-imports",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--score",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--trend",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--save-snapshot",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--coverage",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--coverage-root",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--include-entry-exports",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--type-aware",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--no-type-aware",
+      "type": "bool",
+      "required": false,
+      "possible_values": [
+        "true",
+        "false"
+      ]
+    },
+    {
+      "name": "--type-aware-project",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "--type-aware-require",
+      "type": "string",
+      "required": false,
+      "possible_values": [
+        "best-effort",
+        "complete"
+      ]
+    }
+  ],
+  "commands": [
+    {
+      "name": "dead-code",
+      "flags": [
+        {
+          "name": "--unused-files",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-exports",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-deps",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-types",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--private-type-leaks",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-enum-members",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-class-members",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-store-members",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unprovided-injects",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unrendered-components",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-component-props",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-component-emits",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-component-inputs",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-component-outputs",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-svelte-events",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-server-actions",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-load-data-keys",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unresolved-imports",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unlisted-deps",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--duplicate-exports",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--circular-deps",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--re-export-cycles",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--boundary-violations",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--policy-violations",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--stale-suppressions",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-catalog-entries",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--empty-catalog-groups",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unresolved-catalog-references",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--unused-dependency-overrides",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--misconfigured-dependency-overrides",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--include-dupes",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--trace",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--trace-file",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--trace-dependency",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--impact-closure",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--symbol-impact",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--top",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--file",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "watch",
+      "flags": [
+        {
+          "name": "--no-clear",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "type-aware",
+      "flags": []
+    },
+    {
+      "name": "similar-code",
+      "flags": [
+        {
+          "name": "--threshold",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--min-lines",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--top",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--file",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "inspect",
+      "flags": [
+        {
+          "name": "--file",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--symbol",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--symbol-chain",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--churn",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "trace",
+      "flags": [
+        {
+          "name": "symbol",
+          "type": "string",
+          "required": true
+        },
+        {
+          "name": "--callers",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--callees",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--depth",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "fix",
+      "flags": [
+        {
+          "name": "--dry-run",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--yes",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--no-create-config",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "init",
+      "flags": [
+        {
+          "name": "--toml",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--agents",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--hooks",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--branch",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--decline",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "hooks",
+      "flags": []
+    },
+    {
+      "name": "agent",
+      "flags": []
+    },
+    {
+      "name": "ci",
+      "flags": []
+    },
+    {
+      "name": "config-schema",
+      "flags": []
+    },
+    {
+      "name": "plugin-schema",
+      "flags": []
+    },
+    {
+      "name": "plugin-check",
+      "flags": []
+    },
+    {
+      "name": "rule-pack-schema",
+      "flags": []
+    },
+    {
+      "name": "rule-pack",
+      "flags": []
+    },
+    {
+      "name": "guard",
+      "flags": [
+        {
+          "name": "files",
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "config",
+      "flags": [
+        {
+          "name": "--path",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "recommend",
+      "flags": []
+    },
+    {
+      "name": "list",
+      "flags": [
+        {
+          "name": "--entry-points",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--files",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--plugins",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--boundaries",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--workspaces",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "workspaces",
+      "flags": []
+    },
+    {
+      "name": "dupes",
+      "flags": [
+        {
+          "name": "--mode",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "strict",
+            "mild",
+            "weak",
+            "semantic"
+          ]
+        },
+        {
+          "name": "--near",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--min-tokens",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--min-lines",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--min-occurrences",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--threshold",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--skip-local",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--cross-language",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--ignore-imports",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--no-ignore-imports",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--top",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--trace",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "health",
+      "flags": [
+        {
+          "name": "--max-cyclomatic",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--max-cognitive",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--max-crap",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--top",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--sort",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "severity",
+            "cyclomatic",
+            "cognitive",
+            "lines"
+          ]
+        },
+        {
+          "name": "--complexity",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--complexity-breakdown",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--file-scores",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--coverage-gaps",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--hotspots",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--ownership",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--ownership-emails",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "raw",
+            "handle",
+            "anonymized",
+            "hash"
+          ]
+        },
+        {
+          "name": "--targets",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--type-coupling",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--css",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--effort",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        {
+          "name": "--score",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--min-score",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--min-severity",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "moderate",
+            "high",
+            "critical"
+          ]
+        },
+        {
+          "name": "--report-only",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--since",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--min-commits",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--save-snapshot",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--trend",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--coverage",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--coverage-root",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--runtime-coverage",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--min-invocations-hot",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--min-observation-volume",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--low-traffic-threshold",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "flags",
+      "flags": [
+        {
+          "name": "--top",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "suppressions",
+      "flags": [
+        {
+          "name": "--file",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "explain",
+      "flags": [
+        {
+          "name": "issue_type",
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "audit",
+      "flags": [
+        {
+          "name": "--production-dead-code",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--production-health",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--production-dupes",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--dead-code-baseline",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--health-baseline",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--dupes-baseline",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--max-crap",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--coverage",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--coverage-root",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--no-css",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--css-deep",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--no-css-deep",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--gate",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "new-only",
+            "all"
+          ]
+        },
+        {
+          "name": "--runtime-coverage",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--min-invocations-hot",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--gate-marker",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--brief",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--max-decisions",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--walkthrough-guide",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--walkthrough-file",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--walkthrough",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--mark-viewed",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--show-cleared",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--show-deprioritized",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "audit-cache",
+      "flags": []
+    },
+    {
+      "name": "decision-surface",
+      "flags": [
+        {
+          "name": "--max-decisions",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "impact",
+      "flags": [
+        {
+          "name": "--all",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--sort",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "recent",
+            "resolved",
+            "contained",
+            "name"
+          ]
+        },
+        {
+          "name": "--limit",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "security",
+      "flags": [
+        {
+          "name": "--runtime-coverage",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--min-invocations-hot",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--file",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--gate",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "new",
+            "newly-reachable"
+          ]
+        },
+        {
+          "name": "--surface",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "report",
+      "flags": [
+        {
+          "name": "--from",
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "schema",
+      "flags": []
+    },
+    {
+      "name": "ci-template",
+      "flags": []
+    },
+    {
+      "name": "migrate",
+      "flags": [
+        {
+          "name": "--toml",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--jsonc",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--dry-run",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--from",
+          "type": "string",
+          "required": false
+        }
+      ]
+    },
+    {
+      "name": "license",
+      "flags": []
+    },
+    {
+      "name": "telemetry",
+      "flags": []
+    },
+    {
+      "name": "coverage",
+      "flags": []
+    },
+    {
+      "name": "setup-hooks",
+      "flags": [
+        {
+          "name": "--agent",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "claude",
+            "codex"
+          ]
+        },
+        {
+          "name": "--dry-run",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--force",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--user",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--gitignore-claude",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--uninstall",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "viz",
+      "flags": [
+        {
+          "name": "--out",
+          "type": "string",
+          "required": false
+        },
+        {
+          "name": "--no-open",
+          "type": "bool",
+          "required": false,
+          "possible_values": [
+            "true",
+            "false"
+          ]
+        },
+        {
+          "name": "--viz-format",
+          "type": "string",
+          "required": false,
+          "possible_values": [
+            "html",
+            "dot",
+            "mermaid"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/schema-registry-check.test.mjs
+++ b/tests/schema-registry-check.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+import { assertRegistrySchema } from "../scripts/schema-registry-check.mjs";
+
+const jiti = createJiti(import.meta.url);
+const { fallowToolCommands, getFallowToolCommandSpec } = await jiti.import("../extensions/fallow/registry.ts");
+const specs = fallowToolCommands.map(getFallowToolCommandSpec);
+const frozen = JSON.parse(readFileSync(new URL("./fixtures/fallow/schema-3.21.0.json", import.meta.url), "utf8"));
+const manifest = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+
+function changedSchema(change) {
+	const schema = structuredClone(frozen);
+	change(schema);
+	return schema;
+}
+
+function command(schema, name) {
+	return schema.commands.find((entry) => entry.name === name);
+}
+
+function globalFlag(schema, name) {
+	return schema.global_flags.find((entry) => entry.name === name);
+}
+
+describe("registry versus certified Fallow schema", () => {
+	it("certifies every tool command against a fixture matching the pinned development target", () => {
+		assert.equal(frozen.version, manifest.devDependencies.fallow);
+		assertRegistrySchema(frozen, specs);
+	});
+
+	it("identifies every affected alias when its CLI command disappears", () => {
+		for (const spec of specs.filter((entry) => entry.cliPrefix.length)) {
+			const root = spec.cliPrefix[0];
+			const schema = changedSchema((data) => { data.commands = data.commands.filter((entry) => entry.name !== root); });
+			assert.throws(() => assertRegistrySchema(schema, [spec]), {
+				message: `${spec.name} -> ${root}: schema is missing command ${root}`,
+			});
+		}
+	});
+
+	it("checks fixed boolean flags and value-taking trace flags, not just command names", () => {
+		for (const spec of specs.filter((entry) => entry.cliPrefix.some((token) => token.startsWith("--")))) {
+			const [root, flag] = spec.cliPrefix;
+			const schema = changedSchema((data) => {
+				const entry = command(data, root).flags.find((entry) => entry.name === flag);
+				entry.type = entry.type === "bool" ? "string" : "bool";
+			});
+			assert.throws(() => assertRegistrySchema(schema, [spec]), /must remain/);
+		}
+	});
+
+	it("rejects missing managed flags, loss of JSON, and incompatible local shadows", () => {
+		for (const mutate of [
+			(data) => { data.global_flags = data.global_flags.filter((flag) => flag.name !== "--quiet"); },
+			(data) => { data.output_formats = ["human"]; },
+			(data) => { globalFlag(data, "--format").possible_values = ["human"]; },
+			(data) => { command(data, "health").flags.push({ name: "--quiet", type: "string" }); },
+		]) assert.throws(() => assertRegistrySchema(changedSchema(mutate), specs), /quiet|json|JSON/);
+	});
+
+	it("checks target requirements and the architecture boolean-flag scanner", () => {
+		for (const mutate of [
+			(data) => { command(data, "guard").flags = []; },
+			(data) => { command(data, "trace").flags[0].required = false; },
+			(data) => { command(data, "explain").flags[0].type = "bool"; },
+			(data) => { globalFlag(data, "--no-cache").type = "string"; },
+			(data) => { delete globalFlag(data, "--quiet").short; },
+		]) assert.throws(() => assertRegistrySchema(changedSchema(mutate), specs), /positional target|must remain|missing -q/);
+	});
+
+	it("checks changed-file and selected type-aware requirements", () => {
+		for (const mutate of [
+			(data) => { globalFlag(data, "--changed-since").type = "bool"; },
+			(data) => { globalFlag(data, "--type-aware-project").type = "bool"; },
+			(data) => { command(data, "dead-code").flags = command(data, "dead-code").flags.filter((flag) => flag.name !== "--symbol-impact"); },
+			(data) => { command(data, "health").flags = command(data, "health").flags.filter((flag) => flag.name !== "--type-coupling"); },
+		]) assert.throws(() => assertRegistrySchema(changedSchema(mutate), specs), /must remain|schema is missing/);
+	});
+
+	it("requires review of manifest, default-command, and nested-prefix changes", () => {
+		assert.throws(() => assertRegistrySchema(changedSchema((data) => { data.manifest_version = "2"; }), specs), /manifest format/);
+		assert.throws(() => assertRegistrySchema(changedSchema((data) => { data.default_command = "health"; }), specs), /changed default command/);
+		assert.throws(() => assertRegistrySchema(frozen, [{ name: "coverage-analyze", cliPrefix: ["coverage", "missing"] }]), /unverified nested CLI prefix/);
+	});
+
+	it("allows additive commands, flags, issue types, formats, and version changes", () => {
+		const schema = changedSchema((data) => {
+			data.version = "99.0.0";
+			data.commands.push({ name: "future-command", flags: [] });
+			data.global_flags.push({ name: "--future-flag", type: "bool", required: false });
+			command(data, "health").flags.push({ name: "--future-health-flag", type: "string", required: false });
+			data.issue_types = [{ id: "future-issue" }];
+			data.output_formats.push("future-format");
+		});
+		assertRegistrySchema(schema, specs);
+	});
+});


### PR DESCRIPTION
## Summary
- Capture a reproducible, projected Fallow 3.21 capability fixture with provenance and regeneration instructions.
- Check every tool registry entry against frozen and live schema evidence: CLI roots/fixed flags, managed JSON output, positional targets, architecture boolean flags, and selected type-aware flags.
- Add mutation coverage for incompatible changes while allowing additive capabilities and version changes in the scoped checker.
- Explicitly document manifest-v1 omissions; verify the nested coverage analyze prefix through read-only CLI help.

This is development-only certification groundwork related to #77, not its runtime diagnostic UI or a complete compatibility detector. No extension runtime, dependency, peer, startup, autocomplete, or publication behavior changes. #77 remains open.

## Validation
- npm test: 214/214 passing on Node 22.19 and Node 24
- npm run coverage: passing thresholds; 90.24% statements/lines
- npm run check:bundle
- npm run health / dupes / dead-code: zero threshold findings, clone groups, or dead-code issues
- npm run smoke:fallow: passing against Fallow 3.21.0
- npm run audit:production / audit:all: zero vulnerabilities
- npm run pack:check / package:smoke: passing; Pi 0.84.3 RPC/print/JSON
- Token and performance benchmarks and baseline comparisons completed; runtime sources unchanged, no performance-improvement claim
- git diff --check

## Boundaries
Does not validate arbitrary forwarded flags, new required arguments, all nested commands, all slash-only flows, or report layouts. No tags or releases.