### PR TITLE
fix: normalize runtime coverage reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to Pi Fallow are documented here.
 - Added frozen capability-schema certification and mutation tests for every tool registry prefix, managed output flags, positional targets, and selected type-aware flags; the live CLI smoke suite shares these checks without adding runtime version constraints.
 - Updated the pinned Fallow compatibility target to 3.21.0 and re-certified the current command/schema, MCP-resource, type-aware, quality, and packaged host surfaces, including the 3.20 strict-exit and project-reference resolution changes plus the 3.21 runtime-coverage and hidden-source diagnostic fixes.
 
+### Fixed
+- Normalized `coverage-analyze` runtime findings, uncertainty discriminators, capture quality, provenance, blast radius, and importance into bounded output and the navigator, keeping informational context out of finding counts and incomplete evidence explicitly non-authoritative.
+
 ## [0.5.1] - 2026-08-29
 
 ### Changed

--- a/extensions/fallow/normalized-report.ts
+++ b/extensions/fallow/normalized-report.ts
@@ -350,7 +350,7 @@ function requireStorage(report: NormalizedFallowReport): NormalizedReportStorage
 function extractSemanticFields(raw: Record<string, any> | undefined): RetainedSemanticFields {
 	const source = asRecord(raw?.candidate) ?? raw;
 	return {
-		type: firstString(source, ["kind", "type", "issue_type", "rule_id"]),
+		type: firstString(source, ["kind", "type", "issue_type", "rule_id", "verdict"]),
 		id: firstString(source, ["candidate_id", "benchmark_id", "id", "finding_id"]),
 		severity: firstString(source, ["severity"]),
 		evidence: firstText(source, ["evidence", "reason", "rationale", "message", "description"]),

--- a/extensions/fallow/overview-section.ts
+++ b/extensions/fallow/overview-section.ts
@@ -1,0 +1,19 @@
+import type { FallowIssueLine, FallowOverviewSection } from "./types";
+
+export function appendContextSection(
+	sections: FallowOverviewSection[],
+	title: string,
+	entries: unknown[],
+	includeAllRaw: boolean,
+	inlineRawLimit: number,
+	buildItem: (entry: unknown, includeRaw: boolean) => FallowIssueLine,
+): void {
+	if (!entries.length) return;
+	sections.push({
+		title,
+		count: entries.length,
+		color: "accent",
+		role: "context",
+		items: entries.map((entry, index) => buildItem(entry, includeAllRaw || index < inlineRawLimit)),
+	});
+}

--- a/extensions/fallow/overview.ts
+++ b/extensions/fallow/overview.ts
@@ -1,5 +1,7 @@
 import { asRecord } from "./data";
 import { getNormalizedFallowReport, retainNormalizedFallowEntry } from "./normalized-report";
+import { appendContextSection } from "./overview-section";
+import { addRuntimeCoverageOverview, isRuntimeCoverageWarning } from "./runtime-coverage-report";
 import { addSimilarCodeOverview, isSimilarCodeWarning } from "./similar-code-report";
 import type { FallowIssueLine, FallowOverview, FallowOverviewSection } from "./types";
 
@@ -419,9 +421,9 @@ function symbolImpactTarget(target: Record<string, any>): string | undefined {
 }
 
 function addSymbolImpactSections(root: Record<string, any>, sections: FallowOverviewSection[], includeAllRaw: boolean): void {
-	appendSemanticContextSection(sections, "Direct consumers", asArray(root.direct_consumers), includeAllRaw, buildSymbolImpactEvidence);
-	appendSemanticContextSection(sections, "Affected files", asArray(root.affected_files), includeAllRaw, buildSymbolImpactEvidence);
-	appendSemanticContextSection(sections, "Targeted tests", asArray(root.targeted_tests), includeAllRaw, buildSymbolImpactEvidence);
+	appendContextSection(sections, "Direct consumers", asArray(root.direct_consumers), includeAllRaw, INLINE_RAW_DEFAULT, buildSymbolImpactEvidence);
+	appendContextSection(sections, "Affected files", asArray(root.affected_files), includeAllRaw, INLINE_RAW_DEFAULT, buildSymbolImpactEvidence);
+	appendContextSection(sections, "Targeted tests", asArray(root.targeted_tests), includeAllRaw, INLINE_RAW_DEFAULT, buildSymbolImpactEvidence);
 }
 
 function buildSymbolImpactEvidence(entry: unknown, includeRaw: boolean): FallowIssueLine {
@@ -447,23 +449,6 @@ function symbolImpactVia(evidence: Record<string, any>): string | undefined {
 	const via = asArray(evidence.via);
 	if (!via.length) return undefined;
 	return `via ${via.join(" → ")}`;
-}
-
-function appendSemanticContextSection(
-	sections: FallowOverviewSection[],
-	title: string,
-	entries: unknown[],
-	includeAllRaw: boolean,
-	buildItem: (entry: unknown, includeRaw: boolean) => FallowIssueLine,
-): void {
-	if (!entries.length) return;
-	sections.push({
-		title,
-		count: entries.length,
-		color: "accent",
-		role: "context",
-		items: entries.map((entry, index) => buildItem(entry, includeAllRaw || index < INLINE_RAW_DEFAULT)),
-	});
 }
 
 function addSymbolImpactWarning(status: unknown, notes: string[]): void {
@@ -512,7 +497,7 @@ function addTypeCouplingMetadata(
 	const files = asArray(coupling.files);
 	addIfDefinedStat(stats, "type coupling", coupling.status);
 	addIfDefinedStat(stats, "coupled files", files.length);
-	appendSemanticContextSection(sections, "Type coupling", files, includeAllRaw, buildTypeCouplingEvidence);
+	appendContextSection(sections, "Type coupling", files, includeAllRaw, INLINE_RAW_DEFAULT, buildTypeCouplingEvidence);
 	notes.push("Type-coupling evidence is advisory and does not change the health score.");
 }
 
@@ -819,6 +804,7 @@ export function buildFallowOverview(
 	addProjectIssuesMetadata(root, stats, title, notes);
 	addConfigStats(root, stats, title);
 	addOverviewSections(root, sections, title, includeAllRaw);
+	addRuntimeCoverageOverview(root, stats, sections, title, notes, includeAllRaw);
 	addSimilarCodeOverview(root, stats, sections, title, notes, includeAllRaw);
 	addSemanticEvidence(root, stats, sections, title, notes, includeAllRaw);
 	addFeatureFlags(root, sections, title, includeAllRaw);
@@ -872,6 +858,7 @@ function isFallowErrorState(root: Record<string, any>, exitCode: number): boolea
 
 function isFallowWarningState(root: Record<string, any>, sections: FallowOverviewSection[], exitCode: number): boolean {
 	return isSimilarCodeWarning(root)
+		|| isRuntimeCoverageWarning(root)
 		|| sections.some((section) => section.role !== "context" && section.items.length > 0)
 		|| exitCode === 1;
 }

--- a/extensions/fallow/runtime-coverage-report.ts
+++ b/extensions/fallow/runtime-coverage-report.ts
@@ -1,0 +1,294 @@
+import { asRecord } from "./data";
+import { retainNormalizedFallowEntry } from "./normalized-report";
+import { appendContextSection } from "./overview-section";
+import type { FallowIssueLine, FallowOverviewSection } from "./types";
+
+interface OverviewStat {
+	label: string;
+	value: string | number;
+}
+
+interface MutableTitle {
+	value: string;
+}
+
+const INLINE_RAW_LIMIT = 5;
+
+export function isRuntimeCoverageWarning(root: Record<string, any>): boolean {
+	const runtime = asRecord(root.runtime_coverage);
+	if (!runtime) return false;
+	const provenance = asRecord(runtime.provenance) ?? {};
+	return [
+		runtime.verdict !== "clean",
+		runtime.actionable === false,
+		array(runtime.warnings).length > 0,
+		provenance.stale === true,
+		Boolean(runtime.watermark),
+	].some(Boolean);
+}
+
+export function addRuntimeCoverageOverview(
+	root: Record<string, any>,
+	stats: OverviewStat[],
+	sections: FallowOverviewSection[],
+	title: MutableTitle,
+	notes: string[],
+	includeAllRaw: boolean,
+): void {
+	const runtime = asRecord(root.runtime_coverage);
+	if (!runtime) return;
+	applyRuntimeTitle(root.kind, title);
+	addRuntimeStats(runtime, stats);
+	addRuntimeFindings(runtime, sections, includeAllRaw);
+	addRuntimeContext(runtime, sections, includeAllRaw);
+	addRuntimeNotes(runtime, notes);
+}
+
+function applyRuntimeTitle(kind: unknown, title: MutableTitle): void {
+	if (kind === "coverage-analyze") title.value = "Fallow runtime coverage";
+	else if (kind === "health" && title.value === "Fallow") title.value = "Fallow health";
+}
+
+function addRuntimeStats(runtime: Record<string, any>, stats: OverviewStat[]): void {
+	const summary = record(runtime.summary);
+	const quality = record(summary.capture_quality);
+	const provenance = record(runtime.provenance);
+	const values: Array<[string, unknown]> = [
+		["runtime verdict", runtime.verdict],
+		["signals", stringList(runtime.signals)],
+		["data source", firstDefined(summary.data_source, provenance.data_source)],
+		["functions tracked", summary.functions_tracked],
+		["functions hit", summary.functions_hit],
+		["functions unhit", summary.functions_unhit],
+		["functions untracked", summary.functions_untracked],
+		["runtime coverage", percentage(summary.coverage_percent)],
+		["trace count", summary.trace_count],
+		["capture window", duration(quality.window_seconds)],
+		["production origin", provenance.is_production],
+		["actionable", booleanText(runtime.actionable)],
+	];
+	for (const [label, value] of values) addStat(stats, label, value);
+}
+
+function addRuntimeFindings(runtime: Record<string, any>, sections: FallowOverviewSection[], includeAllRaw: boolean): void {
+	const findings = array(runtime.findings);
+	if (!findings.length) return;
+	sections.push({
+		title: "Runtime coverage findings",
+		count: findings.length,
+		color: "warning",
+		items: findings.map((entry, index) => buildRuntimeFinding(entry, includeAllRaw || index < INLINE_RAW_LIMIT)),
+	});
+}
+
+function buildRuntimeFinding(entry: unknown, includeRaw: boolean): FallowIssueLine {
+	const finding = asRecord(entry) ?? {};
+	return withRaw({
+		label: text(finding.function) ?? text(finding.verdict) ?? "runtime finding",
+		path: text(finding.path),
+		line: number(finding.line),
+		meta: join([
+			text(finding.verdict), confidence(finding.confidence), invocations(finding.invocations),
+			trackingState(finding), observationVolume(finding),
+		]),
+		action: guardedRuntimeAction(finding),
+	}, finding, includeRaw);
+}
+
+function addRuntimeContext(runtime: Record<string, any>, sections: FallowOverviewSection[], includeAllRaw: boolean): void {
+	appendContextSection(sections, "Runtime hot paths", array(runtime.hot_paths), includeAllRaw, INLINE_RAW_LIMIT, buildHotPath);
+	appendContextSection(sections, "Runtime blast radius", array(runtime.blast_radius), includeAllRaw, INLINE_RAW_LIMIT, buildBlastRadius);
+	appendContextSection(sections, "Runtime importance", array(runtime.importance), includeAllRaw, INLINE_RAW_LIMIT, buildImportance);
+}
+
+function buildHotPath(entry: unknown, includeRaw: boolean): FallowIssueLine {
+	const item = asRecord(entry) ?? {};
+	return withRaw({
+		label: text(item.function) ?? "hot path",
+		path: text(item.path),
+		line: number(item.line),
+		meta: join([invocations(item.invocations), item.percentile === undefined ? undefined : `p${item.percentile}`]),
+		action: primaryAction(item),
+	}, item, includeRaw);
+}
+
+function buildBlastRadius(entry: unknown, includeRaw: boolean): FallowIssueLine {
+	const item = asRecord(entry) ?? {};
+	return withRaw({
+		label: text(item.function) ?? "blast radius",
+		path: text(item.file),
+		line: number(item.line),
+		meta: join([
+			text(item.risk_band), metric(item.caller_count, "caller", "callers"),
+			metric(item.caller_count_weighted_by_traffic, "weighted caller", "weighted callers"),
+		]),
+	}, item, includeRaw);
+}
+
+function buildImportance(entry: unknown, includeRaw: boolean): FallowIssueLine {
+	const item = asRecord(entry) ?? {};
+	return withRaw({
+		label: text(item.function) ?? "runtime importance",
+		path: text(item.file),
+		line: number(item.line),
+		meta: join([
+			item.importance_score === undefined ? undefined : `score ${item.importance_score}`,
+			invocations(item.invocations), metric(item.owner_count, "owner", "owners"),
+		]),
+		action: text(item.reason),
+	}, item, includeRaw);
+}
+
+function addRuntimeNotes(runtime: Record<string, any>, notes: string[]): void {
+	const summary = asRecord(runtime.summary) ?? {};
+	const quality = asRecord(summary.capture_quality) ?? {};
+	const provenance = asRecord(runtime.provenance) ?? {};
+	addProvenanceNote(provenance, notes);
+	addCaptureQualityNote(quality, notes);
+	addStalenessNote(provenance, notes);
+	addActionabilityNote(runtime, notes);
+	addAdvisoryNote(runtime, notes);
+	appendWarnings(runtime, notes);
+	addWatermarkNote(runtime, notes);
+}
+
+function addProvenanceNote(provenance: Record<string, any>, notes: string[]): void {
+	if (!Object.keys(provenance).length) return;
+	notes.push(`Runtime evidence source is ${provenance.data_source ?? "unknown"}; production origin is ${provenance.is_production ?? "unknown"}.`);
+}
+
+function addCaptureQualityNote(quality: Record<string, any>, notes: string[]): void {
+	if (!quality.lazy_parse_warning) return;
+	const ratio = typeof quality.untracked_ratio_percent === "number" ? `${quality.untracked_ratio_percent}%` : "an unknown percentage";
+	notes.push(`Capture quality warns that ${ratio} of functions were untracked.`);
+}
+
+function addStalenessNote(provenance: Record<string, any>, notes: string[]): void {
+	if (!provenance.stale) return;
+	notes.push(`Runtime evidence is stale under the report's ${provenance.stale_after_days ?? "configured"}-day cutoff.`);
+}
+
+function addActionabilityNote(runtime: Record<string, any>, notes: string[]): void {
+	if (runtime.actionable !== false) return;
+	notes.push(`Runtime evidence is not actionable: ${runtime.actionability_reason ?? runtime.actionability_verdict ?? "insufficient evidence"}.`);
+}
+
+function addAdvisoryNote(runtime: Record<string, any>, notes: string[]): void {
+	if (!array(runtime.findings).length) return;
+	notes.push("Runtime verdicts are advisory evidence, not deletion authorization; inspect or trace code and review capture quality before editing.");
+}
+
+function addWatermarkNote(runtime: Record<string, any>, notes: string[]): void {
+	if (runtime.watermark) notes.push(`Runtime coverage watermark: ${runtime.watermark}.`);
+}
+
+function appendWarnings(runtime: Record<string, any>, notes: string[]): void {
+	const warnings = array(runtime.warnings);
+	notes.push(...warnings.slice(0, 3).map(runtimeWarningMessage));
+	if (warnings.length > 3) notes.push(`${warnings.length - 3} additional runtime coverage warning(s) omitted.`);
+}
+
+function runtimeWarningMessage(warning: unknown): string {
+	const message = runtimeWarningRecordMessage(asRecord(warning));
+	if (message) return message;
+	return text(warning) ?? "Runtime coverage warning.";
+}
+
+function runtimeWarningRecordMessage(warning: Record<string, any> | undefined): string | undefined {
+	if (!warning) return undefined;
+	return text(warning.message) ?? text(warning.code);
+}
+
+function withRaw(item: FallowIssueLine, raw: Record<string, any>, includeRaw: boolean): FallowIssueLine {
+	retainNormalizedFallowEntry(item, raw);
+	if (includeRaw) item.raw = raw;
+	return item;
+}
+
+function guardedRuntimeAction(finding: Record<string, any>): string {
+	const suggested = primaryAction(finding);
+	const guard = runtimeActionGuard(finding);
+	return suggested ? `${guard} Suggested action: ${suggested}` : guard;
+}
+
+function runtimeActionGuard(finding: Record<string, any>): string {
+	if (finding.verdict === "coverage_unavailable") return "Coverage is unavailable; do not infer that this code is unused or safe to delete.";
+	if (asRecord(finding.discriminators)?.meets_observation_volume === false) return "Below the confidence floor—not proof of unused or delete safety; inspect or trace before editing.";
+	return "Inspect or trace and review capture quality before editing.";
+}
+
+function primaryAction(record: Record<string, any>): string | undefined {
+	const action = array(record.actions).map(asRecord).find(Boolean);
+	return text(action?.description) ?? text(action?.type);
+}
+
+function trackingState(finding: Record<string, any>): string | undefined {
+	const state = asRecord(finding.discriminators)?.tracking_state;
+	return state ? `tracking ${state}` : undefined;
+}
+
+function observationVolume(finding: Record<string, any>): string | undefined {
+	const discriminators = asRecord(finding.discriminators) ?? {};
+	const values = [discriminators.trace_count, discriminators.min_observation_volume];
+	if (values.some((value) => value === undefined)) return undefined;
+	const state = discriminators.meets_observation_volume === false ? "below floor" : "meets floor";
+	return `volume ${values[0]}/${values[1]} (${state})`;
+}
+
+function confidence(value: unknown): string | undefined {
+	return value ? `confidence ${value}` : undefined;
+}
+
+function invocations(value: unknown): string | undefined {
+	return typeof value === "number" ? metric(value, "invocation", "invocations") : undefined;
+}
+
+function metric(value: unknown, singular: string, plural: string): string | undefined {
+	return typeof value === "number" ? `${value} ${value === 1 ? singular : plural}` : undefined;
+}
+
+function booleanText(value: unknown): string | undefined {
+	return typeof value === "boolean" ? String(value) : undefined;
+}
+
+function percentage(value: unknown): string | undefined {
+	return typeof value === "number" ? `${value}%` : undefined;
+}
+
+function duration(value: unknown): string | undefined {
+	return typeof value === "number" ? `${value}s` : undefined;
+}
+
+function stringList(value: unknown): string | undefined {
+	const values = array(value).map(String);
+	return values.length ? values.join(", ") : undefined;
+}
+
+function addStat(stats: OverviewStat[], label: string, value: unknown): void {
+	if (typeof value === "string" || typeof value === "number") stats.push({ label, value });
+}
+
+function join(values: Array<string | undefined>): string | undefined {
+	const present = values.filter((value): value is string => Boolean(value));
+	return present.length ? present.join(" · ") : undefined;
+}
+
+function record(value: unknown): Record<string, any> {
+	return asRecord(value) ?? {};
+}
+
+function firstDefined(primary: unknown, fallback: unknown): unknown {
+	return primary === undefined ? fallback : primary;
+}
+
+function text(value: unknown): string | undefined {
+	return typeof value === "string" && value ? value : undefined;
+}
+
+function number(value: unknown): number | undefined {
+	return typeof value === "number" ? value : undefined;
+}
+
+function array(value: unknown): unknown[] {
+	return Array.isArray(value) ? value : [];
+}

--- a/tests/fallow-cov-certification.test.mjs
+++ b/tests/fallow-cov-certification.test.mjs
@@ -8,7 +8,10 @@ import { assertEvidenceSubset } from "../scripts/report-certification.mjs";
 
 const jiti = createJiti(import.meta.url);
 const { parseJson } = await jiti.import("../extensions/fallow/json.ts");
+const { getNormalizedFallowReport, allNormalizedFallowEntries } = await jiti.import("../extensions/fallow/normalized-report.ts");
 const { formatToolOutput } = await jiti.import("../extensions/fallow/output.ts");
+const { buildFallowOverview } = await jiti.import("../extensions/fallow/overview.ts");
+const { buildFallowPrompt } = await jiti.import("../extensions/fallow/prompt.ts");
 const frozen = JSON.parse(await readFile(new URL("./fixtures/fallow/coverage-report-3.21.0.json", import.meta.url), "utf8"));
 
 function changedEvidence(change) {
@@ -72,18 +75,134 @@ describe("optional fallow-cov certification", () => {
 		assert.equal(frozen.report.runtime_coverage.actionable, true);
 	});
 
+	it("normalizes actionable findings separately from runtime context", () => {
+		const overview = buildFallowOverview(frozen.report, frozen.exitCode);
+		const normalized = getNormalizedFallowReport(overview);
+		const entries = allNormalizedFallowEntries(normalized);
+		assert.equal(overview.title, "Fallow runtime coverage");
+		assert.equal(overview.status, "warning");
+		assert.equal(normalized.findingCount, 1);
+		assert.equal(normalized.contextCount, 3);
+		assert.deepEqual(entries.map((entry) => [entry.role, entry.section, entry.subject]), [
+			["finding", "Runtime coverage findings", "cold"],
+			["context", "Runtime blast radius", "observed"],
+			["context", "Runtime blast radius", "cold"],
+			["context", "Runtime importance", "observed"],
+		]);
+		assert.equal(entries[0].type, "safe_to_delete");
+		assert.equal(entries[0].id, "fallow:prod:c26fb3c4");
+		assert.match(entries[0].details, /volume 3\/5000 \(below floor\)/);
+		assert.match(entries[0].evidence, /"v8_tracking":"tracked"/);
+		assert.match(entries[0].action, /Below the confidence floor—not proof of unused or delete safety/);
+		assert.match(overview.notes.join("\n"), /not deletion authorization/);
+		assert.match(overview.notes.join("\n"), /production origin is unknown/);
+	});
+
+	it("does not turn unavailable coverage into delete-safety evidence", () => {
+		const report = structuredClone(frozen.report);
+		Object.assign(report.runtime_coverage, { verdict: "unknown", actionable: false });
+		Object.assign(report.runtime_coverage.findings[0], {
+			verdict: "coverage_unavailable", confidence: "none", invocations: null,
+			actions: [{ type: "review-runtime", description: "Collect a broader capture.", auto_fixable: false }],
+		});
+		const finding = allNormalizedFallowEntries(getNormalizedFallowReport(buildFallowOverview(report, 0)))[0];
+		assert.match(finding.action, /^Coverage is unavailable; do not infer/);
+		assert.match(finding.action, /Suggested action: Collect a broader capture/);
+	});
+
+	it("keeps clean runtime context informational", () => {
+		const report = structuredClone(frozen.report);
+		Object.assign(report.runtime_coverage, {
+			verdict: "clean", signals: [], findings: [], actionable: true,
+			hot_paths: [{ id: "fallow:hot:1", path: "target.js", function: "observed", line: 1, end_line: 1, invocations: 3, percentile: 100 }],
+		});
+		const normalized = getNormalizedFallowReport(buildFallowOverview(report, 0));
+		assert.equal(normalized.status, "success");
+		assert.equal(normalized.findingCount, 0);
+		assert.equal(normalized.contextCount, 4);
+		assert.equal(allNormalizedFallowEntries(normalized)[0].section, "Runtime hot paths");
+	});
+
+	it("keeps a non-actionable empty capture explicit instead of claiming no issues", () => {
+		const report = structuredClone(frozen.report);
+		Object.assign(report.runtime_coverage, {
+			verdict: "unknown", signals: [], findings: [], blast_radius: [], importance: [],
+			actionable: false, actionability_verdict: "insufficient_evidence", actionability_reason: "No tracked functions.",
+		});
+		Object.assign(report.runtime_coverage.summary, {
+			functions_tracked: 0, functions_hit: 0, functions_unhit: 0, functions_untracked: 2, coverage_percent: 0,
+		});
+		const overview = buildFallowOverview(report, 0);
+		const normalized = getNormalizedFallowReport(overview);
+		assert.equal(overview.title, "Fallow runtime coverage");
+		assert.equal(overview.status, "warning");
+		assert.equal(normalized.findingCount, 0);
+		assert.equal(normalized.contextCount, 0);
+		assert.match(overview.notes.join("\n"), /not actionable: No tracked functions/);
+		assert.doesNotMatch(overview.notes.join("\n"), /No issues found/);
+	});
+
+	it("bounds capture warnings and marks stale, low-quality evidence", () => {
+		const report = structuredClone(frozen.report);
+		report.runtime_coverage.summary.capture_quality.lazy_parse_warning = true;
+		report.runtime_coverage.summary.capture_quality.untracked_ratio_percent = 42;
+		report.runtime_coverage.provenance.stale = true;
+		report.runtime_coverage.warnings = Array.from({ length: 5 }, (_, index) => ({ code: `w${index}`, message: `warning ${index}` }));
+		const overview = buildFallowOverview(report, 0);
+		assert.equal(overview.status, "warning");
+		assert.match(overview.notes.join("\n"), /42% of functions were untracked/);
+		assert.match(overview.notes.join("\n"), /evidence is stale/);
+		assert.match(overview.notes.join("\n"), /warning 2/);
+		assert.doesNotMatch(overview.notes.join("\n"), /warning 3/);
+		assert.match(overview.notes.join("\n"), /2 additional runtime coverage warning/);
+	});
+
+	it("preserves health identity when runtime coverage is nested in a health report", () => {
+		const health = {
+			kind: "health", findings: [], summary: { files_analyzed: 1 },
+			runtime_coverage: structuredClone(frozen.report.runtime_coverage),
+		};
+		const overview = buildFallowOverview(health, 0);
+		assert.equal(overview.title, "Fallow health");
+		assert.equal(getNormalizedFallowReport(overview).findingCount, 1);
+	});
+
 	it("preserves complete sidecar JSON through existing parsing and bounded storage", async () => {
 		const parsed = parseJson(JSON.stringify(frozen.report), "");
 		assert.equal(parsed.parsed, true);
 		assert.deepEqual(parsed.data, frozen.report);
-		const result = await formatToolOutput(parsed, "/fixture", frozen.exitCode, true, "findings");
+		const [result, summaryResult, rawResult] = await Promise.all([
+			formatToolOutput(parsed, "/fixture", frozen.exitCode, true, "findings"),
+			formatToolOutput(parsed, "/fixture", frozen.exitCode, true, "summary"),
+			formatToolOutput(parsed, "/fixture", frozen.exitCode, true, "raw"),
+		]);
 		try {
-			assert.ok(result.fullOutputPath);
-			assert.deepEqual(JSON.parse(await readFile(result.fullOutputPath, "utf8")), frozen.report);
+			for (const output of [result, summaryResult, rawResult]) {
+				assert.ok(output.fullOutputPath);
+				assert.deepEqual(JSON.parse(await readFile(output.fullOutputPath, "utf8")), frozen.report);
+			}
 			assert.ok(result.text.includes(result.fullOutputPath));
 			assert.ok(result.text.length < 12_000);
+			assert.match(summaryResult.text, /^Fallow summary:\n/);
+			assert.match(summaryResult.text, /"finding_count":1/);
+			assert.match(summaryResult.text, /"context_count":3/);
+			assert.match(rawResult.text, /"runtime_coverage"/);
+			const detail = JSON.parse(result.text.slice("Fallow findings:\n".length));
+			assert.equal(detail.finding_count, 1);
+			assert.equal(detail.context_count, 3);
+			assert.equal(detail.findings[0].type, "safe_to_delete");
+			assert.equal(detail.findings[0].location.path, "target.js");
+			assert.match(detail.findings[0].details, /tracking never_called/);
+			const normalized = getNormalizedFallowReport(result.overview);
+			const finding = allNormalizedFallowEntries(normalized)[0];
+			const prompt = buildFallowPrompt({ findings: [{ sectionTitle: finding.section, item: result.overview.sections[0].items[0], normalized: finding }], detail: "compact" });
+			assert.match(prompt, /safe_to_delete.*target\.js:4.*cold/);
+			assert.match(prompt, /below floor/);
+			assert.match(prompt, /Below the confidence floor—not proof of unused or delete safety/);
 		} finally {
-			if (result.fullOutputPath) await rm(dirname(result.fullOutputPath), { recursive: true, force: true });
+			for (const path of new Set([result.fullOutputPath, summaryResult.fullOutputPath, rawResult.fullOutputPath])) {
+				if (path) await rm(dirname(path), { recursive: true, force: true });
+			}
 		}
 	});
 


### PR DESCRIPTION
## Summary
- recognize successful `coverage-analyze` envelopes and embedded health runtime coverage
- normalize runtime findings with verdict, confidence, evidence, discriminator floors, and guarded follow-up actions
- keep hot paths, blast radius, and importance as informational context
- surface capture/provenance/actionability warnings without treating runtime evidence as deletion authorization
- certify bounded summary/findings/raw output, prompt selection, complete retention, drift, empty, clean, stale, and unavailable states against the frozen Fallow 3.21 report

## Validation
- `npm run check`
- `npm run coverage`
- Node 22.19: `npm test`
- `npm run smoke:fallow`
- `fallow audit --format json --quiet`
- `fallow dead-code --format json --quiet`
- `fallow dupes --format json --quiet`
- `npm audit --audit-level=high`

Closes #87
