### PR TITLE
test: capture report and nested-command contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Pi Fallow are documented here.
 - Added explicit opt-in semantic similar-code analysis across `/fallow` and `fallow_run`, with read-only status/discovery/inspect/review flows, reproducible model and input provenance, advisory source-grounded rendering, partial-phase and skip diagnostics, distinct cancellation/timeout metadata, a cold-run timeout allowance, and hard guards against model downloads or cache mutation.
 
 ### Changed
+- Extended development certification with reproducible real CLI report fixtures, nested help and missing-input contracts, new-required-argument checks, and parsing/normalization/complete-output regression tests; successful companion/model-backed nested analysis remains explicitly uncertified.
 - Added frozen capability-schema certification and mutation tests for every tool registry prefix, managed output flags, positional targets, and selected type-aware flags; the live CLI smoke suite shares these checks without adding runtime version constraints.
 - Updated the pinned Fallow compatibility target to 3.21.0 and re-certified the current command/schema, MCP-resource, type-aware, quality, and packaged host surfaces, including the 3.20 strict-exit and project-reference resolution changes plus the 3.21 runtime-coverage and hidden-source diagnostic fixes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ What these cover:
 - `npm run health` runs Fallow health checks.
 - `npm run dupes` checks for duplicate code.
 - `npm run dead-code` checks for unused files/exports and stale suppressions.
-- `npm run smoke:fallow` smoke-tests modeled Fallow CLI surfaces and checks every tool registry prefix against the live capability schema. Offline fixture and mutation tests run with `npm test`; see [`tests/fixtures/fallow/README.md`](./tests/fixtures/fallow/README.md) for certification scope and regeneration.
+- `npm run smoke:fallow` smoke-tests modeled Fallow CLI surfaces and checks every tool registry prefix against the live capability schema. It also recaptures isolated report/help evidence and compares known fields while accepting additive object fields. Offline fixture and mutation tests run with `npm test`; see [`tests/fixtures/fallow/README.md`](./tests/fixtures/fallow/README.md) for certification scope and regeneration.
 - `npm run coverage` generates text/lcov reports and enforces gradual all-file thresholds.
 - `npm run audit:production` and `npm run audit:all` check the shipped and complete dependency trees.
 - `npm run package:smoke` packs, installs, and validates the npm tarball in an isolated project.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ This roadmap describes the current baseline and likely next work. It is planning
 
 Unless noted otherwise, these are repository-specific measurements from the `0.5.0` release candidate, not universal expectations for other machines, hosts, Fallow installations, or providers.
 
-- **Tests and coverage:** 214 tests; current coverage is **90.24% statements/lines**, **86.88% branches**, and **88.94% functions**. The `0.5.0` release-candidate snapshot recorded **88.50% statements/lines**, **86.35% branches**, and **85.44% functions**; subprocess-sensitive reruns can vary slightly by run and Node line while CI continues to enforce the coverage thresholds.
+- **Tests and coverage:** 223 tests; current coverage is **90.38% statements/lines**, **86.89% branches**, and **89.04% functions**. The `0.5.0` release-candidate snapshot recorded **88.50% statements/lines**, **86.35% branches**, and **85.44% functions**; subprocess-sensitive reruns can vary slightly by run and Node line while CI continues to enforce the coverage thresholds.
 - **Fallow quality:** Fallow 3.21 reports health **83.4 (B)**, average maintainability **91.6**, and zero threshold findings, dead-code issues, or clone groups.
 - **Dependency audits:** strict production and complete-tree npm audits report zero vulnerabilities. These audit results are separate from Fallow's modeled security-candidate analysis.
 - **Host compatibility:** packaged, provider-free Pi **0.84.3** behavior is certified on Node **22.19** and **24**. Pi host libraries intentionally remain external wildcard peers; this is a tested compatibility matrix, not a restrictive peer range or provider-backed/PTY/tmux certification. See the [README compatibility section](./README.md#tested-compatibility).
@@ -41,7 +41,7 @@ See [`benchmarks/README.md`](./benchmarks/README.md), [`benchmarks/PERFORMANCE.m
 
 ## Remaining priorities
 
-1. **Keep command and report compatibility honest.** Frozen capability-schema and live registry-prefix checks now cover managed output, positional targets, and selected type-aware flags (see [`fixture scope`](./tests/fixtures/fallow/README.md)). Expand representative report fixtures and nested-command coverage next; installed-capability diagnostics remain separate work, preserving graceful behavior with separately installed Fallow versions.
+1. **Keep command and report compatibility honest.** Frozen capability-schema and live registry-prefix checks now cover managed output, positional targets, and selected type-aware flags (see [`fixture scope`](./tests/fixtures/fallow/README.md)). Initial real report fixtures and nested help/missing-input checks now supplement those checks. Continue #83 with successful companion-backed nested execution and broader representative reports; installed-capability diagnostics remain separate work, preserving graceful behavior with separately installed Fallow versions.
 2. **Decide whether user-owned customization is still desired.** If demand remains, design Pi Fallow-specific global/project configuration, prompt templates, and a safe prompt/config preview without taking ownership of Fallow's configuration file.
 3. **Refine navigator workflows from evidence.** Make any remaining history, comparison, or UI density improvements only when real large-report use identifies a concrete need.
 4. **Improve quality where evidence points.** Raise coverage and maintainability gradually around real execution, command-flow, rendering, project-state, and PR-summary hotspots. Do not split files cosmetically merely to improve a metric.

--- a/scripts/fallow-smoke.mjs
+++ b/scripts/fallow-smoke.mjs
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
 import { createJiti } from "jiti";
 import { assertRegistrySchema } from "./schema-registry-check.mjs";
+import { assertEvidenceSubset, collectReportEvidence } from "./report-certification.mjs";
 
 const jiti = createJiti(import.meta.url);
 const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
@@ -229,5 +231,7 @@ function assertCliSurfaces() {
 }
 
 assertModeledArgs();
+const frozenReports = JSON.parse(await readFile(new URL("../tests/fixtures/fallow/reports-3.21.0.json", import.meta.url), "utf8"));
+assertEvidenceSubset(await collectReportEvidence(), frozenReports);
 assertCliSurfaces();
 console.log("Fallow CLI smoke checks passed.");

--- a/scripts/report-certification.mjs
+++ b/scripts/report-certification.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repository = fileURLToPath(new URL("../", import.meta.url));
+const fixtures = join(repository, "tests/fixtures/fallow");
+const reportCommands = {
+	"dead-code": ["dead-code", "--no-cache"],
+	"health": ["health", "--no-cache"],
+	"similar-status": ["similar-code", "status"],
+	"similar-missing-model": ["similar-code", "--no-cache"],
+	"coverage-missing-value": ["coverage", "analyze", "--runtime-coverage"],
+	"inspect-missing-inputs": ["similar-code", "inspect"],
+	"review-missing-inputs": ["similar-code", "review"],
+};
+const helpCommands = {
+	"coverage-analyze": ["coverage", "analyze"],
+	"similar-discovery": ["similar-code"],
+	"similar-inspect": ["similar-code", "inspect"],
+	"similar-review": ["similar-code", "review"],
+};
+
+function execute(args, root) {
+	// Do not inherit cloud selection, credentials, model/cache overrides, or a
+	// user's home/config. PATH only exposes the pinned package and this Node.
+	const home = join(root, "home");
+	const result = spawnSync(join(repository, "node_modules/.bin/fallow"), args, {
+		cwd: root, encoding: "utf8", timeout: 30_000, maxBuffer: 2 * 1024 * 1024,
+		env: {
+			PATH: [join(repository, "node_modules/.bin"), dirname(process.execPath)].join(delimiter),
+			HOME: home, XDG_CACHE_HOME: join(home, "cache"), XDG_CONFIG_HOME: join(home, "config"),
+			FALLOW_TELEMETRY: "0", NO_COLOR: "1",
+		},
+	});
+	assert.ifError(result.error);
+	assert.equal(result.signal, null, `${args.join(" ")}: terminated by a signal`);
+	return result;
+}
+
+function normalizeReport(report) {
+	// Only measured nondeterminism is replaced. Preserve all actionable and
+	// completeness fields, including unknown fields, in the frozen evidence.
+	if ("elapsed_ms" in report) report.elapsed_ms = 0;
+	normalizeRunIdentity(report._meta);
+	if (report.kind === "similar-code-status") report.cache_dir = "<ISOLATED_MODEL_CACHE>";
+	return report;
+}
+
+function normalizeRunIdentity(meta) {
+	if (!meta?.telemetry) return;
+	if ("analysis_run_id" in meta.telemetry) meta.telemetry.analysis_run_id = "<RUN_ID>";
+}
+
+export function projectHelp(text) {
+	const usage = text.split("\n").find((line) => line.startsWith("Usage: "));
+	assert.ok(usage, "nested help: missing Usage declaration");
+	const options = {};
+	for (const line of text.split("\n")) {
+		const option = line.match(/^\s+(?:-\w, )?(--[\w-]+)(?:\s+(\[?<[^>]+>\]?))?/);
+		if (option) options[option[1]] = option[2] ?? "boolean";
+	}
+	return { requiredUsage: usage.replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim(), options };
+}
+
+export async function collectReportEvidence() {
+	const projectText = await readFile(join(fixtures, "report-project.json"), "utf8");
+	const manifest = JSON.parse(await readFile(join(repository, "package.json"), "utf8"));
+	const root = await mkdtemp(join(tmpdir(), "pi-fallow-certification-"));
+	try {
+		await mkdir(join(root, "node_modules"));
+		for (const [name, content] of Object.entries(JSON.parse(projectText))) {
+			assert.equal(dirname(name), ".", "capture inputs must be flat project files");
+			await writeFile(join(root, name), content);
+		}
+		const versionResult = execute(["--version"], root);
+		assert.equal(versionResult.status, 0, "pinned executable version check failed");
+		const version = versionResult.stdout.split("\n")[0].trim();
+		assert.equal(version, `fallow ${manifest.devDependencies.fallow}`, "capture requires the pinned Fallow target");
+		return {
+			version: manifest.devDependencies.fallow,
+			inputSha256: createHash("sha256").update(projectText).digest("hex"),
+			reports: captureReports(root),
+			help: captureHelp(root),
+		};
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+function captureReports(root) {
+	return Object.fromEntries(Object.entries(reportCommands).map(([id, command]) => {
+		const args = [...command, "--format", "json", "--quiet"];
+		const result = execute(args, root);
+		return [id, { args, exitCode: result.status, report: normalizeReport(JSON.parse(result.stdout)) }];
+	}));
+}
+
+function captureHelp(root) {
+	return Object.fromEntries(Object.entries(helpCommands).map(([id, command]) => {
+		const args = [...command, "--help"];
+		const result = execute(args, root);
+		assert.equal(result.status, 0, `${id}: help failed`);
+		return [id, { args, ...projectHelp(result.stdout) }];
+	}));
+}
+
+// Known fields must remain compatible; additive object fields/options are fine.
+// Arrays are exact for this fixed tiny input, not a general report comparator.
+export function assertEvidenceSubset(actual, expected, context = "report certification") {
+	if (Object(expected) !== expected) {
+		assert.equal(actual, expected, context);
+		return;
+	}
+	assert.equal(typeof actual, "object", `${context}: expected object`);
+	assert.notEqual(actual, null, `${context}: expected non-null object`);
+	assert.equal(Array.isArray(actual), Array.isArray(expected), `${context}: changed object/array shape`);
+	if (Array.isArray(expected)) assert.equal(actual.length, expected.length, `${context}: changed array length`);
+	for (const [key, value] of Object.entries(expected)) assertEvidenceSubset(actual[key], value, `${context}.${key}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	assert.deepEqual(process.argv.slice(2), ["--write"], "Usage: node scripts/report-certification.mjs --write");
+	const evidence = await collectReportEvidence();
+	await writeFile(join(fixtures, `reports-${evidence.version}.json`), `${JSON.stringify(evidence, null, 2)}\n`);
+	console.log(`Captured ${Object.keys(evidence.reports).length} reports and ${Object.keys(evidence.help).length} help contracts.`);
+}

--- a/scripts/schema-registry-check.mjs
+++ b/scripts/schema-registry-check.mjs
@@ -42,6 +42,7 @@ function assertCommandSchema(schema, commands, spec) {
 	assertManagedOutput(flags, context);
 	assertPrefix(suffix, flags, spec, context);
 	assertTarget(command, suffix, spec, context);
+	assertRequiredArguments(flags, spec, context);
 	assertPositionalFlags(flags, spec, context);
 	if (spec.name === "check-changed") requireFlag(flags, "--changed-since", "string", context);
 	if (["dead-code", "health"].includes(spec.name)) assertTypeAwareFlags(flags, spec.name, context);
@@ -76,6 +77,18 @@ function assertTarget(command, suffix, spec, context) {
 	assert.equal(positionals.length, 1, `${context}: expected one positional target`);
 	assert.equal(positionals[0].type, "string", `${context}: positional target must remain string`);
 	assert.equal(positionals[0].required, true, `${context}: review changed positional target requirement`);
+}
+
+function assertRequiredArguments(flags, spec, context) {
+	for (const flag of flags.filter((entry) => entry.required)) {
+		assert.ok(suppliesRequiredArgument(spec, flag), `${context}: new required argument ${flag.name}`);
+	}
+}
+
+function suppliesRequiredArgument(spec, flag) {
+	const normalizedFlags = spec.name === "check-changed" ? ["--changed-since"] : [];
+	if (flag.name.startsWith("-")) return [...spec.cliPrefix, "--format", "--quiet", ...normalizedFlags].includes(flag.name);
+	return spec.positionalTarget === true && spec.cliPrefix.length === 1;
 }
 
 function assertPositionalFlags(flags, spec, context) {

--- a/tests/fixtures/fallow/README.md
+++ b/tests/fixtures/fallow/README.md
@@ -38,19 +38,82 @@ when changing the certified target. Tests require the fixture version to match
 
 `tests/schema-registry-check.test.mjs` checks every tool registry entry against this
 fixture, with mutation tests for missing commands, fixed flags, target metadata,
-managed JSON output, architecture's boolean-flag scanner, and selected type-aware
-flags. `npm run smoke:fallow` runs the same checks against the actual CLI schema
+new required inputs, managed JSON output, architecture's boolean-flag scanner,
+and selected type-aware flags. `npm run smoke:fallow` runs the same checks against the actual CLI schema
 alongside the existing report, issue-type, resource, and version assertions.
 
 Manifest v1 does **not** describe nested `coverage analyze` or built-in help flags.
 The checker explicitly exempts only the known nested prefix and help flags;
-the live smoke check separately verifies `coverage analyze --help`. This does
-not certify the nested command's full argument or output contract.
+the live smoke check separately verifies nested help and missing-input execution
+contracts described below. This does not certify successful nested analysis.
 
 Extra commands, optional flags, issue types, and output formats do not fail the
 registry check. This is scoped development certification, not a general semantic
 compatibility detector: it does not validate arbitrary forwarded flags, all
-allowed values, new required arguments, all slash-only flows, or report layouts.
+allowed values, all slash-only flows, or arbitrary report layouts. Required-input
+checks cover advertised required flags/positionals not supplied by fixed registry
+prefixes or managed output flags; help evidence extends this to selected nested
+commands, not conditional argument constraints.
 No schema probing or version gate is added to startup, autocomplete, or runtime
 execution. Independently installed older/newer Fallow versions remain usable;
 user-facing installed-capability diagnostics remain separate work (#77).
+
+## Captured report and nested-command evidence
+
+`reports-3.21.0.json` contains seven real CLI JSON reports and four projected help
+contracts. `report-project.json` holds the complete tiny input project; its SHA-256
+is recorded in the evidence. The capture script records the exact CLI tokens,
+exit status, and report for each case:
+
+- dead-code: one actionable unused export, exit 1 (findings, not a crash);
+- health: no threshold findings, with an informational file score;
+- similar-code status: pinned-model provenance with an isolated, missing model;
+- similar-code discovery: the real missing-model failure, without inference;
+- coverage analyze: missing runtime-coverage option value;
+- similar-code inspect/review: required-input failures before any candidate read.
+
+Regenerate deliberately from the repository root:
+
+```sh
+node scripts/report-certification.mjs --write
+npm test
+npm run smoke:fallow
+```
+
+The capture script verifies the pinned CLI version, creates and finally removes
+an isolated temporary project/home/config/cache, and inherits neither Fallow
+cloud/model overrides nor credentials. Its PATH contains only the repository's
+pinned executables and the running Node directory. It never runs setup, cache
+clear, fixes, or successful model inference. No optional companion installation
+is attempted. Signature verification by the npm executable wrapper may use its
+existing package-local verification marker.
+
+Normalization is explicit: top-level `elapsed_ms` becomes 0; telemetry
+`analysis_run_id` becomes `<RUN_ID>`; the status report's machine-specific model
+cache path becomes `<ISOLATED_MODEL_CACHE>`. No finding, source location, action,
+error, model identity, or completeness data is removed. Stderr is not archived;
+these fixtures certify JSON stdout and exit codes, not diagnostic logging.
+
+Help projection retains required Usage tokens and option value placeholders
+(including optional values), not descriptions. A new required Usage token or a
+changed/missing known option declaration fails certification; additive optional
+options do not. This is a scoped parser for current help, not a general Clap
+schema parser or proof that all declared options execute successfully.
+
+`tests/report-certification.test.mjs` exercises JSON parsing, normalization,
+bounded output, and readable complete-report retention using these captures.
+It also injects **synthetic** partial type-aware metadata into the captured health
+report to test advisory-state retention; that test is not live semantic evidence.
+Mutation tests remove/change actionable fields, schema identity, required nested
+inputs, and option arity. Live smoke recaptures evidence and requires the known
+fields to match, allowing additive object fields. Array contents/counts are exact
+for this fixed input, not a general comparison of arbitrary projects.
+
+### Remaining #83 scope
+
+This is an initial slice, not closure of #83. Successful `coverage analyze` needs
+the optional `fallow-cov` companion, which is not in the current development
+package. Model-backed discovery and successful source-grounded inspect/review
+are not certified here. Additional representative security, duplication,
+combined, and real partial reports also remain future coverage. These gaps must
+not be inferred as supported from help-only or failure-path checks.

--- a/tests/fixtures/fallow/report-project.json
+++ b/tests/fixtures/fallow/report-project.json
@@ -1,0 +1,5 @@
+{
+  "package.json": "{\"name\":\"certification-fixture\",\"private\":true,\"type\":\"module\",\"main\":\"index.js\"}\n",
+  "index.js": "import { used } from './lib.js';\nconsole.log(used(2));\n",
+  "lib.js": "export function used(value) { return value + 1; }\nexport function unused(value) { return value - 1; }\n"
+}

--- a/tests/fixtures/fallow/reports-3.21.0.json
+++ b/tests/fixtures/fallow/reports-3.21.0.json
@@ -1,0 +1,497 @@
+{
+  "version": "3.21.0",
+  "inputSha256": "2272a5d687eeec2b258ca8dabac40adcd66f841d4deefd198f10f51f00396288",
+  "reports": {
+    "dead-code": {
+      "args": [
+        "dead-code",
+        "--no-cache",
+        "--format",
+        "json",
+        "--quiet"
+      ],
+      "exitCode": 1,
+      "report": {
+        "kind": "dead-code",
+        "schema_version": 9,
+        "version": "3.21.0",
+        "elapsed_ms": 0,
+        "total_issues": 1,
+        "entry_points": {
+          "total": 1,
+          "sources": {
+            "package.json": 1
+          }
+        },
+        "summary": {
+          "total_issues": 1,
+          "unused_files": 0,
+          "unused_exports": 1,
+          "unused_types": 0,
+          "private_type_leaks": 0,
+          "unused_dependencies": 0,
+          "unused_enum_members": 0,
+          "unused_class_members": 0,
+          "unused_store_members": 0,
+          "unprovided_injects": 0,
+          "unrendered_components": 0,
+          "unused_component_props": 0,
+          "unused_component_emits": 0,
+          "unused_component_inputs": 0,
+          "unused_component_outputs": 0,
+          "unused_svelte_events": 0,
+          "unused_server_actions": 0,
+          "unused_load_data_keys": 0,
+          "unresolved_imports": 0,
+          "unlisted_dependencies": 0,
+          "duplicate_exports": 0,
+          "type_only_dependencies": 0,
+          "test_only_dependencies": 0,
+          "dev_dependencies_in_production": 0,
+          "circular_dependencies": 0,
+          "re_export_cycles": 0,
+          "boundary_violations": 0,
+          "boundary_coverage_violations": 0,
+          "boundary_call_violations": 0,
+          "policy_violations": 0,
+          "stale_suppressions": 0,
+          "unused_catalog_entries": 0,
+          "empty_catalog_groups": 0,
+          "unresolved_catalog_references": 0,
+          "unused_dependency_overrides": 0,
+          "misconfigured_dependency_overrides": 0,
+          "invalid_client_exports": 0,
+          "mixed_client_server_barrels": 0,
+          "misplaced_directives": 0,
+          "route_collisions": 0,
+          "dynamic_segment_name_conflicts": 0
+        },
+        "unused_files": [],
+        "unused_exports": [
+          {
+            "path": "lib.js",
+            "export_name": "unused",
+            "is_type_only": false,
+            "line": 2,
+            "col": 16,
+            "span_start": 66,
+            "is_re_export": false,
+            "actions": [
+              {
+                "type": "remove-export",
+                "auto_fixable": true,
+                "description": "Remove the unused export from the public API"
+              },
+              {
+                "type": "suppress-line",
+                "auto_fixable": false,
+                "description": "Suppress with an inline comment above the line",
+                "comment": "// fallow-ignore-next-line unused-export"
+              }
+            ]
+          }
+        ],
+        "unused_types": [],
+        "private_type_leaks": [],
+        "unused_dependencies": [],
+        "unused_dev_dependencies": [],
+        "unused_optional_dependencies": [],
+        "unused_enum_members": [],
+        "unused_class_members": [],
+        "unresolved_imports": [],
+        "unlisted_dependencies": [],
+        "duplicate_exports": [],
+        "type_only_dependencies": [],
+        "test_only_dependencies": [],
+        "dev_dependencies_in_production": [],
+        "circular_dependencies": [],
+        "re_export_cycles": [],
+        "boundary_violations": [],
+        "boundary_coverage_violations": [],
+        "boundary_call_violations": [],
+        "policy_violations": [],
+        "stale_suppressions": [],
+        "unused_catalog_entries": [],
+        "empty_catalog_groups": [],
+        "unresolved_catalog_references": [],
+        "unused_dependency_overrides": [],
+        "misconfigured_dependency_overrides": [],
+        "invalid_client_exports": [],
+        "mixed_client_server_barrels": [],
+        "misplaced_directives": [],
+        "route_collisions": [],
+        "dynamic_segment_name_conflicts": [],
+        "next_steps": [
+          {
+            "id": "setup",
+            "command": "fallow schema",
+            "reason": "fallow has no config here; the manifest lists guided-setup commands (agent guide, commit gate) to offer the user"
+          },
+          {
+            "id": "trace-unused-export",
+            "command": "fallow dead-code --trace lib.js:unused",
+            "reason": "verify an export is truly unused before deleting"
+          }
+        ],
+        "_meta": {
+          "telemetry": {
+            "analysis_run_id": "<RUN_ID>"
+          }
+        }
+      }
+    },
+    "health": {
+      "args": [
+        "health",
+        "--no-cache",
+        "--format",
+        "json",
+        "--quiet"
+      ],
+      "exitCode": 0,
+      "report": {
+        "kind": "health",
+        "schema_version": 11,
+        "version": "3.21.0",
+        "elapsed_ms": 0,
+        "findings": [],
+        "summary": {
+          "files_analyzed": 2,
+          "functions_analyzed": 2,
+          "functions_above_threshold": 0,
+          "max_cyclomatic_threshold": 20,
+          "max_cognitive_threshold": 15,
+          "max_crap_threshold": 30,
+          "max_unit_size_threshold": 60,
+          "files_scored": 1,
+          "average_maintainability": 88.8,
+          "coverage_model": "static_estimated",
+          "severity_critical_count": 0,
+          "severity_high_count": 0,
+          "severity_moderate_count": 0
+        },
+        "vital_signs": {
+          "dead_file_pct": 0,
+          "dead_export_pct": 50,
+          "avg_cyclomatic": 1,
+          "critical_complexity_pct": 0,
+          "p90_cyclomatic": 1,
+          "duplication_pct": 0,
+          "hotspot_count": 0,
+          "hotspot_top_pct_count": 0,
+          "maintainability_avg": 88.8,
+          "maintainability_low_pct": 0,
+          "unused_dep_count": 0,
+          "unused_deps_per_k_files": 0,
+          "circular_dep_count": 0,
+          "circular_deps_per_k_files": 0,
+          "counts": {
+            "total_files": 2,
+            "total_exports": 2,
+            "dead_files": 0,
+            "dead_exports": 1,
+            "duplicated_lines": 0,
+            "total_lines": 6,
+            "files_scored": 1,
+            "total_deps": 0
+          },
+          "unit_size_profile": {
+            "low_risk": 100,
+            "medium_risk": 0,
+            "high_risk": 0,
+            "very_high_risk": 0
+          },
+          "functions_over_60_loc_per_k": 0,
+          "unit_interfacing_profile": {
+            "low_risk": 100,
+            "medium_risk": 0,
+            "high_risk": 0,
+            "very_high_risk": 0
+          },
+          "p95_fan_in": 1,
+          "coupling_high_pct": 0,
+          "total_loc": 6
+        },
+        "health_score": {
+          "formula_version": 2,
+          "score": 90,
+          "grade": "A",
+          "penalties": {
+            "dead_files": 0,
+            "dead_exports": 10,
+            "complexity": 0,
+            "p90_complexity": 0,
+            "maintainability": 0,
+            "hotspots": 0,
+            "unused_deps": 0,
+            "circular_deps": 0,
+            "unit_size": 0,
+            "coupling": 0,
+            "duplication": 0
+          }
+        },
+        "file_scores": [
+          {
+            "path": "lib.js",
+            "fan_in": 1,
+            "fan_out": 0,
+            "dead_code_ratio": 0.5,
+            "complexity_density": 0.67,
+            "maintainability_index": 88.8,
+            "total_cyclomatic": 2,
+            "total_cognitive": 0,
+            "function_count": 2,
+            "lines": 3,
+            "crap_max": 2,
+            "crap_above_threshold": 0
+          }
+        ],
+        "target_thresholds": {
+          "fan_in_p95": 5,
+          "fan_in_p75": 3,
+          "fan_out_p95": 8,
+          "fan_out_p90": 5
+        },
+        "_meta": {
+          "telemetry": {
+            "analysis_run_id": "<RUN_ID>"
+          }
+        }
+      }
+    },
+    "similar-status": {
+      "args": [
+        "similar-code",
+        "status",
+        "--format",
+        "json",
+        "--quiet"
+      ],
+      "exitCode": 0,
+      "report": {
+        "kind": "similar-code-status",
+        "schema_version": "1",
+        "version": "3.21.0",
+        "protocol_version": 2,
+        "embedding_semantics_version": 1,
+        "companion_version": "3.21.0",
+        "model_ready": false,
+        "model_id": "jinaai/jina-embeddings-v2-base-code",
+        "model_revision": "516f4baf13dec4ddddda8631e019b5737c8bc250",
+        "dimensions": 768,
+        "max_tokens": 1024,
+        "license": "Apache-2.0",
+        "cache_dir": "<ISOLATED_MODEL_CACHE>",
+        "download_bytes": 324329844,
+        "analysis_offline": true,
+        "integrity_verified": false,
+        "problem": "the local model is not installed; run `fallow similar-code setup --local`"
+      }
+    },
+    "similar-missing-model": {
+      "args": [
+        "similar-code",
+        "--no-cache",
+        "--format",
+        "json",
+        "--quiet"
+      ],
+      "exitCode": 3,
+      "report": {
+        "error": true,
+        "message": "the local model is not installed; run `fallow similar-code setup --local`",
+        "exit_code": 3
+      }
+    },
+    "coverage-missing-value": {
+      "args": [
+        "coverage",
+        "analyze",
+        "--runtime-coverage",
+        "--format",
+        "json",
+        "--quiet"
+      ],
+      "exitCode": 2,
+      "report": {
+        "error": true,
+        "message": "error: a value is required for '--runtime-coverage <PATH>' but none was supplied\n\nFor more information, try '--help'.",
+        "exit_code": 2
+      }
+    },
+    "inspect-missing-inputs": {
+      "args": [
+        "similar-code",
+        "inspect",
+        "--format",
+        "json",
+        "--quiet"
+      ],
+      "exitCode": 2,
+      "report": {
+        "error": true,
+        "message": "error: the following required arguments were not provided:\n  --candidates <PATH>\n  <CANDIDATE_ID>\n\nUsage: fallow similar-code inspect --format <FORMAT> --quiet --candidates <PATH> <CANDIDATE_ID>\n\nFor more information, try '--help'.",
+        "exit_code": 2
+      }
+    },
+    "review-missing-inputs": {
+      "args": [
+        "similar-code",
+        "review",
+        "--format",
+        "json",
+        "--quiet"
+      ],
+      "exitCode": 2,
+      "report": {
+        "error": true,
+        "message": "error: the following required arguments were not provided:\n  --candidates <PATH>\n  --verdicts <PATH>\n\nUsage: fallow similar-code review --candidates <PATH> --verdicts <PATH> --format <FORMAT> --quiet\n\nFor more information, try '--help'.",
+        "exit_code": 2
+      }
+    }
+  },
+  "help": {
+    "coverage-analyze": {
+      "args": [
+        "coverage",
+        "analyze",
+        "--help"
+      ],
+      "requiredUsage": "Usage: fallow coverage analyze",
+      "options": {
+        "--runtime-coverage": "<PATH>",
+        "--cloud": "boolean",
+        "--api-key": "<KEY>",
+        "--api-endpoint": "<URL>",
+        "--repo": "<OWNER/REPO>",
+        "--project-id": "<ID>",
+        "--coverage-period": "<DAYS>",
+        "--environment": "<ENV>",
+        "--commit-sha": "<SHA>",
+        "--production": "boolean",
+        "--min-invocations-hot": "<MIN_INVOCATIONS_HOT>",
+        "--min-observation-volume": "<N>",
+        "--low-traffic-threshold": "<RATIO>",
+        "--top": "<TOP>",
+        "--blast-radius": "boolean",
+        "--importance": "boolean",
+        "--root": "<ROOT>",
+        "--config": "<CONFIG>",
+        "--allow-remote-extends": "boolean",
+        "--format": "<FORMAT>",
+        "--pretty": "boolean",
+        "--quiet": "boolean",
+        "--no-cache": "boolean",
+        "--threads": "<THREADS>",
+        "--changed-since": "<CHANGED_SINCE>",
+        "--diff-file": "<PATH>",
+        "--diff-stdin": "boolean",
+        "--churn-file": "<PATH>",
+        "--max-file-size": "<MB>",
+        "--baseline": "<BASELINE>",
+        "--baseline-mode": "<BASELINE_MODE>",
+        "--save-baseline": "<SAVE_BASELINE>",
+        "--no-production": "boolean",
+        "--workspace": "<WORKSPACE>",
+        "--changed-workspaces": "<REF>",
+        "--group-by": "<GROUP_BY>",
+        "--performance": "boolean",
+        "--explain": "boolean",
+        "--explain-skipped": "boolean",
+        "--summary": "boolean",
+        "--ci": "boolean",
+        "--fail-on-issues": "boolean",
+        "--sarif-file": "<PATH>",
+        "--output-file": "<PATH>",
+        "--report-path-prefix": "<PREFIX>",
+        "--fail-on-regression": "boolean",
+        "--tolerance": "<TOLERANCE>",
+        "--regression-baseline": "<PATH>",
+        "--save-regression-baseline": "[<PATH>]",
+        "--dupes-mode": "<DUPES_MODE>",
+        "--dupes-near": "boolean",
+        "--dupes-threshold": "<DUPES_THRESHOLD>",
+        "--dupes-min-tokens": "<DUPES_MIN_TOKENS>",
+        "--dupes-min-lines": "<DUPES_MIN_LINES>",
+        "--dupes-min-occurrences": "<DUPES_MIN_OCCURRENCES>",
+        "--dupes-skip-local": "boolean",
+        "--dupes-cross-language": "boolean",
+        "--dupes-ignore-imports": "boolean",
+        "--dupes-no-ignore-imports": "boolean",
+        "--include-entry-exports": "boolean",
+        "--type-aware": "boolean",
+        "--no-type-aware": "boolean",
+        "--type-aware-project": "<PATH>",
+        "--type-aware-require": "<TYPE_AWARE_REQUIRE>",
+        "--help": "boolean"
+      }
+    },
+    "similar-discovery": {
+      "args": [
+        "similar-code",
+        "--help"
+      ],
+      "requiredUsage": "Usage: fallow similar-code",
+      "options": {
+        "--root": "<ROOT>",
+        "--config": "<CONFIG>",
+        "--allow-remote-extends": "boolean",
+        "--format": "<FORMAT>",
+        "--pretty": "boolean",
+        "--quiet": "boolean",
+        "--no-cache": "boolean",
+        "--threads": "<THREADS>",
+        "--changed-since": "<REF>",
+        "--diff-file": "<PATH>",
+        "--diff-stdin": "boolean",
+        "--workspace": "<WORKSPACE>",
+        "--changed-workspaces": "<REF>",
+        "--max-file-size": "<MB>",
+        "--explain": "boolean",
+        "--threshold": "<0..1>",
+        "--min-lines": "<N>",
+        "--top": "<N>",
+        "--file": "<PATH>",
+        "--output-file": "<PATH>",
+        "--help": "boolean"
+      }
+    },
+    "similar-inspect": {
+      "args": [
+        "similar-code",
+        "inspect",
+        "--help"
+      ],
+      "requiredUsage": "Usage: fallow similar-code inspect <CANDIDATE_ID> --candidates <PATH>",
+      "options": {
+        "--root": "<ROOT>",
+        "--config": "<CONFIG>",
+        "--allow-remote-extends": "boolean",
+        "--candidates": "<PATH>",
+        "--format": "<FORMAT>",
+        "--pretty": "boolean",
+        "--quiet": "boolean",
+        "--output-file": "<PATH>",
+        "--help": "boolean"
+      }
+    },
+    "similar-review": {
+      "args": [
+        "similar-code",
+        "review",
+        "--help"
+      ],
+      "requiredUsage": "Usage: fallow similar-code review --candidates <PATH> --verdicts <PATH>",
+      "options": {
+        "--candidates": "<PATH>",
+        "--verdicts": "<PATH>",
+        "--require-verdict-for-each-candidate": "boolean",
+        "--format": "<FORMAT>",
+        "--pretty": "boolean",
+        "--quiet": "boolean",
+        "--output-file": "<PATH>",
+        "--help": "boolean"
+      }
+    }
+  }
+}

--- a/tests/report-certification.test.mjs
+++ b/tests/report-certification.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile, rm } from "node:fs/promises";
+import { dirname } from "node:path";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+import { assertEvidenceSubset, projectHelp } from "../scripts/report-certification.mjs";
+
+const jiti = createJiti(import.meta.url);
+const { parseJson } = await jiti.import("../extensions/fallow/json.ts");
+const { buildFallowOverview } = await jiti.import("../extensions/fallow/overview.ts");
+const { getNormalizedFallowReport, allNormalizedFallowEntries } = await jiti.import("../extensions/fallow/normalized-report.ts");
+const { formatToolOutput } = await jiti.import("../extensions/fallow/output.ts");
+const frozen = JSON.parse(await readFile(new URL("./fixtures/fallow/reports-3.21.0.json", import.meta.url), "utf8"));
+
+function overview(id) {
+	const evidence = frozen.reports[id];
+	return buildFallowOverview(evidence.report, evidence.exitCode);
+}
+
+function mutateEvidence(change) {
+	const actual = structuredClone(frozen);
+	change(actual);
+	return actual;
+}
+
+describe("captured report and nested-command certification", () => {
+	it("binds offline evidence to the pinned version and reproducible project input", async () => {
+		const manifest = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+		const project = await readFile(new URL("./fixtures/fallow/report-project.json", import.meta.url));
+		assert.equal(frozen.version, manifest.devDependencies.fallow);
+		assert.equal(frozen.inputSha256, createHash("sha256").update(project).digest("hex"));
+		assertEvidenceSubset(frozen, frozen);
+	});
+
+	it("preserves every captured JSON document through parsing and complete-output storage", async () => {
+		for (const [id, evidence] of Object.entries(frozen.reports)) {
+			const parsed = parseJson(JSON.stringify(evidence.report), "");
+			assert.equal(parsed.parsed, true, id);
+			assert.deepEqual(parsed.data, evidence.report, id);
+			const result = await formatToolOutput(parsed, "/fixture", evidence.exitCode, true, "findings");
+			try {
+				assert.ok(result.fullOutputPath, id);
+				assert.deepEqual(JSON.parse(await readFile(result.fullOutputPath, "utf8")), evidence.report, id);
+				assert.ok(result.text.includes(result.fullOutputPath), id);
+				assert.ok(result.text.length < 12_000, `${id}: bounded model output`);
+			} finally {
+				if (result.fullOutputPath) await rm(dirname(result.fullOutputPath), { recursive: true, force: true });
+			}
+		}
+	});
+
+	it("normalizes real actionable export evidence without treating exit 1 as a crash", () => {
+		const view = overview("dead-code");
+		const report = getNormalizedFallowReport(view);
+		assert.equal(view.status, "warning");
+		assert.equal(report.findingCount, 1);
+		const [entry] = allNormalizedFallowEntries(report);
+		assert.equal(entry.path, "lib.js");
+		assert.equal(entry.line, 2);
+		assert.equal(entry.subject, "unused");
+		assert.equal(entry.action, "Remove the unused export from the public API");
+		assert.match(view.notes.join("\n"), /not a crashed command/);
+	});
+
+	it("keeps informational health scores out of empty finding counts", () => {
+		const view = overview("health");
+		const report = getNormalizedFallowReport(view);
+		assert.equal(view.status, "success");
+		assert.equal(report.findingCount, 0);
+		assert.equal(report.contextCount, 1);
+		assert.equal(allNormalizedFallowEntries(report)[0].role, "context");
+	});
+
+	it("retains pinned-model readiness and missing-input errors without proposing automatic setup", () => {
+		const status = overview("similar-status");
+		assert.equal(status.status, "warning");
+		assert.ok(status.stats.some((stat) => stat.label === "revision" && stat.value === frozen.reports["similar-status"].report.model_revision));
+		const missing = overview("similar-missing-model");
+		assert.equal(missing.status, "error");
+		assert.match(missing.notes.join("\n"), /does not download models/);
+		for (const id of ["coverage-missing-value", "inspect-missing-inputs", "review-missing-inputs"]) {
+			const view = overview(id);
+			assert.equal(view.status, "error", id);
+			assert.match(view.notes.join("\n"), /required/, id);
+			assert.doesNotMatch(view.notes.join("\n"), /No issues found/, id);
+		}
+	});
+
+	it("retains synthetic partial semantic evidence injected into a captured health report", async () => {
+		// Synthetic mutation, NOT evidence of a real companion/inference run.
+		const report = structuredClone(frozen.reports.health.report);
+		report._meta.type_aware = {
+			executed: true, identity: { completeness: "partial" },
+			type_coupling: { status: "partial", diagnostics: [{ message: "Fixture-only missing project" }] },
+		};
+		const result = await formatToolOutput(parseJson(JSON.stringify(report), ""), "/fixture", 0, true, "findings");
+		try {
+			assert.match(result.overview.notes.join("\n"), /advisory/);
+			assert.match(result.overview.notes.join("\n"), /evidence is partial/);
+			assert.deepEqual(JSON.parse(await readFile(result.fullOutputPath, "utf8")), report);
+		} finally {
+			await rm(dirname(result.fullOutputPath), { recursive: true, force: true });
+		}
+	});
+
+	it("identifies selected report schema and actionable-field drift, while accepting additive fields", () => {
+		for (const [change, message] of [
+			[(data) => { data.reports["dead-code"].report.schema_version = 99; }, /dead-code.report.schema_version/],
+			[(data) => { delete data.reports["dead-code"].report.unused_exports[0].path; }, /unused_exports.0.path/],
+			[(data) => { data.reports.health.report.findings = null; }, /health.report.findings/],
+			[(data) => { data.reports["similar-status"].report.model_ready = true; }, /similar-status.report.model_ready/],
+		]) assert.throws(() => assertEvidenceSubset(mutateEvidence(change), frozen), message);
+		const additive = mutateEvidence((data) => {
+			data.reports["dead-code"].report.future_field = { explanation: "additional evidence" };
+			data.help["similar-inspect"].options["--future-optional"] = "boolean";
+		});
+		assertEvidenceSubset(additive, frozen);
+	});
+
+	it("checks required nested usage and flag arity without claiming successful analysis", () => {
+		assert.match(frozen.help["similar-inspect"].requiredUsage, /<CANDIDATE_ID> --candidates <PATH>/);
+		assert.match(frozen.help["similar-review"].requiredUsage, /--candidates <PATH> --verdicts <PATH>/);
+		assert.equal(frozen.help["coverage-analyze"].options["--runtime-coverage"], "<PATH>");
+		for (const change of [
+			(data) => { data.help["coverage-analyze"].requiredUsage += " --new-input <PATH>"; },
+			(data) => { data.help["similar-review"].options["--verdicts"] = "boolean"; },
+			(data) => { delete data.help["similar-inspect"].options["--candidates"]; },
+		]) assert.throws(() => assertEvidenceSubset(mutateEvidence(change), frozen), /help\./);
+		assert.deepEqual(projectHelp("Usage: fallow fixture [OPTIONS] <TARGET>\n  -q, --quiet  Quiet\n      --input <PATH>  Input\n      --save [<PATH>]  Optional value\n"), {
+			requiredUsage: "Usage: fallow fixture <TARGET>",
+			options: { "--quiet": "boolean", "--input": "<PATH>", "--save": "[<PATH>]" },
+		});
+		assert.throws(() => projectHelp("no usage"), /missing Usage/);
+	});
+});

--- a/tests/schema-registry-check.test.mjs
+++ b/tests/schema-registry-check.test.mjs
@@ -85,6 +85,28 @@ describe("registry versus certified Fallow schema", () => {
 		assert.throws(() => assertRegistrySchema(frozen, [{ name: "coverage-analyze", cliPrefix: ["coverage", "missing"] }]), /unverified nested CLI prefix/);
 	});
 
+	it("rejects new required inputs without rejecting already supplied fixed flags", () => {
+		for (const [root, specName, flag] of [
+			["health", "health", "--new-input"],
+			["dead-code", "trace-export", "new_positional"],
+			["coverage", "coverage-analyze", "--new-input"],
+		]) {
+			const schema = changedSchema((data) => {
+				command(data, root).flags.push({ name: flag, type: "string", required: true });
+			});
+			assert.throws(() => assertRegistrySchema(schema, [getFallowToolCommandSpec(specName)]), /new required argument/);
+		}
+		const global = changedSchema((data) => { globalFlag(data, "--config").required = true; });
+		assert.throws(() => assertRegistrySchema(global, specs), /new required argument --config/);
+		const supplied = changedSchema((data) => { command(data, "fix").flags[0].required = true; });
+		assertRegistrySchema(supplied, [getFallowToolCommandSpec("fix-preview")]);
+		const managed = changedSchema((data) => {
+			globalFlag(data, "--quiet").required = true;
+			globalFlag(data, "--changed-since").required = true;
+		});
+		assertRegistrySchema(managed, [getFallowToolCommandSpec("check-changed")]);
+	});
+
 	it("allows additive commands, flags, issue types, formats, and version changes", () => {
 		const schema = changedSchema((data) => {
 			data.version = "99.0.0";


### PR DESCRIPTION
## Summary
Initial development-only certification slice for #83 (does not close it).

- Capture seven real JSON reports: actionable dead-code, empty health with context, isolated model readiness/missing-model failure, and three nested missing-input failures.
- Project four real nested help contracts to required Usage tokens and option value declarations.
- Recapture evidence during live smoke; compare known fields while allowing additive object fields/options.
- Exercise parsing, normalized actionable fields, finding/context counts, bounded output, and complete JSON retention offline.
- Test partial semantic retention through an explicitly synthetic mutation, not claimed as live companion evidence.
- Detect newly required schema inputs not already supplied by registry/managed arguments.

## Safety and provenance
The capture script uses a temporary project/home/config/cache and a restricted environment/PATH, verifies the pinned Fallow target, and never installs companions/models, runs setup/cache-clear/fixes, or requires credentials. The complete project input and its digest, CLI tokens, exit codes, normalized reports, normalization rules, and regeneration instructions are checked in. Two consecutive captures produced identical fixture SHA-256 hashes.

No extension runtime, dependency, peer, startup, configuration, or publication behavior changes.

## Validation
- 223/223 tests passing on Node 22.19 and Node 24
- Live Fallow smoke passing on both Node lines; final focused Node 22.19 tests and Node 24 live smoke rerun
- Coverage thresholds pass: 90.38% statements/lines, 86.89% branches, 89.04% functions
- Bundle, health, duplication, and dead-code checks pass without threshold findings, clone groups, or dead-code issues
- Production and full-tree audits: zero vulnerabilities
- Package contents and isolated Pi 0.84.3 RPC/print/JSON package smoke pass
- Token/performance benchmarks and baseline comparisons completed; no runtime performance change claimed
- git diff --check

## Deliberately remaining #83 scope
Successful coverage analysis needs the optional fallow-cov companion, absent from the current development package. Successful model-backed discovery and source-grounded inspect/review remain uncertified. Security, duplication, combined, and real partial report captures also remain follow-up work. Help and missing-input checks are not successful-analysis evidence.

Ready for independent review and CI; no release/tag/publication.