### PR TITLE
feat: add optional analysis overlay controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Pi Fallow are documented here.
 ## [Unreleased]
 
 ### Added
+- Added TUI-only Optional Analysis controls with separate Status, previewed/confirmed Setup, and Run actions for Similar Code and local runtime coverage; setup is cancellable, drift-checked, user-global, and unavailable to tools or non-interactive modes.
 - Added bounded, project-isolated `/fallow history` for reopening digest-validated session reports and conservatively comparing compatible runs as new, unchanged, resolved, or unavailable without retaining raw reports in memory or treating resolved findings as current work.
 - Added a command-aware TUI navigator action palette with safe inspect, explain, trace, symbol-impact, and architecture queries; action results return to preserved navigator state, while fix actions are limited to explicitly previewable project-wide dry runs and can never apply changes.
 - Added explicit opt-in semantic similar-code analysis across `/fallow` and `fallow_run`, with read-only status/discovery/inspect/review flows, reproducible model and input provenance, advisory source-grounded rendering, partial-phase and skip diagnostics, distinct cancellation/timeout metadata, a cold-run timeout allowance, and hard guards against model downloads or cache mutation.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use it when you want Pi to verify changes, review a PR, find dead code, inspect 
 - **Safe defaults:** JSON and quiet output are added when appropriate; complete output is saved to a temp file whenever transcript or navigator data omits fields, and released from retained engine state after formatting. Pi Fallow never automatically deletes saved reports.
 - **Cached CLI lookup:** resolves `FALLOW_BIN`, `fallow` from `PATH`, or a package-local installation once per project/session before falling back to `npx -y fallow`.
 - **Stable type-aware reports:** Fallow semantic symbol impact and advisory public-signature coupling can be requested through both Pi surfaces, with completeness and advisory status kept visible.
-- **Opt-in semantic similarity:** `/fallow similar-code` and `fallow_run(command: "similar-code")` expose Fallow's pinned local-model workflow without adding candidates to default checks or downloading model artifacts.
+- **Opt-in semantic similarity:** `/fallow similar-code` and `fallow_run(command: "similar-code")` expose Fallow's pinned local-model workflow without adding candidates to default checks; TUI setup remains a separate previewed and explicitly confirmed action.
 
 ## Installation
 
@@ -130,11 +130,17 @@ When `fallow_run` is active, its compact Pi prompt guidance tells the model to i
 
 `--type-aware-project` selects a TypeScript project and `--type-aware-require best-effort|complete` controls required completeness. Always inspect the returned type-aware completeness, omissions, and abstentions: incomplete evidence remains advisory and must not be treated as exact delete-safety proof. Fallow also supports `--baseline-mode count|identity` for health baselines and `--no-type-aware` to override config for a syntactic-only run.
 
+### Optional analysis controls
+
+In TUI mode, run `/fallow` and press `o` to open visible **Status**, **Setup**, and **Run** actions for Similar Code and Runtime Coverage. Opening the panel, selecting Status, changing finding selection, or choosing Run never installs anything. Setup first shows source, pinned version/revision, license, expected size, destination, exact command, and side effects, then requires a distinct confirmation. Setup progress is cancellable, complete setup output is saved under the OS temporary directory, and readiness is rechecked afterward. Similar Code Run visibly collects optional project-file scope, threshold, and result-limit controls before rechecking readiness. RPC, print, JSON, and `fallow_run` remain non-interactive and cannot install optional components.
+
+Runtime Coverage setup installs the exact `@fallow-cli/fallow-cov@0.4.1` with scripts disabled into Pi Fallow's user-global managed tools directory, not the project manifest or lockfile. The panel first reads `fallow coverage setup --json` and discloses—but does not execute—the plan's beacon, credential, project-file, or cloud steps. Run accepts only an explicitly selected local V8/Istanbul artifact, previews its resolved path, rechecks sidecar readiness after confirmation, passes the verified managed sidecar only to that child analysis process, and removes cloud-source/API credential variables from that child's environment. Continuous/cloud coverage and credentials remain excluded.
+
 ### Opt-in similar-code analysis
 
 `/fallow similar-code` and `fallow_run` with `command: "similar-code"` expose Fallow's semantic similar-code workflow explicitly. It is never part of `/fallow`, `/fallow issues`, audits, security checks, or automatic fixes. Raw candidates are unverified advisory leads—not deterministic clone findings or proof that a consolidation is safe. Check `completion.status`, phase skips, diagnostics, model provenance, both source locations, and enrichment availability before drawing conclusions. Only `completion.status: "complete"` makes an empty result conclusive for the admitted scope.
 
-Start with `/fallow similar-code status`. This reads no project source and reports the exact companion, pinned model identifier/revision, license, integrity state, download size, cache directory, and readiness. Pi Fallow never runs `similar-code setup` or cache mutation and never downloads a model or sidecar. After reviewing those details, a user who chooses to install the pinned model must run `fallow similar-code setup --local` directly outside Pi Fallow.
+Start with `/fallow similar-code status`, or use the TUI Optional Analysis Status action. This reads no project source and reports the exact companion, pinned model identifier/revision, license, integrity state, download size, cache directory, and readiness. Slash arguments and tools cannot run setup or cache mutation. Only the TUI Setup action may delegate to `fallow similar-code setup --local --yes`, after showing the exact pinned preview and receiving direct user confirmation.
 
 Inference uses Fallow's version-pinned local companion and reports whether source left the machine; the current contract requires local-only source processing. Model vectors live in Fallow's user-local, project-namespaced cache, while saved candidate reports remain independent JSON documents for reproducible inspect/review steps. Cold inference can take minutes and currently requires roughly the download size reported by `similar-code status` (about 310 MiB for Fallow 3.21); warm cached runs should be faster but remain project- and hardware-dependent. Pi Fallow allows up to 15 minutes by default for this explicit command, while cancellation and `FALLOW_TIMEOUT_SECS` or tool `timeoutSecs` overrides remain available.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,7 +34,8 @@ The long measurement history belongs in the benchmark documentation rather than 
 - a typed command registry shared by tool, slash, autocomplete, and smoke-test surfaces, including architecture-to-`guard` support;
 - authoritative normalized-report selection shared across output and prompts, with complete-report hydration and drift protection;
 - bounded, project-isolated session history with digest-validated report reopening and conservative compatible-run comparison;
-- explicit opt-in semantic similar-code status, discovery, inspect, and review flows with local-model provenance, advisory completion, and mutation guards; and
+- explicit opt-in semantic similar-code status, discovery, inspect, and review flows with local-model provenance and advisory completion, plus TUI-only previewed and confirmed model setup;
+- visible Optional Analysis Status / Setup / Run controls for Similar Code and selected local runtime-coverage artifacts, with verified user-global sidecars and no project or cloud mutation; and
 - an issue-focused default that combines actionable dead-code, duplication, health, and security candidates without flooding the navigator with informational file scores or hotspots.
 
 See [`benchmarks/README.md`](./benchmarks/README.md), [`benchmarks/PERFORMANCE.md`](./benchmarks/PERFORMANCE.md), [`CHANGELOG.md`](./CHANGELOG.md), and the [README compatibility section](./README.md#tested-compatibility) for authoritative detail.

--- a/extensions/fallow.ts
+++ b/extensions/fallow.ts
@@ -6,12 +6,18 @@ import { runFallowCommandHandler } from "./fallow/command/handler";
 import { fallowArgumentHint } from "./fallow/registry";
 import type { FallowCommandState } from "./fallow/command/types";
 import { createFallowHistoryState } from "./fallow/history";
+import { createOptionalAnalysisState } from "./fallow/optional-analysis";
 import { registerFallowSessionStart } from "./fallow/session";
 import { renderFallowMessageRenderer, renderFallowToolCall, renderFallowToolResult } from "./fallow/tool-render";
 import { renderFallowAboutMessage } from "./fallow/update-notice";
 
 export default function (pi: ExtensionAPI) {
-	const commandState: FallowCommandState = { lastArgs: null, baseRefs: new Map(), history: createFallowHistoryState() };
+	const commandState: FallowCommandState = {
+		lastArgs: null,
+		baseRefs: new Map(),
+		history: createFallowHistoryState(),
+		optionalAnalysis: createOptionalAnalysisState(),
+	};
 	registerFallowTool(pi);
 	registerFallowCommand(pi, commandState);
 	registerFallowResultRenderer(pi);

--- a/extensions/fallow/cli.ts
+++ b/extensions/fallow/cli.ts
@@ -466,8 +466,15 @@ function isRecord(value: unknown): value is Record<string, any> {
 
 const fallowRunner = createFallowRunner();
 
-function execFallow(pi: ExtensionAPI, args: string[], cwd: string, signal: AbortSignal | undefined, timeoutSecs: number) {
-	return fallowRunner.execute(pi, args, cwd, signal, timeoutSecs);
+function execFallow(
+	pi: ExtensionAPI,
+	args: string[],
+	cwd: string,
+	signal: AbortSignal | undefined,
+	timeoutSecs: number,
+	environment?: NodeJS.ProcessEnv,
+) {
+	return fallowRunner.execute(pi, args, cwd, signal, timeoutSecs, environment);
 }
 
 function clearRunnerCache(pi: ExtensionAPI): void {

--- a/extensions/fallow/command/handler.ts
+++ b/extensions/fallow/command/handler.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { fallowCli } from "../cli";
 import { recordFallowHistory } from "../history";
+import { OPTIONAL_ANALYSIS_COMMAND } from "../optional-analysis";
 import { detectFallowBaseRef } from "../project/git";
 import type { FallowNavigatorResult, FallowNavigatorState } from "../types";
 import { sendFallowAboutMessage } from "../update-notice";
@@ -9,6 +10,7 @@ import { resolveFallowCommandBaseRef } from "./base";
 import { executeFallowHistoryCommand } from "./history";
 import { isFallowTuiMode } from "./mode";
 import { runFallowNavigatorLoop } from "./navigator-loop";
+import { runOptionalAnalysisWorkflow } from "./optional-analysis";
 import { executeFallowResult } from "./result-flow";
 import type { FallowCommandContext, FallowCommandState } from "./types";
 
@@ -75,8 +77,8 @@ async function executeFallowCommandLoop(
 	commandState: FallowCommandState,
 	initialArgs: string[],
 ): Promise<FallowNavigatorResult | null | undefined> {
-	return runFallowNavigatorLoop(initialArgs, isFallowTuiMode(ctx.mode), (args, rememberLast, initialState, protectedHistoryIds) => (
-		runFallowCommandOnce(pi, ctx, commandState, args, rememberLast, initialState, protectedHistoryIds)
+	return runFallowNavigatorLoop(initialArgs, isFallowTuiMode(ctx.mode), (args, rememberLast, initialState, protectedHistoryIds, executionEnvironment) => (
+		runFallowCommandOnce(pi, ctx, commandState, args, rememberLast, initialState, protectedHistoryIds, executionEnvironment)
 	));
 }
 
@@ -88,7 +90,9 @@ function runFallowCommandOnce(
 	rememberLast: boolean,
 	initialNavigatorState?: FallowNavigatorState,
 	protectedHistoryIds?: string[],
+	executionEnvironment?: NodeJS.ProcessEnv,
 ): Promise<FallowNavigatorResult | null | undefined> {
+	if (args[0] === OPTIONAL_ANALYSIS_COMMAND) return runOptionalAnalysisWorkflow(pi, ctx, commandState.optionalAnalysis);
 	if (args[0] === "history") {
 		return executeFallowHistoryCommand(pi, ctx, commandState.history, args, initialNavigatorState);
 	}
@@ -96,7 +100,7 @@ function runFallowCommandOnce(
 		commandState.lastArgs = updated;
 	}, initialNavigatorState, initialNavigatorState ? undefined : (result, commandArgs) => (
 		recordFallowHistory(pi, commandState.history, ctx.cwd, result, protectedHistoryIds, commandArgs)
-	));
+	), executionEnvironment);
 }
 
 function applyFallowPrompt(ctx: FallowCommandContext, result: FallowNavigatorResult | null | undefined): void {

--- a/extensions/fallow/command/loader.ts
+++ b/extensions/fallow/command/loader.ts
@@ -3,6 +3,7 @@ import { BorderedLoader } from "@earendil-works/pi-coding-agent";
 import { fallowCli } from "../cli";
 import { fallowPurple } from "../colors";
 import { fallowEngine } from "../engine";
+import { settleCancellableTask } from "../process";
 import { isSimilarCodeCommand, SIMILAR_CODE_DEFAULT_TIMEOUT_SECS } from "../similar-code";
 import { isFallowTuiMode } from "./mode";
 import type { FallowCommandContext } from "./types";
@@ -26,6 +27,7 @@ export function buildFallowExecutor(
 	ctx: FallowCommandContext,
 	args: string[],
 	executor = fallowCli.execFallow,
+	environment?: NodeJS.ProcessEnv,
 ): FallowCommandExecutor {
 	const timeoutSecs = resolveFallowCommandTimeout(args);
 	return (signal?: AbortSignal) => fallowEngine.runFallowWithExecutor({
@@ -34,7 +36,7 @@ export function buildFallowExecutor(
 		args,
 		signal: signal ?? ctx.signal,
 		timeoutSecs,
-		executor,
+		executor: (host, commandArgs, cwd, signal, commandTimeout) => executor(host, commandArgs, cwd, signal, commandTimeout, environment),
 		throwOnExecutionError: false,
 		preserveNavigatorDetails: true,
 	});
@@ -45,9 +47,7 @@ export async function runFallowWithLoaderIfUi(
 	executeCommand: FallowCommandExecutor,
 	finalArgs: string[],
 ): Promise<NullableFallowCommandResult> {
-	if (isFallowTuiMode(ctx.mode)) {
-		return runFallowWithLoader(ctx, executeCommand, finalArgs).finally(() => clearFallowStatus(ctx));
-	}
+	if (isFallowTuiMode(ctx.mode)) return runFallowWithLoader(ctx, executeCommand, finalArgs);
 	if (!ctx.hasUI) return executeCommand();
 	ctx.ui.setStatus("fallow", "fallow running…");
 	return executeCommand(ctx.signal).finally(() => clearFallowStatus(ctx));
@@ -62,19 +62,27 @@ function runFallowWithLoader(
 	executeCommand: FallowCommandExecutor,
 	args: string[],
 ): Promise<NullableFallowCommandResult> {
+	const displayArgs = args.length ? args.join(" ") : "all";
+	return runFallowTaskWithLoader(ctx, `Running fallow ${displayArgs}...`, executeCommand);
+}
+
+export function runFallowTaskWithLoader<T>(
+	ctx: FallowCommandContext,
+	label: string,
+	execute: (signal: AbortSignal) => Promise<T>,
+): Promise<T | null> {
 	ctx.ui.setStatus("fallow", "fallow running…");
-	return ctx.ui.custom<NullableFallowCommandResult>((_tui, theme, _keybindings, done) => {
-		const displayArgs = args.length ? args.join(" ") : "all";
-		const loaderTheme = buildFallowLoaderTheme(theme);
-		const loader = new BorderedLoader(_tui, loaderTheme, `Running fallow ${displayArgs}...`);
+	return ctx.ui.custom<T | null>((tui, theme, _keybindings, done) => {
+		const loader = new BorderedLoader(tui, buildFallowLoaderTheme(theme), label);
 		const finish = once(done);
-		loader.onAbort = () => finish(null);
-		executeCommand(loader.signal).then(finish, (error) => {
+		let aborted = false;
+		loader.onAbort = () => { aborted = true; };
+		settleCancellableTask(execute, loader.signal, () => aborted).then(finish, (error) => {
 			ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
 			finish(null);
 		});
 		return loader;
-	});
+	}).finally(() => clearFallowStatus(ctx));
 }
 
 function buildFallowLoaderTheme(theme: any): any {

--- a/extensions/fallow/command/mode.ts
+++ b/extensions/fallow/command/mode.ts
@@ -6,7 +6,7 @@ export function isFallowTuiMode(mode: FallowRunMode): boolean {
 	return mode === "tui";
 }
 
-export function hasFallowNavigator(mode: FallowRunMode, overview: FallowOverview | undefined): boolean {
+export function hasFallowNavigator(mode: FallowRunMode, overview: FallowOverview | undefined, optionalAnalysis = false): boolean {
 	if (!isFallowTuiMode(mode)) return false;
-	return resolveFallowNavigatorMode(overview) !== "none";
+	return resolveFallowNavigatorMode(overview, optionalAnalysis) !== "none";
 }

--- a/extensions/fallow/command/navigator-loop.ts
+++ b/extensions/fallow/command/navigator-loop.ts
@@ -5,6 +5,7 @@ export type FallowNavigatorRunOnce = (
 	rememberLast: boolean,
 	initialState?: FallowNavigatorState,
 	protectedHistoryIds?: string[],
+	executionEnvironment?: NodeJS.ProcessEnv,
 ) => Promise<FallowNavigatorResult | null | undefined>;
 
 export async function runFallowNavigatorLoop(
@@ -23,6 +24,7 @@ async function continueNavigatorLoop(
 	runOnce: FallowNavigatorRunOnce,
 ): Promise<FallowNavigatorResult | null | undefined> {
 	if (isActionResult(result)) return runAction(result, returnStack, runOnce);
+	if (isForwardResult(result)) return runForward(result, returnStack, runOnce);
 	if (isPromptResult(result)) return result;
 	return returnToPreviousNavigator(result, returnStack, runOnce);
 }
@@ -35,6 +37,15 @@ async function runAction(
 	const nextStack = [...returnStack, result.returnTo];
 	const actionResult = await runOnce(result.commandArgs, false, undefined, protectedHistoryIds(nextStack));
 	return continueNavigatorLoop(actionResult, nextStack, runOnce);
+}
+
+async function runForward(
+	result: Extract<FallowNavigatorResult, { type: "forward" }>,
+	returnStack: FallowNavigatorReturnTarget[],
+	runOnce: FallowNavigatorRunOnce,
+): Promise<FallowNavigatorResult | null | undefined> {
+	const forwarded = await runOnce(result.commandArgs, false, undefined, protectedHistoryIds(returnStack), result.executionEnvironment);
+	return continueNavigatorLoop(forwarded, returnStack, runOnce);
 }
 
 async function returnToPreviousNavigator(
@@ -52,6 +63,12 @@ function isActionResult(
 	result: FallowNavigatorResult | null | undefined,
 ): result is Extract<FallowNavigatorResult, { type: "action" }> {
 	return result?.type === "action";
+}
+
+function isForwardResult(
+	result: FallowNavigatorResult | null | undefined,
+): result is Extract<FallowNavigatorResult, { type: "forward" }> {
+	return result?.type === "forward";
 }
 
 function isPromptResult(

--- a/extensions/fallow/command/navigator.ts
+++ b/extensions/fallow/command/navigator.ts
@@ -22,9 +22,10 @@ export function resolveFallowNavigatorVisibleRows(terminalRows: number, informat
 	return Math.max(MIN_VISIBLE_ROWS, Math.min(MAX_VISIBLE_ROWS, overlayRows - staticRows));
 }
 
-export function resolveFallowNavigatorMode(overview: FallowOverview | undefined): FallowNavigatorMode {
+export function resolveFallowNavigatorMode(overview: FallowOverview | undefined, optionalAnalysis = false): FallowNavigatorMode {
 	if (!overview) return "none";
 	const report = getNormalizedFallowReport(overview);
-	if (!report.entryCount) return "none";
-	return report.findingCount ? "actionable" : "informational";
+	if (![report.entryCount > 0, optionalAnalysis].some(Boolean)) return "none";
+	if (report.findingCount > 0) return "actionable";
+	return "informational";
 }

--- a/extensions/fallow/command/optional-analysis.ts
+++ b/extensions/fallow/command/optional-analysis.ts
@@ -1,0 +1,586 @@
+import { isAbsolute, relative, resolve } from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { fallowCli } from "../cli";
+import { parseJson } from "../json";
+import {
+	artifactDisplayName,
+	capabilityLabel,
+	createOptionalAnalysisState,
+	inspectRuntimeCoverageCapability,
+	parseCoverageSetupPlan,
+	parseSimilarCodeCapability,
+	resolveLocalArtifact,
+	saveOptionalSetupOutput,
+	runtimeCoverageInstallArgs,
+	runtimeCoverageSetupPreview,
+	runtimeCoverageStatusLines,
+	similarCodeSetupPreview,
+	similarCodeStatusLines,
+	FALLOW_COV_VERSION,
+	type CapabilityPhase,
+	type OptionalAnalysisState,
+	type RuntimeCoverageCapability,
+	type SimilarCodeCapability,
+} from "../optional-analysis";
+import { SIMILAR_CODE_DEFAULT_TIMEOUT_SECS } from "../similar-code";
+import type { FallowNavigatorResult } from "../types";
+import { runFallowTaskWithLoader } from "./loader";
+import type { FallowCommandContext } from "./types";
+
+interface RawCommandResult {
+	result: {
+		stdout: string;
+		stderr: string;
+		code: number;
+		killed?: boolean;
+		terminationReason?: string;
+	};
+}
+
+interface ProcessResult {
+	stdout: string;
+	stderr: string;
+	code: number;
+	killed?: boolean;
+	terminationReason?: string;
+}
+
+export interface OptionalAnalysisDependencies {
+	runFallow(args: string[], label: string, timeoutSecs?: number): Promise<RawCommandResult | null>;
+	runProcess(command: string, args: string[], label: string, timeoutSecs?: number): Promise<ProcessResult | null>;
+	inspectRuntime(plan?: unknown): Promise<RuntimeCoverageCapability>;
+	resolveArtifact(path: string): Promise<string>;
+	saveSetupOutput(stdout: string, stderr: string): Promise<string>;
+}
+
+interface OptionalChoice {
+	id: "similar-status" | "similar-setup" | "similar-run" | "coverage-status" | "coverage-setup" | "coverage-run" | "back";
+	label: string;
+}
+
+export async function runOptionalAnalysisWorkflow(
+	pi: ExtensionAPI,
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState = createOptionalAnalysisState(),
+	providedDependencies?: OptionalAnalysisDependencies,
+): Promise<FallowNavigatorResult | null> {
+	if (ctx.mode !== "tui") return null;
+	return runTuiOptionalAnalysis(ctx, state, providedDependencies ?? createDependencies(pi, ctx));
+}
+
+async function runTuiOptionalAnalysis(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<FallowNavigatorResult | null> {
+	while (true) {
+		const choices = buildOptionalChoices(state);
+		const selected = await ctx.ui.select(buildPanelTitle(state), choices.map((choice) => choice.label));
+		const choice = actionableChoice(choices.find((entry) => entry.label === selected));
+		if (!choice) return null;
+		const result = await applyChoice(choice.id, ctx, state, dependencies);
+		if (result) return result;
+	}
+}
+
+function actionableChoice(choice: OptionalChoice | undefined): OptionalChoice | undefined {
+	if (!choice || choice.id === "back") return undefined;
+	return choice;
+}
+
+function buildOptionalChoices(state: OptionalAnalysisState): OptionalChoice[] {
+	const similar = stateCapabilityLabel(state.similarCode);
+	const coverage = stateCapabilityLabel(state.runtimeCoverage);
+	return [
+		{ id: "similar-status", label: `Similar Code · Status [${similar}]` },
+		{ id: "similar-setup", label: "Similar Code · Setup (preview + confirmation)" },
+		{ id: "similar-run", label: `Similar Code · Run${runAvailabilityLabel(similar)}` },
+		{ id: "coverage-status", label: `Runtime Coverage · Status [${coverage}]` },
+		{ id: "coverage-setup", label: "Runtime Coverage · Setup (local sidecar preview + confirmation)" },
+		{ id: "coverage-run", label: `Runtime Coverage · Run local artifact${runAvailabilityLabel(coverage)}` },
+		{ id: "back", label: "Back to Fallow results" },
+	];
+}
+
+function stateCapabilityLabel(capability: { phase: CapabilityPhase } | undefined): string {
+	return capabilityLabel(capability?.phase);
+}
+
+function runAvailabilityLabel(phase: string): string {
+	return phase === "ready" ? "" : " (requires ready status)";
+}
+
+function buildPanelTitle(state: OptionalAnalysisState): string {
+	return [
+		"Optional analysis — Status / Setup / Run",
+		"Opening this panel or selecting Status never installs anything. Setup always shows a separate preview and confirmation.",
+		...similarCodeStatusLines(state.similarCode),
+		...runtimeCoverageStatusLines(state.runtimeCoverage),
+		`Similar Code options: ${similarCodeOptionsLabel(state.similarCodeArgs)}`,
+		`Runtime artifact: ${artifactDisplayName(state.artifactPath)}`,
+		...completeSetupOutputLines(state.completeSetupOutputPath),
+		...noticeLines(state.notice),
+	].join("\n");
+}
+
+function similarCodeOptionsLabel(args: string[] | undefined): string {
+	if (!args?.length) return "project defaults";
+	return args.join(" ").replace(/[\u0000-\u001f\u007f-\u009f]/gu, "�");
+}
+
+function completeSetupOutputLines(path: string | undefined): string[] {
+	return path ? [`Complete setup output: ${artifactDisplayName(path)}`] : [];
+}
+
+function noticeLines(notice: string | undefined): string[] {
+	return notice ? [`Result: ${notice}`] : [];
+}
+
+async function applyChoice(
+	choice: OptionalChoice["id"],
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<FallowNavigatorResult | null> {
+	state.notice = undefined;
+	const handlers: Record<OptionalChoice["id"], () => Promise<FallowNavigatorResult | null>> = {
+		"similar-status": () => refreshSimilarCode(state, dependencies).then(() => null),
+		"similar-setup": () => setupSimilarCode(ctx, state, dependencies).then(() => null),
+		"similar-run": () => runSimilarCode(ctx, state, dependencies),
+		"coverage-status": () => refreshRuntimeCoverage(state, dependencies).then(() => null),
+		"coverage-setup": () => setupRuntimeCoverage(ctx, state, dependencies).then(() => null),
+		"coverage-run": () => runRuntimeCoverage(ctx, state, dependencies),
+		back: async () => null,
+	};
+	return handlers[choice]();
+}
+
+async function refreshSimilarCode(
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<SimilarCodeCapability | undefined> {
+	const execution = await dependencies.runFallow(
+		["similar-code", "status", "--format", "json", "--quiet"],
+		"Checking Similar Code readiness...",
+		120,
+	);
+	if (!execution) {
+		state.notice = "Similar Code status cancelled; no setup was performed.";
+		return undefined;
+	}
+	const parsed = parseJson(execution.result.stdout, execution.result.stderr);
+	state.similarCode = parseSimilarCodeCapability(parsed.parsed ? parsed.data : undefined);
+	if (execution.result.code >= 2) state.similarCode = { ...state.similarCode, phase: "error", problem: commandFailure(execution.result) };
+	state.notice = `Similar Code status: ${state.similarCode.phase}.`;
+	return state.similarCode;
+}
+
+async function setupSimilarCode(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<void> {
+	state.completeSetupOutputPath = undefined;
+	const preview = await confirmedSimilarCodePreview(ctx, state, dependencies);
+	if (!preview) return;
+	const current = await refreshSimilarCode(state, dependencies);
+	if (!sameSimilarCodePreview(preview, current)) return setNotice(state, "Similar Code status changed after preview; setup was stopped. Review Status and preview again.");
+	await executeSimilarCodeSetup(state, dependencies);
+}
+
+async function confirmedSimilarCodePreview(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<SimilarCodeCapability | undefined> {
+	const preview = await eligibleSimilarCodePreview(state, dependencies);
+	if (!preview) return undefined;
+	const confirmed = await ctx.ui.confirm("Set up Similar Code?", similarCodeSetupPreview(preview));
+	return confirmed ? preview : setNotice(state, "Similar Code setup declined; no download was started.");
+}
+
+async function eligibleSimilarCodePreview(
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<SimilarCodeCapability | undefined> {
+	const preview = await refreshSimilarCode(state, dependencies);
+	if (!preview) return undefined;
+	if (preview.phase === "ready") return setNotice(state, "Similar Code is already ready; setup did not run.");
+	if (preview.phase !== "missing") return setNotice(state, `Similar Code setup is blocked for ${preview.phase} state. Review the status remediation; Pi Fallow will not overwrite or clear the model cache.`);
+	return preview;
+}
+
+function sameSimilarCodePreview(preview: SimilarCodeCapability, current: SimilarCodeCapability | undefined): boolean {
+	return current?.fingerprint === preview.fingerprint;
+}
+
+async function executeSimilarCodeSetup(
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<void> {
+	const setup = await dependencies.runFallow(
+		["similar-code", "setup", "--local", "--yes", "--format", "json", "--quiet"],
+		"Downloading and verifying the pinned Similar Code model...",
+		SIMILAR_CODE_DEFAULT_TIMEOUT_SECS,
+	);
+	await persistSetupOutput(setup, state, dependencies);
+	await refreshSimilarCode(state, dependencies);
+	if (!setup) return setNotice(state, "Similar Code setup was cancelled; Status was rechecked for partial state.");
+	if (setup.result.code >= 2) return setNotice(state, `Similar Code setup failed: ${commandFailure(setup.result)}`);
+	if (!similarCodeIsReady(state)) return setNotice(state, "Similar Code setup completed without verified readiness. Review Status remediation.");
+	setNotice(state, "Similar Code setup completed and pinned model integrity was verified.");
+}
+
+function similarCodeIsReady(state: OptionalAnalysisState): boolean {
+	return state.similarCode?.phase === "ready";
+}
+
+async function runSimilarCode(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<FallowNavigatorResult | null> {
+	const status = await refreshSimilarCode(state, dependencies);
+	if (!similarCodeReadyForRun(status, state)) return null;
+	const args = await selectSimilarCodeArgs(ctx, state);
+	if (!args) return null;
+	const current = await refreshSimilarCode(state, dependencies);
+	if (!sameSimilarCodePreview(status, current)) {
+		setNotice(state, "Similar Code status changed while selecting Run options; Run was stopped. Review Status and choose the options again.");
+		return null;
+	}
+	return { type: "forward", label: "Run Similar Code", commandArgs: ["similar-code", ...args] };
+}
+
+function similarCodeReadyForRun(
+	status: SimilarCodeCapability | undefined,
+	state: OptionalAnalysisState,
+): status is SimilarCodeCapability {
+	if (status?.phase === "ready") return true;
+	setNotice(state, "Similar Code Run is disabled until Status reports a ready, integrity-verified pinned model.");
+	return false;
+}
+
+async function selectSimilarCodeArgs(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+): Promise<string[] | undefined> {
+	const inputs = await promptSimilarCodeArgs(ctx, state);
+	if (!inputs) return undefined;
+	try {
+		state.similarCodeArgs = buildSimilarCodeArgs(ctx.cwd, inputs.scope, inputs.threshold, inputs.top);
+		return state.similarCodeArgs;
+	} catch (error) {
+		return setNotice(state, `Similar Code Run options are invalid: ${errorMessage(error)}`);
+	}
+}
+
+async function promptSimilarCodeArgs(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+): Promise<{ scope: string; threshold: string; top: string } | undefined> {
+	const scope = await ctx.ui.input("Similar Code scope", "Project-relative file, or blank for the whole project");
+	if (scope === undefined) return setNotice(state, "Similar Code Run cancelled before choosing scope.");
+	const threshold = await ctx.ui.input("Similar Code threshold", "0..1, or blank for the Fallow default");
+	if (threshold === undefined) return setNotice(state, "Similar Code Run cancelled before choosing a threshold.");
+	const top = await ctx.ui.input("Similar Code result limit", "Positive integer, or blank for the Fallow default");
+	if (top === undefined) return setNotice(state, "Similar Code Run cancelled before choosing a result limit.");
+	return { scope, threshold, top };
+}
+
+function buildSimilarCodeArgs(projectRoot: string, scope: string, threshold: string, top: string): string[] {
+	return [
+		...similarScopeArgs(projectRoot, scope.trim()),
+		...numericOptionArgs("--threshold", threshold.trim(), 0, 1, false),
+		...numericOptionArgs("--top", top.trim(), 1, 100_000, true),
+	];
+}
+
+function similarScopeArgs(projectRoot: string, scope: string): string[] {
+	if (!scope) return [];
+	const target = resolve(projectRoot, scope);
+	const invalid = [isAbsolute(scope), /^[a-z][a-z0-9+.-]*:\/\//iu.test(scope), scope.startsWith("-"), /[\u0000-\u001f\u007f-\u009f]/u.test(scope), !isPathWithin(projectRoot, target)].some(Boolean);
+	if (invalid) throw new Error("scope must be a project-relative local path");
+	const projectPath = relative(resolve(projectRoot), target);
+	if (!projectPath) throw new Error("leave scope blank to analyze the whole project");
+	return ["--file", projectPath];
+}
+
+function numericOptionArgs(flag: string, value: string, minimum: number, maximum: number, integer: boolean): string[] {
+	if (!value) return [];
+	const parsed = Number(value);
+	const valid = [Number.isFinite(parsed), parsed >= minimum, parsed <= maximum, validNumberKind(parsed, integer)].every(Boolean);
+	if (!valid) throw new Error(`${flag} must be ${integer ? "an integer " : ""}between ${minimum} and ${maximum}`);
+	return [flag, value];
+}
+
+function validNumberKind(value: number, integer: boolean): boolean {
+	return integer ? Number.isInteger(value) : true;
+}
+
+async function refreshRuntimeCoverage(
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<RuntimeCoverageCapability | undefined> {
+	const execution = await dependencies.runFallow(
+		["coverage", "setup", "--json", "--root", "."],
+		"Reading the runtime coverage setup plan...",
+		120,
+	);
+	if (!execution) {
+		state.notice = "Runtime Coverage status cancelled; no setup was performed.";
+		return undefined;
+	}
+	return applyRuntimeCoverageStatus(execution, state, dependencies);
+}
+
+async function applyRuntimeCoverageStatus(
+	execution: RawCommandResult,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<RuntimeCoverageCapability> {
+	try {
+		state.runtimeCoverage = await dependencies.inspectRuntime(runtimePlanFromExecution(execution));
+		state.notice = `Runtime Coverage status: ${state.runtimeCoverage.phase}.`;
+	} catch (error) {
+		const inspected = await dependencies.inspectRuntime();
+		state.runtimeCoverage = { ...inspected, phase: "error", problem: errorMessage(error) };
+		state.notice = "Runtime Coverage status failed; no setup was performed.";
+	}
+	return state.runtimeCoverage;
+}
+
+function runtimePlanFromExecution(execution: RawCommandResult): unknown {
+	if (execution.result.code >= 2) throw new Error(commandFailure(execution.result));
+	const parsed = parseJson(execution.result.stdout, execution.result.stderr);
+	return parseCoverageSetupPlan(parsed.parsed ? parsed.data : undefined);
+}
+
+async function setupRuntimeCoverage(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<void> {
+	state.completeSetupOutputPath = undefined;
+	const preview = await confirmedRuntimeCoveragePreview(ctx, state, dependencies);
+	if (!preview) return;
+	const current = await refreshRuntimeCoverage(state, dependencies);
+	if (!sameRuntimePreview(preview, current)) return setNotice(state, "Runtime Coverage status or Fallow setup plan changed after preview; installation was stopped. Review Status and preview again.");
+	await executeRuntimeCoverageSetup(preview, state, dependencies);
+}
+
+async function confirmedRuntimeCoveragePreview(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<RuntimeCoverageCapability | undefined> {
+	const preview = await eligibleRuntimeCoveragePreview(ctx.cwd, state, dependencies);
+	if (!preview) return undefined;
+	const confirmed = await ctx.ui.confirm("Install local Runtime Coverage sidecar?", runtimeCoverageSetupPreview(preview));
+	return confirmed ? preview : setNotice(state, "Runtime Coverage setup declined; no installation was started.");
+}
+
+async function eligibleRuntimeCoveragePreview(
+	projectRoot: string,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<RuntimeCoverageCapability | undefined> {
+	const preview = await refreshRuntimeCoverage(state, dependencies);
+	if (!preview) return undefined;
+	if (preview.phase === "ready") return setNotice(state, "Runtime Coverage sidecar is already ready; setup did not run.");
+	if (runtimeSetupBlocked(projectRoot, preview, state)) return undefined;
+	return preview;
+}
+
+function runtimeSetupBlocked(
+	projectRoot: string,
+	preview: RuntimeCoverageCapability,
+	state: OptionalAnalysisState,
+): boolean {
+	if (isPathWithin(projectRoot, preview.destination)) {
+		setNotice(state, "Runtime Coverage setup is blocked because the managed-tools destination resolves inside the project. Choose a user-global PI_FALLOW_TOOLS_DIR and check Status again.");
+		return true;
+	}
+	if (preview.phase !== "missing") {
+		setNotice(state, `Runtime Coverage setup is blocked for ${preview.phase} state. Remove or repair the displayed managed-cache destination manually; Pi Fallow will not clear it.`);
+		return true;
+	}
+	return false;
+}
+
+async function executeRuntimeCoverageSetup(
+	preview: RuntimeCoverageCapability,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<void> {
+	const install = await dependencies.runProcess(
+		"npm",
+		runtimeCoverageInstallArgs(preview.destination),
+		`Installing @fallow-cli/fallow-cov@${FALLOW_COV_VERSION} in the Pi Fallow managed cache...`,
+		300,
+	);
+	await persistSetupOutput(wrapProcessResult(install), state, dependencies);
+	await refreshRuntimeCoverage(state, dependencies);
+	if (!install) return setNotice(state, "Runtime Coverage setup was cancelled; Status was rechecked for partial state.");
+	if (install.code !== 0) return setNotice(state, `Runtime Coverage setup failed: ${commandFailure(install)}`);
+	if (!runtimeCoverageIsReady(state)) return setNotice(state, "Runtime Coverage setup completed without verified package/signature readiness. Review Status remediation.");
+	setNotice(state, "Runtime Coverage sidecar installed in the managed cache; exact package metadata and detached signature presence were verified.");
+}
+
+function runtimeCoverageIsReady(state: OptionalAnalysisState): boolean {
+	return state.runtimeCoverage?.phase === "ready";
+}
+
+function sameRuntimePreview(
+	preview: RuntimeCoverageCapability,
+	current: RuntimeCoverageCapability | undefined,
+): boolean {
+	return current?.phase === "missing"
+		&& current.destination === preview.destination
+		&& current.planFingerprint === preview.planFingerprint;
+}
+
+async function runRuntimeCoverage(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<FallowNavigatorResult | null> {
+	const status = await readyRuntimeCoverageStatus(state, dependencies);
+	if (!status) return null;
+	const artifactPath = await confirmedRuntimeArtifact(ctx, state, status, dependencies);
+	if (!artifactPath) return null;
+	const current = await refreshRuntimeCoverage(state, dependencies);
+	if (!sameRuntimeRunStatus(status, current)) {
+		setNotice(state, "Runtime Coverage status changed while selecting the artifact; Run was stopped. Review Status and select the artifact again.");
+		return null;
+	}
+	return {
+		type: "forward",
+		label: "Run Runtime Coverage",
+		commandArgs: ["coverage", "analyze", "--runtime-coverage", artifactPath],
+		executionEnvironment: localCoverageEnvironment(status.binaryPath),
+	};
+}
+
+async function confirmedRuntimeArtifact(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	status: RuntimeCoverageCapability & { binaryPath: string },
+	dependencies: OptionalAnalysisDependencies,
+): Promise<string | undefined> {
+	const artifactPath = await selectRuntimeArtifact(ctx, state, dependencies);
+	if (!artifactPath) return undefined;
+	return await confirmRuntimeCoverageRun(ctx, state, status, artifactPath) ? artifactPath : undefined;
+}
+
+async function confirmRuntimeCoverageRun(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	status: RuntimeCoverageCapability & { binaryPath: string },
+	artifactPath: string,
+): Promise<boolean> {
+	const confirmed = await ctx.ui.confirm("Run local Runtime Coverage analysis?", [
+		`Resolved artifact: ${artifactDisplayName(artifactPath)}`,
+		`Verified sidecar: ${artifactDisplayName(status.binaryPath)}`,
+		"Effect: read the selected local V8/Istanbul artifact and project source; run fallow coverage analyze locally.",
+		"Cloud source and API credential environment variables will be removed for the analysis child process.",
+	].join("\n"));
+	if (confirmed) return true;
+	setNotice(state, "Runtime Coverage Run declined after path preview; no analysis was started.");
+	return false;
+}
+
+function sameRuntimeRunStatus(
+	preview: RuntimeCoverageCapability,
+	current: RuntimeCoverageCapability | undefined,
+): boolean {
+	return current?.phase === "ready"
+		&& current.fingerprint === preview.fingerprint
+		&& current.binaryPath === preview.binaryPath;
+}
+
+function localCoverageEnvironment(binaryPath: string): NodeJS.ProcessEnv {
+	return {
+		FALLOW_COV_BIN: binaryPath,
+		FALLOW_RUNTIME_COVERAGE_SOURCE: undefined,
+		FALLOW_API_KEY: undefined,
+		FALLOW_API_URL: undefined,
+		FALLOW_REPO: undefined,
+		FALLOW_CA_BUNDLE: undefined,
+	};
+}
+
+async function readyRuntimeCoverageStatus(
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<(RuntimeCoverageCapability & { binaryPath: string }) | undefined> {
+	const status = await refreshRuntimeCoverage(state, dependencies);
+	if (status?.phase === "ready" && status.binaryPath) return { ...status, binaryPath: status.binaryPath };
+	setNotice(state, "Runtime Coverage Run is disabled until Status reports the exact certified sidecar and detached signature.");
+	return undefined;
+}
+
+async function selectRuntimeArtifact(
+	ctx: FallowCommandContext,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<string | undefined> {
+	const selected = await ctx.ui.input("Local V8/Istanbul artifact", "Path to a local coverage JSON file or directory");
+	if (!selected?.trim()) return setNotice(state, "Runtime Coverage Run cancelled before selecting an artifact.");
+	try {
+		state.artifactPath = await dependencies.resolveArtifact(selected.trim());
+		return state.artifactPath;
+	} catch (error) {
+		return setNotice(state, `Runtime artifact is unavailable: ${errorMessage(error)}`);
+	}
+}
+
+function createDependencies(pi: ExtensionAPI, ctx: FallowCommandContext): OptionalAnalysisDependencies {
+	return {
+		runFallow: (args, label, timeoutSecs = 120) => runFallowTaskWithLoader(
+			ctx, label, (signal) => fallowCli.execFallow(pi, args, ctx.cwd, signal, timeoutSecs),
+		),
+		runProcess: (command, args, label, timeoutSecs = 120) => runFallowTaskWithLoader(
+			ctx, label, (signal) => fallowCli.execCommand(command, args, ctx.cwd, signal, timeoutSecs),
+		),
+		inspectRuntime: (plan) => inspectRuntimeCoverageCapability(plan),
+		resolveArtifact: resolveLocalArtifact,
+		saveSetupOutput: saveOptionalSetupOutput,
+	};
+}
+
+function wrapProcessResult(result: ProcessResult | null): RawCommandResult | null {
+	return result ? { result } : null;
+}
+
+async function persistSetupOutput(
+	execution: RawCommandResult | null,
+	state: OptionalAnalysisState,
+	dependencies: OptionalAnalysisDependencies,
+): Promise<void> {
+	if (!execution) return;
+	try {
+		state.completeSetupOutputPath = await dependencies.saveSetupOutput(execution.result.stdout, execution.result.stderr);
+	} catch {
+		state.completeSetupOutputPath = undefined;
+	}
+}
+
+function isPathWithin(parent: string, child: string): boolean {
+	const path = relative(resolve(parent), resolve(child));
+	return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+
+function setNotice(state: OptionalAnalysisState, notice: string): undefined {
+	state.notice = notice.replace(/[\u0000-\u001f\u007f-\u009f]/gu, "�");
+	return undefined;
+}
+
+function commandFailure(result: { stderr: string; stdout: string; code: number; terminationReason?: string }): string {
+	const message = [result.terminationReason, result.stderr.trim(), result.stdout.trim()].find(Boolean) ?? `exit ${result.code}`;
+	return message.length > 500 ? `${message.slice(0, 499)}…` : message;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}

--- a/extensions/fallow/command/result-flow.ts
+++ b/extensions/fallow/command/result-flow.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { fallowCli } from "../cli";
 import { formatFallowProjectStateText } from "../project/text";
 import { formatFallowPrSummaryText } from "../pr-summary/text";
 import { commandDisplay, fallowExitLabel } from "../tool-render";
@@ -21,6 +22,7 @@ export async function executeFallowResult(
 	setLastFallowArgs: (args: string[] | null) => void,
 	initialNavigatorState?: FallowNavigatorState,
 	onCompleted?: FallowCommandCompleted,
+	executionEnvironment?: NodeJS.ProcessEnv,
 ): Promise<FallowNavigatorResult | null | undefined> {
 	if (rawCommandArgs[0] === "issues") {
 		return executeFallowProjectIssuesResult(
@@ -30,7 +32,7 @@ export async function executeFallowResult(
 	const finalArgs = buildFallowFinalArgs(rawCommandArgs);
 	if (rememberLast) setLastFallowArgs([...finalArgs]);
 	return runFallowResultFlow(
-		pi, ctx, finalArgs, buildFallowExecutor(pi, ctx, finalArgs), initialNavigatorState, onCompleted,
+		pi, ctx, finalArgs, buildFallowExecutor(pi, ctx, finalArgs, fallowCli.execFallow, executionEnvironment), initialNavigatorState, onCompleted,
 	);
 }
 
@@ -121,7 +123,7 @@ function renderFallowResultMessage(
 	resultPrefix: string,
 ): void {
 	const { details: commandDetails, formatted, content } = result;
-	const hasNavigator = hasFallowNavigator(ctx.mode, formatted.overview);
+	const hasNavigator = hasFallowNavigator(ctx.mode, formatted.overview, true);
 	pi.sendMessage({
 		customType: "fallow-result",
 		content: buildFallowTranscriptContent(resultPrefix, formatted.summary, content, hasNavigator),
@@ -151,6 +153,7 @@ function openFallowNavigator(
 		truncated: result.formatted.truncated,
 		projectState,
 		prSummary,
+		optionalAnalysis: true,
 	});
 }
 
@@ -162,6 +165,7 @@ interface FallowOverviewNavigatorOptions {
 	truncated?: boolean;
 	projectState?: FallowProjectState;
 	prSummary?: FallowPrSummary;
+	optionalAnalysis?: boolean;
 }
 
 export function openFallowOverviewNavigator(
@@ -170,7 +174,7 @@ export function openFallowOverviewNavigator(
 	options: FallowOverviewNavigatorOptions,
 ): Promise<FallowNavigatorResult | null> {
 	if (!isFallowTuiMode(ctx.mode) || !overview) return Promise.resolve(null);
-	const navigatorMode = resolveFallowNavigatorMode(overview);
+	const navigatorMode = resolveFallowNavigatorMode(overview, options.optionalAnalysis);
 	if (navigatorMode === "none") return Promise.resolve(null);
 	const informationalMode = navigatorMode === "informational";
 	return ctx.ui.custom<FallowNavigatorResult | null>((tui, theme, _keybindings, done) => (
@@ -179,6 +183,7 @@ export function openFallowOverviewNavigator(
 			commandArgs: [...options.commandArgs],
 			visibleRows: resolveFallowNavigatorVisibleRows(tui.terminal.rows, informationalMode),
 			informationalMode,
+			optionalAnalysis: options.optionalAnalysis,
 		})
 	), {
 		overlay: true,

--- a/extensions/fallow/command/types.ts
+++ b/extensions/fallow/command/types.ts
@@ -1,10 +1,12 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { FallowHistoryState } from "../history";
+import type { OptionalAnalysisState } from "../optional-analysis";
 
 export type FallowCommandState = {
 	lastArgs: string[] | null;
 	baseRefs: Map<string, string>;
 	history: FallowHistoryState;
+	optionalAnalysis: OptionalAnalysisState;
 };
 export type FallowRunMode = ExtensionContext["mode"];
 
@@ -17,6 +19,9 @@ export type FallowCommandContext = {
 		notify(message: string, level: "info" | "warning" | "error"): void;
 		setStatus(key: string, text: string | undefined): void;
 		custom<T>(render: (tui: any, theme: any, keybindings: any, done: (value: T) => void) => any, options?: any): any;
+		select(title: string, options: string[]): Promise<string | undefined>;
+		confirm(title: string, message: string): Promise<boolean>;
+		input(title: string, placeholder?: string): Promise<string | undefined>;
 		setEditorText(text: string): void;
 	};
 };

--- a/extensions/fallow/optional-analysis.ts
+++ b/extensions/fallow/optional-analysis.ts
@@ -1,0 +1,495 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { access, mkdtemp, readdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join, parse, resolve } from "node:path";
+import { asRecord } from "./data";
+
+export const OPTIONAL_ANALYSIS_COMMAND = "__pi-fallow-optional-analysis";
+const SIMILAR_CODE_MODEL_ID = "jinaai/jina-embeddings-v2-base-code";
+const SIMILAR_CODE_MODEL_REVISION = "516f4baf13dec4ddddda8631e019b5737c8bc250";
+const SIMILAR_CODE_LICENSE = "Apache-2.0";
+const SIMILAR_CODE_DOWNLOAD_BYTES = 324_329_844;
+const SIMILAR_CODE_PEAK_RAM_BYTES = 1_288_490_189;
+const FALLOW_COV_PACKAGE = "@fallow-cli/fallow-cov";
+export const FALLOW_COV_VERSION = "0.4.1";
+const FALLOW_COV_LICENSE = "Proprietary (SEE LICENSE IN LICENSE)";
+const FALLOW_COV_EXPECTED_INSTALLED_BYTES = 3_145_728;
+const FALLOW_COV_REGISTRY_SOURCE = `https://registry.npmjs.org/${FALLOW_COV_PACKAGE}`;
+const FALLOW_COV_DIST_INTEGRITY = "sha512-j6vKYolLyuOdgoONTFoFZ7RBp5vx/U8lHx9sa1oMZetdD7XAwo3nMd11gQHKuDs2JiBcDTra7YpqxhUyjmz4YA==";
+const FALLOW_COV_PLATFORM_INTEGRITIES: Record<string, string> = {
+	"fallow-cov-darwin-arm64": "sha512-pahht40+IUCi8GFaiY10yVGKy5iwsKg62FwM31G+6UvWAYnrtvh/RpqFBVS5QkvhxBfK0kRr3wugaEfFMBsgVQ==",
+	"fallow-cov-darwin-x64": "sha512-hiX+xLSkxGI3UiB0MUleNAk8fHc8/iXaCLwJRRw3TMUlpdh/c/t4GFUUF9UIOcGq+lJtLScJHnfrhXL0u2BmqQ==",
+	"fallow-cov-linux-arm64-gnu": "sha512-/NegKdrIOd1uc/f4i1jRFgYX7j9OZgKnN4M2numcM2ThoRPIomULb/ZYFJxhqheEj8mtJiq9LyVqpNmZM+XHpw==",
+	"fallow-cov-linux-arm64-musl": "sha512-H1/fQ+tAaXSfCrnDFuGwmn6OYw0ZlQQVTwIPffBLTgZrud6uXkhKJKmZ68iodp6fG2AuEdRM4UJV+5/nkEb+ig==",
+	"fallow-cov-linux-x64-gnu": "sha512-CBHoqxAjDxPm3G4JER4G6OQR6Zrg9RTdRqIHmd0+Pv34elib7htFSmB9P3HfcSr8TGVCa/fuKcdANIMamcNBcw==",
+	"fallow-cov-linux-x64-musl": "sha512-/KR0kktHtf/ryO0bywaj1nzrj3XFLGP19aVG5iOiFYQJ1/a9ML5Tz+HFilSc0v6O+zSSvX7qaO98hOLjMHZOgQ==",
+	"fallow-cov-win32-x64-msvc": "sha512-hs0z/jiXtrffOiwPz/Zk1XnAr52Wjybkywk8l5ZlmPuRV7Dz1sw97Y66aQ2AKODeTqLAwFPVrFnV+Qst1UdEBA==",
+};
+
+export type CapabilityPhase = "unknown" | "missing" | "ready" | "incompatible" | "corrupt" | "error";
+
+export interface SimilarCodeCapability {
+	phase: CapabilityPhase;
+	modelReady: boolean;
+	integrityVerified: boolean;
+	modelId: string;
+	modelRevision: string;
+	license: string;
+	downloadBytes: number;
+	cacheDir: string;
+	installedVersion?: string;
+	protocolVersion?: number;
+	problem?: string;
+	fingerprint: string;
+}
+
+interface CoveragePlanDisclosure {
+	commands: string[];
+	filesToEdit: string[];
+	omittedCommands: number;
+	omittedFiles: number;
+}
+
+export interface RuntimeCoverageCapability {
+	phase: CapabilityPhase;
+	destination: string;
+	packageName: string;
+	certifiedVersion: string;
+	installedVersion?: string;
+	license: string;
+	installedBytes?: number;
+	binaryPath?: string;
+	signaturePath?: string;
+	packageMetadataVerified: boolean;
+	signaturePresent: boolean;
+	problem?: string;
+	plan?: CoveragePlanDisclosure;
+	planFingerprint?: string;
+	fingerprint: string;
+}
+
+export interface OptionalAnalysisState {
+	similarCode?: SimilarCodeCapability;
+	runtimeCoverage?: RuntimeCoverageCapability;
+	artifactPath?: string;
+	similarCodeArgs?: string[];
+	completeSetupOutputPath?: string;
+	notice?: string;
+}
+
+export function createOptionalAnalysisState(): OptionalAnalysisState {
+	return {};
+}
+
+export function resetOptionalAnalysisState(state: OptionalAnalysisState): void {
+	for (const key of Object.keys(state) as Array<keyof OptionalAnalysisState>) delete state[key];
+}
+
+export function parseSimilarCodeCapability(value: unknown): SimilarCodeCapability {
+	const report = asRecord(value);
+	if (!report || report.kind !== "similar-code-status") return similarCodeError("Fallow returned an incompatible Similar Code status report.");
+	const modelId = boundedValue(stringOr(report.model_id, "unknown"), 200);
+	const modelRevision = boundedValue(stringOr(report.model_revision, "unknown"), 200);
+	const license = boundedValue(stringOr(report.license, "unknown"), 100);
+	const downloadBytes = positiveNumberOr(report.download_bytes, SIMILAR_CODE_DOWNLOAD_BYTES);
+	const cacheDir = boundedValue(stringOr(report.cache_dir, "unknown"), 1_000);
+	const modelReady = report.model_ready === true;
+	const integrityVerified = report.integrity_verified === true;
+	const compatible = [
+		modelId === SIMILAR_CODE_MODEL_ID,
+		modelRevision === SIMILAR_CODE_MODEL_REVISION,
+		license === SIMILAR_CODE_LICENSE,
+	].every(Boolean);
+	const phase = similarCodePhase(modelReady, integrityVerified, compatible);
+	const capability = {
+		phase,
+		modelReady,
+		integrityVerified,
+		modelId,
+		modelRevision,
+		license,
+		downloadBytes,
+		cacheDir,
+		installedVersion: boundedOptionalValue(string(report.companion_version ?? report.version), 100),
+		protocolVersion: numeric(report.protocol_version),
+		problem: similarCodeProblem(report, phase),
+	};
+	return { ...capability, fingerprint: fingerprint(capability) };
+}
+
+function similarCodePhase(modelReady: boolean, integrityVerified: boolean, compatible: boolean): CapabilityPhase {
+	if (!compatible) return "incompatible";
+	if (!modelReady) return "missing";
+	return integrityVerified ? "ready" : "corrupt";
+}
+
+function similarCodeProblem(report: Record<string, any>, phase: CapabilityPhase): string | undefined {
+	const reported = string(report.problem);
+	if (reported) return boundedValue(reported, 1_000);
+	if (phase === "incompatible") return "Pinned model metadata differs from Pi Fallow's certified model.";
+	if (phase === "corrupt") return "The model is present but its integrity is not verified.";
+	return undefined;
+}
+
+function similarCodeError(problem: string): SimilarCodeCapability {
+	const capability = {
+		phase: "error" as const,
+		modelReady: false,
+		integrityVerified: false,
+		modelId: SIMILAR_CODE_MODEL_ID,
+		modelRevision: SIMILAR_CODE_MODEL_REVISION,
+		license: SIMILAR_CODE_LICENSE,
+		downloadBytes: SIMILAR_CODE_DOWNLOAD_BYTES,
+		cacheDir: "unknown",
+		problem,
+	};
+	return { ...capability, fingerprint: fingerprint(capability) };
+}
+
+function runtimeCoverageDestination(environment: NodeJS.ProcessEnv = process.env): string {
+	const configured = environment.PI_FALLOW_TOOLS_DIR;
+	if (configured) return resolve(configured, "fallow-cov", FALLOW_COV_VERSION);
+	const base = environment.XDG_DATA_HOME || (process.platform === "darwin" ? join(homedir(), "Library", "Application Support") : join(homedir(), ".local", "share"));
+	return join(base, "pi-fallow", "tools", "fallow-cov", FALLOW_COV_VERSION);
+}
+
+export async function inspectRuntimeCoverageCapability(
+	plan?: unknown,
+	destination = runtimeCoverageDestination(),
+): Promise<RuntimeCoverageCapability> {
+	const normalizedPlan = asRecord(plan);
+	const canonical = await canonicalDestination(destination);
+	const base = runtimeCoverageBase(canonical, normalizedPlan);
+	try {
+		await access(canonical, constants.R_OK);
+	} catch {
+		return finalizeRuntimeCoverage({ ...base, phase: "missing", problem: "The certified sidecar is not installed in Pi Fallow's managed cache." });
+	}
+	try {
+		return await inspectInstalledRuntimeCoverage(base);
+	} catch (error) {
+		return finalizeRuntimeCoverage({ ...base, phase: "corrupt", problem: errorMessage(error) });
+	}
+}
+
+async function canonicalDestination(path: string): Promise<string> {
+	const destination = resolve(path);
+	try {
+		return await realpath(destination);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+		const root = parse(destination).root;
+		if (destination === root) return destination;
+		return join(await canonicalDestination(dirname(destination)), basename(destination));
+	}
+}
+
+function runtimeCoverageBase(destination: string, plan: Record<string, any> | undefined): Omit<RuntimeCoverageCapability, "phase" | "fingerprint"> {
+	return {
+		destination,
+		packageName: FALLOW_COV_PACKAGE,
+		certifiedVersion: FALLOW_COV_VERSION,
+		license: FALLOW_COV_LICENSE,
+		packageMetadataVerified: false,
+		signaturePresent: false,
+		...(plan ? { plan: summarizeCoveragePlan(plan), planFingerprint: coveragePlanFingerprint(plan) } : {}),
+	};
+}
+
+async function inspectInstalledRuntimeCoverage(
+	base: Omit<RuntimeCoverageCapability, "phase" | "fingerprint">,
+): Promise<Omit<RuntimeCoverageCapability, "fingerprint">> {
+	const scope = join(base.destination, "node_modules", "@fallow-cli");
+	const wrapper = await readPackage(join(scope, "fallow-cov", "package.json"));
+	const installedVersion = string(wrapper.version);
+	if (isIncompatibleWrapper(wrapper.name, installedVersion)) {
+		return { ...base, phase: "incompatible", installedVersion, problem: "Installed sidecar package/version differs from the certified package." };
+	}
+	const platformPackage = await findPlatformPackage(scope);
+	await verifyPackageIntegrity(base.destination, platformPackage);
+	await verifyPlatformPackage(scope, platformPackage);
+	const binaryPath = join(scope, platformPackage, coverageBinaryName());
+	const signaturePath = `${binaryPath}.sig`;
+	await Promise.all([requireFile(binaryPath), requireFile(signaturePath)]);
+	return {
+		...base,
+		phase: "ready",
+		installedVersion,
+		license: installedCoverageLicense(wrapper.license),
+		installedBytes: await directorySize(base.destination),
+		binaryPath,
+		signaturePath,
+		packageMetadataVerified: true,
+		signaturePresent: true,
+	};
+}
+
+function isIncompatibleWrapper(name: unknown, version: string | undefined): boolean {
+	return [name !== FALLOW_COV_PACKAGE, version !== FALLOW_COV_VERSION].some(Boolean);
+}
+
+function installedCoverageLicense(value: unknown): string {
+	const license = string(value);
+	if (license === "SEE LICENSE IN LICENSE") return FALLOW_COV_LICENSE;
+	return stringOr(license, "unknown");
+}
+
+async function verifyPackageIntegrity(destination: string, platformPackage: string): Promise<void> {
+	const lock = await readPackage(join(destination, "node_modules", ".package-lock.json"));
+	const packages = Object.entries(asRecord(lock.packages) ?? {});
+	if (lockIntegrity(packages, "fallow-cov") !== FALLOW_COV_DIST_INTEGRITY) throw new Error("The managed npm lock does not match the certified wrapper integrity.");
+	if (lockIntegrity(packages, platformPackage) !== FALLOW_COV_PLATFORM_INTEGRITIES[platformPackage]) throw new Error("The managed npm lock does not match the certified platform integrity.");
+}
+
+function lockIntegrity(entries: Array<[string, unknown]>, packageName: string): unknown {
+	const suffix = `node_modules/@fallow-cli/${packageName}`;
+	const entry = entries.find(([path]) => path.replaceAll("\\", "/").endsWith(suffix));
+	return asRecord(entry?.[1])?.integrity;
+}
+
+async function findPlatformPackage(scope: string): Promise<string> {
+	const entries = await readdir(scope, { withFileTypes: true });
+	const packages = entries.filter((entry) => entry.isDirectory() && entry.name.startsWith("fallow-cov-")).map((entry) => entry.name);
+	if (packages.length !== 1) throw new Error(`Expected one signed platform package, found ${packages.length}.`);
+	return packages[0]!;
+}
+
+async function verifyPlatformPackage(scope: string, platformPackage: string): Promise<void> {
+	if (!isCurrentPlatformPackage(platformPackage)) throw new Error(`The installed sidecar package ${platformPackage} does not match ${process.platform}-${process.arch}.`);
+	const platform = await readPackage(join(scope, platformPackage, "package.json"));
+	if ([platform.name !== `@fallow-cli/${platformPackage}`, platform.version !== FALLOW_COV_VERSION].some(Boolean)) throw new Error("The platform sidecar metadata does not match the certified package.");
+}
+
+function coverageBinaryName(): string {
+	return process.platform === "win32" ? "fallow-cov.exe" : "fallow-cov";
+}
+
+function isCurrentPlatformPackage(packageName: string): boolean {
+	if (process.platform === "darwin") return packageName === `fallow-cov-darwin-${process.arch}`;
+	if (process.platform === "win32") return packageName === `fallow-cov-win32-${process.arch}-msvc`;
+	if (process.platform === "linux") return [`fallow-cov-linux-${process.arch}-gnu`, `fallow-cov-linux-${process.arch}-musl`].includes(packageName);
+	return false;
+}
+
+async function readPackage(path: string): Promise<Record<string, any>> {
+	const value = JSON.parse(await readFile(path, "utf8"));
+	const record = asRecord(value);
+	if (!record) throw new Error(`Invalid package metadata at ${path}.`);
+	return record;
+}
+
+async function requireFile(path: string): Promise<void> {
+	const info = await stat(path);
+	if (!info.isFile()) throw new Error(`Expected a regular file at ${path}.`);
+}
+
+async function directorySize(path: string): Promise<number> {
+	const entries = await readdir(path, { withFileTypes: true });
+	const sizes = await Promise.all(entries.map(async (entry) => {
+		const child = join(path, entry.name);
+		return entry.isDirectory() ? directorySize(child) : (await stat(child)).size;
+	}));
+	return sizes.reduce((total, size) => total + size, 0);
+}
+
+function finalizeRuntimeCoverage(
+	capability: Omit<RuntimeCoverageCapability, "fingerprint">,
+): RuntimeCoverageCapability {
+	return { ...capability, fingerprint: fingerprint(capability) };
+}
+
+export function parseCoverageSetupPlan(value: unknown): Record<string, any> {
+	const plan = asRecord(value);
+	if (!plan || plan.kind !== "coverage-setup" || String(plan.schema_version) !== "1") {
+		throw new Error("Fallow returned an incompatible runtime coverage setup plan.");
+	}
+	return plan;
+}
+
+function coveragePlanFingerprint(plan: Record<string, any>): string {
+	const stable = { ...plan };
+	delete stable._meta;
+	return fingerprint(stable);
+}
+
+export function similarCodeSetupPreview(status: SimilarCodeCapability): string {
+	return [
+		`Source: Hugging Face model ${display(status.modelId)}`,
+		`Pinned revision: ${display(status.modelRevision)}`,
+		`License: ${display(status.license)}`,
+		`Download: ${formatBytes(status.downloadBytes)}; peak RAM: approximately ${formatBytes(SIMILAR_CODE_PEAK_RAM_BYTES)}`,
+		`Destination: ${display(status.cacheDir)}`,
+		"Command: fallow similar-code setup --local --yes --format json --quiet",
+		"Side effects: downloads and verifies the pinned model in the user-local Fallow cache, and saves complete setup output under the OS temporary directory. No project manifest or lockfile is changed.",
+	].join("\n");
+}
+
+export function runtimeCoverageSetupPreview(status: RuntimeCoverageCapability): string {
+	const plan = status.plan ?? { commands: [], filesToEdit: [], omittedCommands: 0, omittedFiles: 0 };
+	return [
+		`Source: npm package ${FALLOW_COV_PACKAGE}@${FALLOW_COV_VERSION} (${FALLOW_COV_REGISTRY_SOURCE})`,
+		`Registry integrity (wrapper; the selected platform package is also pinned): ${FALLOW_COV_DIST_INTEGRITY}`,
+		`License: ${FALLOW_COV_LICENSE}`,
+		`Expected installed size: approximately ${formatBytes(FALLOW_COV_EXPECTED_INSTALLED_BYTES)}`,
+		`Destination: ${display(status.destination)}`,
+		`Command: npm install --prefix ${JSON.stringify(status.destination)} --registry https://registry.npmjs.org --ignore-scripts --no-save --package-lock=false --audit=false --fund=false ${FALLOW_COV_PACKAGE}@${FALLOW_COV_VERSION}`,
+		"Side effects: network download plus files in the displayed Pi Fallow managed cache; npm may create node_modules/.package-lock.json there and update its normal user cache/logs. Pi Fallow saves complete setup output under the OS temporary directory. No project manifest or lockfile is changed.",
+		"Scope: single local V8/Istanbul captures only. Continuous/cloud mode, credentials, telemetry opt-in, and beacon setup are excluded.",
+		coveragePlanDisclosure(plan),
+	].join("\n");
+}
+
+function summarizeCoveragePlan(plan: Record<string, any>): CoveragePlanDisclosure {
+	const commands = stringArray(plan.commands);
+	const files = recordArray(plan.files_to_edit).map((entry) => string(entry.path)).filter((path): path is string => Boolean(path));
+	return {
+		commands: commands.slice(0, 10).map(boundedPlanValue),
+		filesToEdit: files.slice(0, 20).map(boundedPlanValue),
+		omittedCommands: Math.max(0, commands.length - 10),
+		omittedFiles: Math.max(0, files.length - 20),
+	};
+}
+
+function boundedPlanValue(value: string): string {
+	const sanitized = display(value);
+	return sanitized.length > 300 ? `${sanitized.slice(0, 299)}…` : sanitized;
+}
+
+function coveragePlanDisclosure(plan: CoveragePlanDisclosure): string {
+	const commandText = listDisclosure(plan.commands, plan.omittedCommands, "; ");
+	const fileText = listDisclosure(plan.filesToEdit, plan.omittedFiles, ", ");
+	return `Fallow's read-only setup plan proposed project/cloud work that this local-only action will NOT perform — commands: ${commandText}; files: ${fileText}.`;
+}
+
+function listDisclosure(values: string[], omitted: number, separator: string): string {
+	const shown = values.length ? values.join(separator) : "none";
+	return omitted ? `${shown} (+${omitted} more not shown)` : shown;
+}
+
+export function similarCodeStatusLines(status: SimilarCodeCapability | undefined): string[] {
+	if (!status) return ["Similar Code: status not checked."];
+	return withProblem([
+		`Similar Code: ${status.phase}; model ${display(status.modelId)}@${display(shortRevision(status.modelRevision))}; integrity ${verificationLabel(status.integrityVerified)}.`,
+		`  Source: Hugging Face; Fallow companion ${display(stringOr(status.installedVersion, "unknown"))}; protocol ${valueOr(status.protocolVersion, "unknown")}; ${display(status.license)}; ${formatBytes(status.downloadBytes)}; ${display(status.cacheDir)}`,
+	], status.problem);
+}
+
+export function runtimeCoverageStatusLines(status: RuntimeCoverageCapability | undefined): string[] {
+	if (!status) return ["Runtime Coverage: status not checked."];
+	return withProblem([
+		`Runtime Coverage: ${status.phase}; ${display(status.packageName)}@${display(stringOr(status.installedVersion, "not installed"))}; package metadata ${verificationLabel(status.packageMetadataVerified)}; detached signature ${presenceLabel(status.signaturePresent)}.`,
+		`  Source: npm registry; certified ${display(status.certifiedVersion)}; ${display(status.license)}; ${installedSizeLabel(status.installedBytes)}; ${display(status.destination)}`,
+		...coveragePlanStatusLines(status.plan),
+	], status.problem);
+}
+
+export function runtimeCoverageInstallArgs(destination: string): string[] {
+	return [
+		"install", "--prefix", destination, "--registry", "https://registry.npmjs.org", "--ignore-scripts", "--no-save",
+		"--package-lock=false", "--audit=false", "--fund=false", `${FALLOW_COV_PACKAGE}@${FALLOW_COV_VERSION}`,
+	];
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes >= 1024 ** 3) return `${(bytes / 1024 ** 3).toFixed(1)} GiB`;
+	if (bytes >= 1024 ** 2) return `${Math.round(bytes / 1024 ** 2)} MiB`;
+	return `${Math.round(bytes / 1024)} KiB`;
+}
+
+export function capabilityLabel(phase: CapabilityPhase | undefined): string {
+	return phase ?? "unchecked";
+}
+
+function coveragePlanStatusLines(plan: CoveragePlanDisclosure | undefined): string[] {
+	return plan ? [`  ${coveragePlanDisclosure(plan)}`] : [];
+}
+
+function withProblem(lines: string[], problem: string | undefined): string[] {
+	if (problem) lines.push(`  ${display(problem)}`);
+	return lines;
+}
+
+function verificationLabel(verified: boolean): string {
+	return verified ? "verified" : "not verified";
+}
+
+function presenceLabel(present: boolean): string {
+	return present ? "present" : "not verified";
+}
+
+function installedSizeLabel(bytes: number | undefined): string {
+	return bytes === undefined ? `expected ${formatBytes(FALLOW_COV_EXPECTED_INSTALLED_BYTES)}` : formatBytes(bytes);
+}
+
+function valueOr(value: string | number | undefined, fallback: string): string | number {
+	return value === undefined ? fallback : value;
+}
+
+function stringOr(value: unknown, fallback: string): string {
+	return string(value) ?? fallback;
+}
+
+function positiveNumberOr(value: unknown, fallback: number): number {
+	const parsed = numeric(value);
+	return parsed === undefined || parsed < 0 ? fallback : parsed;
+}
+
+function boundedOptionalValue(value: string | undefined, maxLength: number): string | undefined {
+	return value === undefined ? undefined : boundedValue(value, maxLength);
+}
+
+function boundedValue(value: string, maxLength: number): string {
+	return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
+}
+
+function display(value: string): string {
+	return value.replace(/[\u0000-\u001f\u007f-\u009f]/gu, "�");
+}
+
+function fingerprint(value: unknown): string {
+	return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function shortRevision(value: string): string {
+	return value === "unknown" ? value : value.slice(0, 12);
+}
+
+function string(value: unknown): string | undefined {
+	return typeof value === "string" && value ? value : undefined;
+}
+
+function numeric(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function stringArray(value: unknown): string[] {
+	return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+function recordArray(value: unknown): Array<Record<string, any>> {
+	return Array.isArray(value) ? value.map(asRecord).filter((entry): entry is Record<string, any> => Boolean(entry)) : [];
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+export async function saveOptionalSetupOutput(stdout: string, stderr: string): Promise<string> {
+	const directory = await mkdtemp(join(tmpdir(), "pi-fallow-optional-"));
+	const path = join(directory, "setup-output.txt");
+	await writeFile(path, [`stdout:\n${stdout}`, `stderr:\n${stderr}`].join("\n\n"), "utf8");
+	return path;
+}
+
+export async function resolveLocalArtifact(path: string): Promise<string> {
+	if (/^[a-z][a-z0-9+.-]*:\/\//iu.test(path)) throw new Error("Cloud and URL artifacts are not supported; select a local path.");
+	const resolved = await realpath(path);
+	const info = await stat(resolved);
+	if (![info.isFile(), info.isDirectory()].some(Boolean)) throw new Error("The selected artifact must be a file or directory.");
+	return resolved;
+}
+
+export function artifactDisplayName(path: string | undefined): string {
+	return path ? `${display(basename(path))} (${display(path)})` : "not selected";
+}

--- a/extensions/fallow/process.ts
+++ b/extensions/fallow/process.ts
@@ -79,12 +79,37 @@ function resolveExitCode(code: number | null, killed: boolean): number {
 	return killed ? 130 : 1;
 }
 
+export async function settleCancellableTask<T>(
+	execute: (signal: AbortSignal) => Promise<T>,
+	signal: AbortSignal,
+	wasAborted: () => boolean,
+): Promise<T | null> {
+	try {
+		const result = await execute(signal);
+		return wasAborted() ? null : result;
+	} catch (error) {
+		if (wasAborted()) return null;
+		throw error;
+	}
+}
+
+function childEnvironment(overrides: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
+	if (!overrides) return process.env;
+	const environment = { ...process.env };
+	for (const [key, value] of Object.entries(overrides)) {
+		if (value === undefined) delete environment[key];
+		else environment[key] = value;
+	}
+	return environment;
+}
+
 export async function execFallowProcess(
 	command: string,
 	args: string[],
 	cwd: string,
 	signal: AbortSignal | undefined,
 	timeoutSecs: number,
+	environment?: NodeJS.ProcessEnv,
 ): Promise<FallowProcessResult> {
 	if (signal?.aborted) {
 		return { stdout: "", stderr: "", code: 130, killed: true, terminationReason: "cancelled" };
@@ -95,7 +120,7 @@ export async function execFallowProcess(
 			detached: process.platform !== "win32",
 			shell: false,
 			stdio: ["ignore", "pipe", "pipe"],
-			env: process.env,
+			env: childEnvironment(environment),
 			windowsHide: true,
 		});
 		let stdout = "";

--- a/extensions/fallow/runner.ts
+++ b/extensions/fallow/runner.ts
@@ -22,6 +22,7 @@ type ProcessExecutor = (
 	cwd: string,
 	signal: AbortSignal | undefined,
 	timeoutSecs: number,
+	environment?: NodeJS.ProcessEnv,
 ) => Promise<FallowProcessResult>;
 type ExecutableFinder = (name: string, pathValue: string, cwd: string) => Promise<string | undefined>;
 
@@ -42,6 +43,7 @@ interface RunnerRequest {
 	cwd: string;
 	signal: AbortSignal | undefined;
 	timeoutSecs: number;
+	environment?: NodeJS.ProcessEnv;
 }
 
 interface RunnerCacheEntry {
@@ -82,9 +84,10 @@ export function createFallowRunner({
 		cwd: string,
 		signal: AbortSignal | undefined,
 		timeoutSecs: number,
+		environment?: NodeJS.ProcessEnv,
 	): Promise<FallowRunnerExecution> {
 		if (signal?.aborted) return unresolvedCancellation(args);
-		const request = { cwd: resolve(cwd), signal, timeoutSecs };
+		const request = { cwd: resolve(cwd), signal, timeoutSecs, environment };
 		const route = await resolveCachedRoute(pi, request);
 		return executeResolvedRoute(pi, args, request, route);
 	}
@@ -96,7 +99,7 @@ export function createFallowRunner({
 		route: RunnerRoute,
 	): Promise<FallowRunnerExecution> {
 		if (request.signal?.aborted) return routeCancellation(route, args);
-		const execution = await executeRoute(route, args, request.cwd, request.signal, request.timeoutSecs);
+		const execution = await executeRoute(route, args, request.cwd, request.signal, request.timeoutSecs, request.environment);
 		return handleExecution(pi, args, request, route, execution);
 	}
 
@@ -133,7 +136,7 @@ export function createFallowRunner({
 		removeCachedRoute(pi, request.cwd, failedRoute);
 		const retryRoute = await resolveRetryRoute(pi, request, failedRoute);
 		if (!retryRoute) return finalizeExecution(failedExecution, false);
-		const retry = await executeRoute(retryRoute, args, request.cwd, request.signal, request.timeoutSecs);
+		const retry = await executeRoute(retryRoute, args, request.cwd, request.signal, request.timeoutSecs, request.environment);
 		if (retry.result.launchError) removeCachedRoute(pi, request.cwd, retryRoute);
 		return finalizeExecution(retry, retryRoute.source === "configured");
 	}
@@ -279,9 +282,10 @@ export function createFallowRunner({
 		cwd: string,
 		signal: AbortSignal | undefined,
 		timeoutSecs: number,
+		environment?: NodeJS.ProcessEnv,
 	): Promise<FallowRunnerExecution & { result: FallowProcessResult }> {
 		const executedArgs = [...route.argsPrefix, ...args];
-		const result = await executeProcess(route.command, executedArgs, cwd, signal, timeoutSecs);
+		const result = await executeProcess(route.command, executedArgs, cwd, signal, timeoutSecs, environment);
 		return { binary: route.displayBinary, args: executedArgs, result };
 	}
 

--- a/extensions/fallow/session.ts
+++ b/extensions/fallow/session.ts
@@ -3,12 +3,16 @@ import { fallowCompletions } from "./autocomplete";
 import { fallowCli } from "./cli";
 import type { FallowCommandState } from "./command/types";
 import { resetFallowHistory } from "./history";
+import { resetOptionalAnalysisState } from "./optional-analysis";
 import { scheduleFallowUpdateNotice } from "./update-notice";
 
 export function registerFallowSessionStart(pi: ExtensionAPI, commandState?: FallowCommandState): void {
 	pi.on("session_start", (_event, ctx) => {
 		fallowCli.clearRunnerCache(pi);
-		if (commandState) resetFallowHistory(commandState.history);
+		if (commandState) {
+			resetFallowHistory(commandState.history);
+			if (commandState.optionalAnalysis) resetOptionalAnalysisState(commandState.optionalAnalysis);
+		}
 		if (ctx.mode !== "tui") return;
 		void fallowCompletions.preloadGitReferences(pi, ctx.cwd);
 		scheduleFallowUpdateNotice(pi, ctx);

--- a/extensions/fallow/similar-code.ts
+++ b/extensions/fallow/similar-code.ts
@@ -22,7 +22,7 @@ function assertReadOnlySimilarCodeArgs(args: string[]): void {
 	if (!subcommand || !MUTATING_SUBCOMMANDS.has(subcommand)) return;
 	if (subcommand === "setup") {
 		throw new Error(
-			"Pi Fallow never downloads the similar-code model. Review `/fallow similar-code status`, then run `fallow similar-code setup --local` directly if you choose to install it.",
+			"Similar Code setup is blocked in slash arguments and tools. In the TUI, open `/fallow`, press `o`, review Optional Analysis → Similar Code → Setup, and explicitly confirm the pinned download.",
 		);
 	}
 	throw new Error("Pi Fallow does not expose similar-code cache mutation; run the Fallow CLI directly after reviewing the cache command.");

--- a/extensions/fallow/types.ts
+++ b/extensions/fallow/types.ts
@@ -89,4 +89,5 @@ export interface FallowNavigatorReturnTarget {
 
 export type FallowNavigatorResult =
 	| { type: "prompt"; prompt: string; issueCount: number; detail: "compact" | "full" }
-	| { type: "action"; label: string; commandArgs: string[]; returnTo: FallowNavigatorReturnTarget };
+	| { type: "action"; label: string; commandArgs: string[]; returnTo: FallowNavigatorReturnTarget }
+	| { type: "forward"; label: string; commandArgs: string[]; executionEnvironment?: NodeJS.ProcessEnv };

--- a/extensions/fallow/ui/navigator.ts
+++ b/extensions/fallow/ui/navigator.ts
@@ -4,6 +4,7 @@ import {
 	type Component, type Focusable, type SelectItem,
 } from "@earendil-works/pi-tui";
 import { buildFallowNavigatorActions, type FallowNavigatorAction } from "../navigator-actions";
+import { OPTIONAL_ANALYSIS_COMMAND } from "../optional-analysis";
 import { allNormalizedFallowEntries, getNormalizedFallowReport, hydrateNormalizedFallowEntry, type NormalizedFallowEntry } from "../normalized-report";
 import { buildFallowOverview } from "../overview";
 import { buildFallowPrompt, type FallowPromptDetail, type FallowPromptFinding } from "../prompt";
@@ -67,6 +68,7 @@ interface FallowNavigatorOptions {
 	prSummary?: FallowPrSummary;
 	visibleRows?: number;
 	informationalMode?: boolean;
+	optionalAnalysis?: boolean;
 }
 
 interface FlatIssue {
@@ -127,6 +129,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 			{ matches: (value) => value === "i", action: () => this.toggleInformational() },
 			{ matches: (value) => value === "d", action: () => this.togglePromptDetail() },
 			{ matches: (value) => value === "p", action: () => this.openActionPalette() },
+			{ matches: (value) => value === "o", action: () => this.finishWithOptionalAnalysis() },
 			{ matches: (value) => value === "e" || value === "a", action: () => this.finishWithPrompt() },
 			{ matches: (value) => value === "t", action: () => this.finishWithTrace() },
 			{ matches: (value) => matchesKey(value, "enter") || matchesKey(value, "space") || matchesKey(value, "right") || value === "l", action: () => this.toggleExpanded() },
@@ -366,6 +369,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 			);
 			return;
 		}
+		if (this.options.optionalAnalysis) lines.push(this.frame(this.optionalAnalysisLine(), frameWidth));
 		if (this.isInformationalMode()) {
 			this.appendWrappedFooter(this.informationalImplicationLine(), frameWidth, innerWidth, lines);
 			return;
@@ -384,6 +388,10 @@ export class FallowIssueNavigator implements Component, Focusable {
 
 	private appendWrappedFooter(text: string, frameWidth: number, innerWidth: number, lines: string[]): void {
 		for (const line of wrapTextWithAnsi(text, innerWidth)) lines.push(this.frame(line, frameWidth));
+	}
+
+	private optionalAnalysisLine(): string {
+		return `${pill("o optional analysis", violet)} ${this.theme.fg("muted", "visible Status / Setup / Run controls; opening them never installs")}`;
 	}
 
 	private footerSelectionLine(): string {
@@ -691,6 +699,21 @@ export class FallowIssueNavigator implements Component, Focusable {
 		});
 	}
 
+	private finishWithOptionalAnalysis(): void {
+		if (!this.options.optionalAnalysis) return;
+		if (!this.options.commandArgs?.length) {
+			this.actionNotice = "The originating command is unavailable; rerun /fallow before opening optional analysis.";
+			this.changed();
+			return;
+		}
+		this.onDone({
+			type: "action",
+			label: "Optional analysis",
+			commandArgs: [OPTIONAL_ANALYSIS_COMMAND],
+			returnTo: { commandArgs: [...this.options.commandArgs], state: this.snapshotState() },
+		});
+	}
+
 	private finishWithTrace(): void {
 		if (this.isInformationalMode()) return;
 		const current = this.currentIssue();
@@ -775,7 +798,8 @@ export class FallowIssueNavigator implements Component, Focusable {
 			`${key("v")} ${this.theme.fg("muted", "severity")}`,
 			`${key("x")} ${this.theme.fg("muted", "reset filters")}`,
 		];
-		if (this.isInformationalMode()) return [...common, `${key("q")} ${this.theme.fg("muted", "close")}`].join("  ");
+		const optional = this.options.optionalAnalysis ? [`${key("o")} ${this.theme.fg("muted", "optional analysis")}`] : [];
+		if (this.isInformationalMode()) return [...common, ...optional, `${key("q")} ${this.theme.fg("muted", "close")}`].join("  ");
 		return [
 			common[0],
 			`${key("enter")} ${this.theme.fg("muted", "expand")}`,
@@ -786,6 +810,7 @@ export class FallowIssueNavigator implements Component, Focusable {
 			`${key("i")} ${this.theme.fg("muted", "informational files")}`,
 			`${key("d")} ${this.theme.fg("muted", "prompt detail")}`,
 			`${key("p")} ${this.theme.fg("muted", "actions")}`,
+			...optional,
 			`${key("e/a")} ${this.theme.fg("muted", "load")}`,
 			`${key("t")} ${this.theme.fg("muted", "quick trace")}`,
 			`${key("q")} ${this.theme.fg("muted", "close")}`,

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -93,9 +93,9 @@ describe("fallowCli.buildFallowArgs", () => {
 		assert.deepEqual(build({ command: "similar-code", args: ["--file", "setup"] }), [
 			"similar-code", "--format", "json", "--quiet", "--file", "setup",
 		]);
-		assert.throws(() => build({ command: "similar-code", args: ["setup", "--local", "--yes"] }), /never downloads/);
-		assert.throws(() => build({ command: "similar-code", args: ["--threshold", "0.8", "setup", "--local"] }), /never downloads/);
-		assert.throws(() => build({ command: "similar-code", args: ["--", "setup"] }), /never downloads/);
+		assert.throws(() => build({ command: "similar-code", args: ["setup", "--local", "--yes"] }), /blocked in slash arguments and tools/);
+		assert.throws(() => build({ command: "similar-code", args: ["--threshold", "0.8", "setup", "--local"] }), /blocked in slash arguments and tools/);
+		assert.throws(() => build({ command: "similar-code", args: ["--", "setup"] }), /blocked in slash arguments and tools/);
 		assert.throws(() => build({ command: "similar-code", args: ["cache", "clear", "--yes"] }), /cache mutation/);
 	});
 

--- a/tests/command-args.test.mjs
+++ b/tests/command-args.test.mjs
@@ -101,7 +101,7 @@ describe("normalizeFallowArgs", () => {
 		]).result, [
 			"similar-code", "review", "--candidates=reports/candidates.json", "--verdicts", "reports/verdicts.json",
 		]);
-		assert.throws(() => normalize(["similar-code", "setup", "--local"]), /never downloads/);
+		assert.throws(() => normalize(["similar-code", "setup", "--local"]), /blocked in slash arguments and tools/);
 		assert.throws(() => normalize(["similar-code", "cache", "clear", "--yes"]), /cache mutation/);
 	});
 

--- a/tests/execution.test.mjs
+++ b/tests/execution.test.mjs
@@ -12,6 +12,7 @@ const jiti = createJiti(import.meta.url);
 const { fallowCli } = await jiti.import("../extensions/fallow/cli.ts");
 const { fallowEngine } = await jiti.import("../extensions/fallow/engine.ts");
 const { buildFallowExecutor } = await jiti.import("../extensions/fallow/command/loader.ts");
+const { settleCancellableTask } = await jiti.import("../extensions/fallow/process.ts");
 
 function assignEnvironmentValue(key, value) {
 	if (value === undefined) delete process.env[key];
@@ -92,6 +93,24 @@ describe("Fallow process execution", () => {
 		const result = await fallowCli.execCommand("definitely-not-a-command", [], root, controller.signal, 10);
 		assert.deepEqual(result, {
 			stdout: "", stderr: "", code: 130, killed: true, terminationReason: "cancelled",
+		});
+	});
+
+	it("scopes runtime sidecar environment overrides to the child process", async () => {
+		await withFixture("environment", async () => {
+			const previous = process.env.FALLOW_COV_BIN;
+			const restore = applyEnvironment({ FALLOW_API_KEY: "parent-secret" });
+			try {
+				const result = await fallowCli.execCommand(fixture, [], root, undefined, 10, {
+					FALLOW_COV_BIN: "/managed/fallow-cov", FALLOW_API_KEY: undefined,
+				});
+				assert.equal(result.code, 0);
+				assert.deepEqual(JSON.parse(result.stdout), { fallowCovBin: "/managed/fallow-cov", apiKey: null });
+				assert.equal(process.env.FALLOW_COV_BIN, previous);
+				assert.equal(process.env.FALLOW_API_KEY, "parent-secret");
+			} finally {
+				restoreEnvironment(restore);
+			}
 		});
 	});
 
@@ -204,6 +223,19 @@ describe("Fallow process execution", () => {
 			else process.env.FALLOW_TIMEOUT_SECS = previous;
 		}
 		assert.deepEqual(observed.map((entry) => entry.timeoutSecs), [900, 120, 45]);
+	});
+
+	it("waits for cancellable work to settle before returning cancellation", async () => {
+		const controller = new AbortController();
+		let settled = false;
+		const resultPromise = settleCancellableTask(
+			() => new Promise((resolveWork) => setTimeout(() => { settled = true; resolveWork("late result"); }, 10)),
+			controller.signal,
+			() => controller.signal.aborted,
+		);
+		controller.abort();
+		assert.equal(await resultPromise, null);
+		assert.equal(settled, true);
 	});
 
 	it("passes loader cancellation through the slash-command executor", async () => {

--- a/tests/fixtures/process-fixture.mjs
+++ b/tests/fixtures/process-fixture.mjs
@@ -11,6 +11,11 @@ if (mode === "success") {
 	process.exit(0);
 }
 
+if (mode === "environment") {
+	process.stdout.write(JSON.stringify({ fallowCovBin: process.env.FALLOW_COV_BIN ?? null, apiKey: process.env.FALLOW_API_KEY ?? null }));
+	process.exit(0);
+}
+
 if (mode === "findings") {
 	process.stdout.write(JSON.stringify({ kind: "dead-code", schema_version: 7, version: "fixture", elapsed_ms: 1, total_issues: 1, unused_files: ["unused.ts"], unused_exports: [] }));
 	process.exit(1);

--- a/tests/navigator-loop.test.mjs
+++ b/tests/navigator-loop.test.mjs
@@ -89,6 +89,27 @@ describe("Fallow navigator action loop", () => {
 		assert.deepEqual(calls[2].protectedHistoryIds, ["r1", "r20"]);
 	});
 
+	it("forwards optional-analysis runs with scoped environment and restores the original navigator", async () => {
+		const responses = [
+			actionResult(["__pi-fallow-optional-analysis"]),
+			{ type: "forward", label: "Run Runtime Coverage", commandArgs: ["coverage", "analyze", "--runtime-coverage", "/tmp/v8"], executionEnvironment: { FALLOW_COV_BIN: "/managed/fallow-cov" } },
+			null,
+			{ type: "prompt", prompt: "restored", issueCount: 1, detail: "compact" },
+		];
+		const calls = [];
+		const result = await runFallowNavigatorLoop(["issues"], true, async (args, rememberLast, initialState, protectedIds, executionEnvironment) => {
+			calls.push({ args, initialState, executionEnvironment });
+			return responses.shift();
+		});
+		assert.equal(result?.type, "prompt");
+		assert.deepEqual(calls.map((entry) => entry.args), [
+			["issues"], ["__pi-fallow-optional-analysis"],
+			["coverage", "analyze", "--runtime-coverage", "/tmp/v8"], ["issues"],
+		]);
+		assert.deepEqual(calls[2].executionEnvironment, { FALLOW_COV_BIN: "/managed/fallow-cov" });
+		assert.equal(calls[3].initialState, state);
+	});
+
 	it("does not execute navigator actions outside TUI mode", async () => {
 		const calls = [];
 		const result = await runFallowNavigatorLoop(["issues"], false, async (args, rememberLast) => {

--- a/tests/navigator-mode.test.mjs
+++ b/tests/navigator-mode.test.mjs
@@ -12,7 +12,7 @@ const { hasFallowNavigator } = await jiti.import("../extensions/fallow/command/m
 const { buildFallowOverview } = await jiti.import("../extensions/fallow/overview.ts");
 
 describe("navigator command mode", () => {
-	it("does not open a finding navigator for type-aware status", () => {
+	it("does not open a finding navigator for type-aware status unless optional controls are requested", () => {
 		const status = buildFallowOverview({
 			kind: "type-aware-status",
 			available: true,
@@ -22,6 +22,9 @@ describe("navigator command mode", () => {
 
 		assert.equal(resolveFallowNavigatorMode(status), "none");
 		assert.equal(hasFallowNavigator("tui", status), false);
+		assert.equal(resolveFallowNavigatorMode(status, true), "informational");
+		assert.equal(hasFallowNavigator("tui", status, true), true);
+		assert.equal(hasFallowNavigator("rpc", status, true), false);
 	});
 
 	it("opens advisory similar-code candidates but not readiness status", () => {

--- a/tests/navigator.test.mjs
+++ b/tests/navigator.test.mjs
@@ -95,6 +95,19 @@ function loadEndFindingPrompt(overview, fullOutputPath, includeFullDetails) {
 }
 
 describe("FallowIssueNavigator prompt generation", () => {
+	it("opens visible optional-analysis controls without changing finding selection", () => {
+		let result = null;
+		const navigator = new FallowIssueNavigator(createOverview(), theme, (value) => { result = value; }, () => {}, {
+			commandArgs: ["issues"], optionalAnalysis: true,
+		});
+		assert.match(navigator.render(100).join("\n"), /o optional analysis.*Status \/ Setup \/ Run controls/);
+		navigator.handleInput("o");
+		assert.equal(result?.type, "action");
+		assert.deepEqual(result?.commandArgs, ["__pi-fallow-optional-analysis"]);
+		assert.deepEqual(result?.returnTo.commandArgs, ["issues"]);
+		assert.deepEqual(result?.returnTo.state.markedReportIndices, []);
+	});
+
 	it("builds an editable prompt for selected findings", () => {
 		let result = null;
 		let renderRequests = 0;

--- a/tests/optional-analysis.test.mjs
+++ b/tests/optional-analysis.test.mjs
@@ -1,0 +1,495 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const { runOptionalAnalysisWorkflow } = await jiti.import("../extensions/fallow/command/optional-analysis.ts");
+const {
+	createOptionalAnalysisState,
+	inspectRuntimeCoverageCapability,
+	parseCoverageSetupPlan,
+	parseSimilarCodeCapability,
+	resolveLocalArtifact,
+	runtimeCoverageInstallArgs,
+	runtimeCoverageSetupPreview,
+	similarCodeSetupPreview,
+	FALLOW_COV_VERSION,
+} = await jiti.import("../extensions/fallow/optional-analysis.ts");
+
+const SIMILAR_CODE_MODEL_ID = "jinaai/jina-embeddings-v2-base-code";
+const SIMILAR_CODE_MODEL_REVISION = "516f4baf13dec4ddddda8631e019b5737c8bc250";
+const FALLOW_COV_DIST_INTEGRITY = "sha512-j6vKYolLyuOdgoONTFoFZ7RBp5vx/U8lHx9sa1oMZetdD7XAwo3nMd11gQHKuDs2JiBcDTra7YpqxhUyjmz4YA==";
+const FALLOW_COV_PLATFORM_INTEGRITIES = {
+	"fallow-cov-darwin-arm64": "sha512-pahht40+IUCi8GFaiY10yVGKy5iwsKg62FwM31G+6UvWAYnrtvh/RpqFBVS5QkvhxBfK0kRr3wugaEfFMBsgVQ==",
+	"fallow-cov-darwin-x64": "sha512-hiX+xLSkxGI3UiB0MUleNAk8fHc8/iXaCLwJRRw3TMUlpdh/c/t4GFUUF9UIOcGq+lJtLScJHnfrhXL0u2BmqQ==",
+	"fallow-cov-linux-arm64-gnu": "sha512-/NegKdrIOd1uc/f4i1jRFgYX7j9OZgKnN4M2numcM2ThoRPIomULb/ZYFJxhqheEj8mtJiq9LyVqpNmZM+XHpw==",
+	"fallow-cov-linux-arm64-musl": "sha512-H1/fQ+tAaXSfCrnDFuGwmn6OYw0ZlQQVTwIPffBLTgZrud6uXkhKJKmZ68iodp6fG2AuEdRM4UJV+5/nkEb+ig==",
+	"fallow-cov-linux-x64-gnu": "sha512-CBHoqxAjDxPm3G4JER4G6OQR6Zrg9RTdRqIHmd0+Pv34elib7htFSmB9P3HfcSr8TGVCa/fuKcdANIMamcNBcw==",
+	"fallow-cov-linux-x64-musl": "sha512-/KR0kktHtf/ryO0bywaj1nzrj3XFLGP19aVG5iOiFYQJ1/a9ML5Tz+HFilSc0v6O+zSSvX7qaO98hOLjMHZOgQ==",
+	"fallow-cov-win32-x64-msvc": "sha512-hs0z/jiXtrffOiwPz/Zk1XnAr52Wjybkywk8l5ZlmPuRV7Dz1sw97Y66aQ2AKODeTqLAwFPVrFnV+Qst1UdEBA==",
+};
+
+const missingSimilarReport = {
+	kind: "similar-code-status",
+	schema_version: "1",
+	version: "3.21.0",
+	protocol_version: 2,
+	companion_version: "3.21.0",
+	model_ready: false,
+	model_id: SIMILAR_CODE_MODEL_ID,
+	model_revision: SIMILAR_CODE_MODEL_REVISION,
+	license: "Apache-2.0",
+	cache_dir: "/cache/model",
+	download_bytes: 324329844,
+	integrity_verified: false,
+	problem: "model missing",
+};
+
+const setupPlan = {
+	kind: "coverage-setup",
+	schema_version: "1",
+	commands: ["npm install @fallow-cli/beacon", "npm install --save-dev @fallow-cli/fallow-cov"],
+	files_to_edit: [{ path: "src/server.ts" }],
+	_meta: { telemetry: { analysis_run_id: "run-1" } },
+};
+
+function rawResult(data, code = 0) {
+	return { result: { stdout: JSON.stringify(data), stderr: "", code } };
+}
+
+function processResult(code = 0) {
+	return { stdout: "", stderr: "", code };
+}
+
+function choiceContaining(fragment) {
+	return (_title, options) => options.find((entry) => entry.includes(fragment));
+}
+
+function createContext(selectors, confirmations = [], inputs = []) {
+	const calls = { titles: [], options: [], confirmations: [], inputs: [] };
+	return {
+		calls,
+		context: {
+			mode: "tui",
+			hasUI: true,
+			cwd: "/project",
+			ui: {
+				async select(title, options) {
+					calls.titles.push(title);
+					calls.options.push(options);
+					const selector = selectors.shift();
+					return selector ? selector(title, options) : undefined;
+				},
+				async confirm(title, message) {
+					calls.confirmations.push({ title, message });
+					return confirmations.shift() ?? false;
+				},
+				async input(title, placeholder) {
+					calls.inputs.push({ title, placeholder });
+					return inputs.shift();
+				},
+				notify() {}, setStatus() {}, custom() {}, setEditorText() {},
+			},
+		},
+	};
+}
+
+function createDependencies(overrides = {}) {
+	const calls = { fallow: [], process: [], inspect: 0, artifact: [], savedOutput: [] };
+	const dependencies = {
+		async runFallow(args) {
+			calls.fallow.push(args);
+			throw new Error(`Unexpected Fallow command: ${args.join(" ")}`);
+		},
+		async runProcess(command, args) {
+			calls.process.push({ command, args });
+			throw new Error(`Unexpected process: ${command}`);
+		},
+		async inspectRuntime(plan) {
+			calls.inspect++;
+			return inspectRuntimeCoverageCapability(plan, "/missing/managed-sidecar");
+		},
+		async resolveArtifact(path) {
+			calls.artifact.push(path);
+			return `/resolved/${path}`;
+		},
+		async saveSetupOutput(stdout, stderr) {
+			calls.savedOutput.push({ stdout, stderr });
+			return "/tmp/pi-fallow-optional/setup-output.txt";
+		},
+		...overrides,
+	};
+	return { calls, dependencies };
+}
+
+describe("optional analysis capability metadata", () => {
+	it("classifies missing, ready, incompatible, and unverified Similar Code states", () => {
+		assert.equal(parseSimilarCodeCapability(missingSimilarReport).phase, "missing");
+		assert.equal(parseSimilarCodeCapability({ ...missingSimilarReport, model_ready: true, integrity_verified: true, problem: undefined }).phase, "ready");
+		assert.equal(parseSimilarCodeCapability({ ...missingSimilarReport, model_revision: "drift" }).phase, "incompatible");
+		assert.equal(parseSimilarCodeCapability({ ...missingSimilarReport, model_ready: true }).phase, "corrupt");
+		const bounded = parseSimilarCodeCapability({ ...missingSimilarReport, problem: "x".repeat(5_000) });
+		assert.equal(bounded.problem.length, 1_000);
+	});
+
+	it("rejects incompatible coverage plans and retains only bounded drift metadata", async () => {
+		assert.throws(() => parseCoverageSetupPlan({ kind: "coverage-setup", schema_version: "2" }), /incompatible/);
+		const first = parseCoverageSetupPlan(setupPlan);
+		const second = structuredClone(first);
+		second._meta.telemetry.analysis_run_id = "run-2";
+		const [left, right] = await Promise.all([
+			inspectRuntimeCoverageCapability(first, "/missing/a"),
+			inspectRuntimeCoverageCapability(second, "/missing/a"),
+		]);
+		assert.equal(left.planFingerprint, right.planFingerprint);
+		const largePlan = {
+			...setupPlan,
+			commands: Array.from({ length: 15 }, (_, index) => `${index}:${"x".repeat(400)}`),
+			files_to_edit: Array.from({ length: 25 }, (_, index) => ({ path: `file-${index}.ts` })),
+		};
+		const bounded = await inspectRuntimeCoverageCapability(largePlan, "/missing/b");
+		assert.equal(bounded.plan.commands.length, 10);
+		assert.equal(bounded.plan.omittedCommands, 5);
+		assert.equal(bounded.plan.filesToEdit.length, 20);
+		assert.equal(bounded.plan.omittedFiles, 5);
+		assert.match(runtimeCoverageSetupPreview(bounded), /\+5 more not shown/);
+	});
+
+	it("verifies exact installed wrapper, platform package, binary, and detached signature", async () => {
+		const root = await mkdtemp(join(tmpdir(), "pi-fallow-cov-status-"));
+		const scope = join(root, "node_modules", "@fallow-cli");
+		const platformPackage = process.platform === "darwin"
+			? `fallow-cov-darwin-${process.arch}`
+			: process.platform === "win32" ? `fallow-cov-win32-${process.arch}-msvc` : `fallow-cov-linux-${process.arch}-gnu`;
+		try {
+			await mkdir(join(scope, "fallow-cov"), { recursive: true });
+			await mkdir(join(scope, platformPackage), { recursive: true });
+			await writeFile(join(scope, "fallow-cov", "package.json"), JSON.stringify({ name: "@fallow-cli/fallow-cov", version: FALLOW_COV_VERSION, license: "SEE LICENSE IN LICENSE" }));
+			await writeFile(join(root, "node_modules", ".package-lock.json"), JSON.stringify({ packages: {
+				"node_modules/@fallow-cli/fallow-cov": { integrity: FALLOW_COV_DIST_INTEGRITY },
+				[`node_modules/@fallow-cli/${platformPackage}`]: { integrity: FALLOW_COV_PLATFORM_INTEGRITIES[platformPackage] },
+			} }));
+			await writeFile(join(scope, platformPackage, "package.json"), JSON.stringify({ name: `@fallow-cli/${platformPackage}`, version: FALLOW_COV_VERSION }));
+			const binary = join(scope, platformPackage, process.platform === "win32" ? "fallow-cov.exe" : "fallow-cov");
+			await writeFile(binary, "binary");
+			await chmod(binary, 0o755);
+			await writeFile(`${binary}.sig`, "signature");
+			const status = await inspectRuntimeCoverageCapability(setupPlan, root);
+			assert.equal(status.phase, "ready");
+			assert.equal(status.packageMetadataVerified, true);
+			assert.equal(status.signaturePresent, true);
+			assert.equal(status.binaryPath, await realpath(binary));
+			assert.ok(status.installedBytes > 0);
+			await rm(`${binary}.sig`);
+			assert.equal((await inspectRuntimeCoverageCapability(setupPlan, root)).phase, "corrupt");
+			await writeFile(`${binary}.sig`, "signature");
+			await writeFile(join(scope, "fallow-cov", "package.json"), JSON.stringify({ name: "@fallow-cli/fallow-cov", version: "9.9.9" }));
+			assert.equal((await inspectRuntimeCoverageCapability(setupPlan, root)).phase, "incompatible");
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("canonicalizes managed destinations through existing symlink ancestors", async () => {
+		const root = await mkdtemp(join(tmpdir(), "pi-fallow-tools-link-"));
+		try {
+			const project = join(root, "project");
+			const alias = join(root, "tools-link");
+			await mkdir(project);
+			await symlink(project, alias, process.platform === "win32" ? "junction" : "dir");
+			const status = await inspectRuntimeCoverageCapability(setupPlan, join(alias, "fallow-cov"));
+			assert.equal(status.destination, join(await realpath(project), "fallow-cov"));
+			assert.equal(status.phase, "missing");
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts only existing local artifact files or directories", async () => {
+		const root = await mkdtemp(join(tmpdir(), "pi-fallow-artifact-"));
+		try {
+			const file = join(root, "coverage.json");
+			await writeFile(file, "{}");
+			assert.equal(await resolveLocalArtifact(file), await realpath(file));
+			assert.equal(await resolveLocalArtifact(root), await realpath(root));
+			await assert.rejects(() => resolveLocalArtifact("https://example.com/coverage.json"), /Cloud and URL artifacts are not supported/);
+			await assert.rejects(() => resolveLocalArtifact(join(root, "missing.json")));
+		} finally {
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("discloses source, revision/version, license, size, destination, command, and excluded cloud effects", async () => {
+		const similar = similarCodeSetupPreview(parseSimilarCodeCapability(missingSimilarReport));
+		assert.match(similar, /Hugging Face/);
+		assert.match(similar, new RegExp(SIMILAR_CODE_MODEL_REVISION));
+		assert.match(similar, /Apache-2\.0.*309 MiB.*1\.2 GiB/s);
+		assert.match(similar, /Destination: \/cache\/model/);
+		assert.match(similar, /--local --yes/);
+		const coverageStatus = await inspectRuntimeCoverageCapability(setupPlan, "/managed/fallow-cov");
+		const coverage = runtimeCoverageSetupPreview(coverageStatus);
+		assert.match(coverage, /@fallow-cli\/fallow-cov@0\.4\.1/);
+		assert.match(coverage, /Proprietary/);
+		assert.match(coverage, /approximately 3 MiB/);
+		assert.match(coverage, /Destination: \/managed\/fallow-cov/);
+		assert.match(coverage, /--ignore-scripts --no-save --package-lock=false/);
+		assert.match(coverage, /will NOT perform.*beacon.*src\/server\.ts/s);
+	});
+});
+
+describe("optional analysis overlay workflow", () => {
+	it("shows separate Status, Setup, and Run rows without executing anything when opened", async () => {
+		const state = createOptionalAnalysisState();
+		const { context, calls: uiCalls } = createContext([choiceContaining("Back")]);
+		const { calls, dependencies } = createDependencies();
+		assert.equal(await runOptionalAnalysisWorkflow({}, context, state, dependencies), null);
+		const labels = uiCalls.options[0];
+		assert.equal(labels.filter((label) => /Status/.test(label)).length, 2);
+		assert.equal(labels.filter((label) => /Setup/.test(label)).length, 2);
+		assert.equal(labels.filter((label) => /· Run/.test(label)).length, 2);
+		assert.deepEqual(calls.fallow, []);
+		assert.deepEqual(calls.process, []);
+	});
+
+	it("runs read-only Similar Code Status without installing", async () => {
+		const { context, calls: uiCalls } = createContext([choiceContaining("Similar Code · Status"), choiceContaining("Back")]);
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(missingSimilarReport); },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.deepEqual(calls.fallow, [["similar-code", "status", "--format", "json", "--quiet"]]);
+		assert.deepEqual(calls.process, []);
+		assert.equal(uiCalls.confirmations.length, 0);
+		assert.equal(state.similarCode.phase, "missing");
+	});
+
+	it("displays the read-only runtime setup plan from Status without installing", async () => {
+		const { context, calls: uiCalls } = createContext([choiceContaining("Runtime Coverage · Status"), choiceContaining("Back")]);
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(setupPlan); },
+		});
+		await runOptionalAnalysisWorkflow({}, context, createOptionalAnalysisState(), dependencies);
+		assert.deepEqual(calls.fallow, [["coverage", "setup", "--json", "--root", "."]]);
+		assert.equal(calls.process.length, 0);
+		assert.match(uiCalls.titles[1], /will NOT perform.*beacon.*src\/server\.ts/s);
+	});
+
+	it("does not download Similar Code when setup confirmation is declined", async () => {
+		const { context, calls: uiCalls } = createContext([choiceContaining("Similar Code · Setup"), choiceContaining("Back")], [false]);
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(missingSimilarReport); },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(calls.fallow.length, 1);
+		assert.equal(calls.fallow.some((args) => args.includes("setup")), false);
+		assert.equal(calls.process.length, 0);
+		assert.match(uiCalls.confirmations[0].message, /309 MiB/);
+		assert.match(state.notice, /declined/);
+	});
+
+	it("runs exact Similar Code setup only after confirmation and verifies readiness", async () => {
+		const { context } = createContext([choiceContaining("Similar Code · Setup"), choiceContaining("Back")], [true]);
+		const ready = { ...missingSimilarReport, model_ready: true, integrity_verified: true, problem: undefined };
+		const reports = [missingSimilarReport, missingSimilarReport, { kind: "similar-code-setup" }, ready];
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(reports.shift()); },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.deepEqual(calls.fallow[2], ["similar-code", "setup", "--local", "--yes", "--format", "json", "--quiet"]);
+		assert.equal(state.similarCode.phase, "ready");
+		assert.equal(state.completeSetupOutputPath, "/tmp/pi-fallow-optional/setup-output.txt");
+		assert.equal(calls.savedOutput.length, 1);
+		assert.match(state.notice, /integrity was verified/);
+	});
+
+	it("rechecks partial Similar Code state after setup cancellation", async () => {
+		const { context } = createContext([choiceContaining("Similar Code · Setup"), choiceContaining("Back")], [true]);
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) {
+				calls.fallow.push(args);
+				return args[1] === "setup" ? null : rawResult(missingSimilarReport);
+			},
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(calls.fallow.length, 4);
+		assert.match(state.notice, /cancelled.*partial state/);
+	});
+
+	it("reports failed Similar Code setup without claiming readiness", async () => {
+		const { context } = createContext([choiceContaining("Similar Code · Setup"), choiceContaining("Back")], [true]);
+		const { dependencies } = createDependencies({
+			async runFallow(args) {
+				return args[1] === "setup"
+					? { result: { stdout: "", stderr: "verification failed", code: 2 } }
+					: rawResult(missingSimilarReport);
+			},
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(state.similarCode.phase, "missing");
+		assert.match(state.notice, /setup failed: verification failed/);
+	});
+
+	it("forwards Similar Code Run only after a fresh integrity-verified status", async () => {
+		const { context } = createContext([choiceContaining("Similar Code · Run")], [], ["src/a.ts", "0.8", "5"]);
+		const ready = { ...missingSimilarReport, model_ready: true, integrity_verified: true, problem: undefined };
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(ready); },
+		});
+		const result = await runOptionalAnalysisWorkflow({}, context, createOptionalAnalysisState(), dependencies);
+		assert.deepEqual(result, {
+			type: "forward", label: "Run Similar Code",
+			commandArgs: ["similar-code", "--file", "src/a.ts", "--threshold", "0.8", "--top", "5"],
+		});
+		assert.equal(calls.process.length, 0);
+	});
+
+	it("stops Similar Code setup when status drifts after confirmation", async () => {
+		const { context } = createContext([choiceContaining("Similar Code · Setup"), choiceContaining("Back")], [true]);
+		const reports = [missingSimilarReport, { ...missingSimilarReport, cache_dir: "/changed/cache" }];
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(reports.shift()); },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(calls.fallow.length, 2);
+		assert.equal(calls.fallow.some((args) => args.includes("setup")), false);
+		assert.match(state.notice, /changed after preview/);
+	});
+
+	it("installs the runtime sidecar only after confirmation and unchanged plan", async () => {
+		const { context, calls: uiCalls } = createContext([choiceContaining("Runtime Coverage · Setup"), choiceContaining("Back")], [true]);
+		let inspectCount = 0;
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult({ ...setupPlan, _meta: { telemetry: { analysis_run_id: `run-${calls.fallow.length}` } } }); },
+			async inspectRuntime(plan) {
+				calls.inspect++;
+				inspectCount++;
+				if (inspectCount < 3) return inspectRuntimeCoverageCapability(plan, "/missing/managed-sidecar");
+				return { ...(await inspectRuntimeCoverageCapability(plan, "/missing/managed-sidecar")), phase: "ready", binaryPath: "/managed/fallow-cov" };
+			},
+			async runProcess(command, args) { calls.process.push({ command, args }); return processResult(); },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(uiCalls.confirmations.length, 1);
+		assert.equal(calls.process.length, 1);
+		assert.equal(calls.process[0].command, "npm");
+		assert.deepEqual(calls.process[0].args, runtimeCoverageInstallArgs("/missing/managed-sidecar"));
+		assert.equal(calls.fallow.length, 3);
+		assert.equal(state.completeSetupOutputPath, "/tmp/pi-fallow-optional/setup-output.txt");
+		assert.equal(calls.savedOutput.length, 1);
+		assert.match(state.notice, /installed in the managed cache/);
+	});
+
+	it("rechecks partial runtime state after setup cancellation", async () => {
+		const { context } = createContext([choiceContaining("Runtime Coverage · Setup"), choiceContaining("Back")], [true]);
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(setupPlan); },
+			async runProcess(command, args) { calls.process.push({ command, args }); return null; },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(calls.fallow.length, 3);
+		assert.match(state.notice, /cancelled.*partial state/);
+	});
+
+	it("stops runtime setup when the read-only plan drifts after confirmation", async () => {
+		const { context } = createContext([choiceContaining("Runtime Coverage · Setup"), choiceContaining("Back")], [true]);
+		const plans = [setupPlan, { ...setupPlan, commands: [...setupPlan.commands, "new command"] }];
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(plans.shift()); },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(calls.process.length, 0);
+		assert.match(state.notice, /plan changed after preview/);
+	});
+
+	it("reports failed runtime setup and rechecks partial state", async () => {
+		const { context } = createContext([choiceContaining("Runtime Coverage · Setup"), choiceContaining("Back")], [true]);
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(setupPlan); },
+			async runProcess(command, args) { calls.process.push({ command, args }); return { stdout: "", stderr: "network failed", code: 1 }; },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(calls.fallow.length, 3);
+		assert.match(state.notice, /setup failed: network failed/);
+	});
+
+	it("blocks runtime setup when the configured tools destination is inside the project", async () => {
+		const { context, calls: uiCalls } = createContext([choiceContaining("Runtime Coverage · Setup"), choiceContaining("Back")], [true]);
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(setupPlan); },
+			async inspectRuntime(plan) { calls.inspect++; return inspectRuntimeCoverageCapability(plan, "/project/.tools/fallow-cov"); },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(uiCalls.confirmations.length, 0);
+		assert.equal(calls.process.length, 0);
+		assert.match(state.notice, /inside the project/);
+	});
+
+	it("declines runtime setup without invoking npm", async () => {
+		const { context } = createContext([choiceContaining("Runtime Coverage · Setup"), choiceContaining("Back")], [false]);
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(setupPlan); },
+		});
+		const state = createOptionalAnalysisState();
+		await runOptionalAnalysisWorkflow({}, context, state, dependencies);
+		assert.equal(calls.process.length, 0);
+		assert.match(state.notice, /declined/);
+	});
+
+	it("stops runtime Run if the sidecar drifts while the artifact is selected", async () => {
+		const ready = { ...(await inspectRuntimeCoverageCapability(setupPlan, "/missing/managed-sidecar")), phase: "ready", binaryPath: "/managed/fallow-cov", signaturePath: "/managed/fallow-cov.sig" };
+		const { context } = createContext([choiceContaining("Runtime Coverage · Run"), choiceContaining("Back")], [true], ["coverage/v8"]);
+		let inspections = 0;
+		const { dependencies } = createDependencies({
+			async runFallow() { return rawResult(setupPlan); },
+			async inspectRuntime() { return inspections++ === 0 ? ready : { ...ready, phase: "corrupt", fingerprint: "drift" }; },
+		});
+		const state = createOptionalAnalysisState();
+		assert.equal(await runOptionalAnalysisWorkflow({}, context, state, dependencies), null);
+		assert.match(state.notice, /status changed while selecting/);
+	});
+
+	it("forwards runtime analysis only with a selected local artifact and managed binary", async () => {
+		const { context, calls: uiCalls } = createContext([choiceContaining("Runtime Coverage · Run")], [true], ["coverage/v8"]);
+		const ready = { ...(await inspectRuntimeCoverageCapability(setupPlan, "/missing/managed-sidecar")), phase: "ready", binaryPath: "/managed/fallow-cov" };
+		const { calls, dependencies } = createDependencies({
+			async runFallow(args) { calls.fallow.push(args); return rawResult(setupPlan); },
+			async inspectRuntime() { calls.inspect++; return ready; },
+		});
+		const result = await runOptionalAnalysisWorkflow({}, context, createOptionalAnalysisState(), dependencies);
+		assert.equal(result.type, "forward");
+		assert.deepEqual(result.commandArgs, ["coverage", "analyze", "--runtime-coverage", "/resolved/coverage/v8"]);
+		assert.match(uiCalls.confirmations[0].message, /Resolved artifact: v8 \(\/resolved\/coverage\/v8\)/);
+		assert.deepEqual(result.executionEnvironment, {
+			FALLOW_COV_BIN: "/managed/fallow-cov",
+			FALLOW_RUNTIME_COVERAGE_SOURCE: undefined,
+			FALLOW_API_KEY: undefined,
+			FALLOW_API_URL: undefined,
+			FALLOW_REPO: undefined,
+			FALLOW_CA_BUNDLE: undefined,
+		});
+		assert.deepEqual(calls.artifact, ["coverage/v8"]);
+	});
+
+	it("never opens interactive controls outside TUI mode", async () => {
+		const { context } = createContext([]);
+		context.mode = "rpc";
+		const { calls, dependencies } = createDependencies();
+		assert.equal(await runOptionalAnalysisWorkflow({}, context, createOptionalAnalysisState(), dependencies), null);
+		assert.deepEqual(calls.fallow, []);
+		assert.deepEqual(calls.process, []);
+	});
+});

--- a/tests/runner.test.mjs
+++ b/tests/runner.test.mjs
@@ -63,6 +63,24 @@ describe("Fallow runner resolution", { concurrency: false }, () => {
 		assert.equal(executions, 0);
 	});
 
+	it("passes scoped child environment through without changing route discovery", async () => {
+		const restore = setEnvironment({ FALLOW_BIN: "/configured/fallow", PATH: "/unused" });
+		let receivedEnvironment;
+		const runner = createFallowRunner({
+			packageRoot: null,
+			executeProcess: async (_command, _args, _cwd, _signal, _timeout, environment) => {
+				receivedEnvironment = environment;
+				return executionResult();
+			},
+		});
+		try {
+			await runner.execute({}, ["coverage", "analyze"], "/project", undefined, 10, { FALLOW_COV_BIN: "/managed/fallow-cov" });
+			assert.deepEqual(receivedEnvironment, { FALLOW_COV_BIN: "/managed/fallow-cov" });
+		} finally {
+			restore();
+		}
+	});
+
 	it("treats an explicit FALLOW_BIN launch failure as final", async () => {
 		const restore = setEnvironment({ FALLOW_BIN: "/configured/fallow", PATH: "/unused" });
 		const calls = [];


### PR DESCRIPTION
## Summary
- add visible TUI-only Status, Setup, and Run actions for Similar Code and local Runtime Coverage
- require drift-bound previews and explicit confirmation before model or sidecar setup, with cancellable progress, post-setup verification, and complete setup output
- verify the exact managed `@fallow-cli/fallow-cov@0.4.1` wrapper/platform packages and registry integrity outside the project
- collect Similar Code scope/threshold/top options and preview explicitly selected runtime artifacts before local execution
- preserve navigator state, scope the verified sidecar to the analysis child, and strip cloud/API environment variables

## Safety boundaries
- overlay open, Status, selection changes, Run, and non-TUI modes never install
- Similar Code setup delegates only to `fallow similar-code setup --local --yes` after confirmation
- Runtime Coverage setup uses scripts-disabled npm installation in a user-global Pi Fallow tools directory
- Fallow’s coverage setup plan is displayed but its beacon, credentials, project files, and cloud work are not performed
- no project manifest, project lockfile, credentials, cloud opt-in, cache clear, release, or tag changes

## Validation
- Node 24: 266/266 tests
- Node 22.19: 266/266 tests
- coverage: 90.48% statements/lines, 85.08% branches, 90.06% functions
- bundle checks and Pi 0.84.3 package smoke
- Fallow health: no complexity findings
- Fallow dead-code: 0; duplication: 0; PR audit: pass
- real signed fallow-cov certification passed
- npm production/full audit: 0 vulnerabilities

Closes #86