### PR TITLE
feat: add safe Fallow configuration assistant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Pi Fallow are documented here.
 ## [Unreleased]
 
 ### Added
+- Added `/fallow config-assist` for bounded read-only configuration inspection and schema-checked rule-severity previews. Applying is TUI-only and requires direct confirmation followed by discovery/schema/content drift checks; project-root JSON, JSONC, and TOML updates preserve unrelated text, back up existing files, and commit atomically without copying inherited values or secrets into transcripts.
 - Added explicit `/fallow compatibility` diagnostics that compare the installed read-only capability schema with the frozen certified surface, distinguish bounded additive guidance from modeled incompatibilities, identify affected Pi Fallow commands, and never install, gate execution, or run during startup/autocomplete.
 - Added inline Runtime Coverage artifact editing and preview with session-local feedback retention, explicit local/unknown-production limitations, and cancellable artifact/sidecar revalidation in both the form and executor. Requests pin the verified sidecar, strip cloud overrides, and disable analysis caching; no capture, upload, or project mutation is performed.
 - Added inline Similar Code scope, threshold, and result-limit editing with field validation, readiness-gated shell-free run requests through the existing loader, and form-state restoration when returning from results. Configuration prompts remain only in the legacy `o` workflow; shared in-overlay execution is follow-up work.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Manual slash command examples:
 /fallow rerun
 /fallow about
 /fallow compatibility
+/fallow config-assist
+/fallow config-assist preview-rule unused-exports warn
+/fallow config-assist apply-rule unused-exports warn
 /fallow audit --base origin/main --gate new-only
 /fallow check-changed --changed-since main
 /fallow dead-code --changed-since main
@@ -117,7 +120,7 @@ Set `PI_FALLOW_DEFAULT_COMMAND` to a shell-free command string to replace the ag
 export PI_FALLOW_DEFAULT_COMMAND='health --complexity --targets --score'
 ```
 
-Arguments after `/fallow run` are appended to the configured default. Explicit commands such as `/fallow dupes` are never replaced. Recursive or extension-only defaults such as `run`, `rerun`, `history`, `about`, or `compatibility` are rejected.
+Arguments after `/fallow run` are appended to the configured default. Explicit commands such as `/fallow dupes` are never replaced. Recursive or extension-only defaults such as `run`, `rerun`, `history`, `about`, `compatibility`, or `config-assist` are rejected.
 
 `/fallow check-changed` is a Pi Fallow convenience alias for Fallow's combined root analysis with `--changed-since`.
 
@@ -130,6 +133,14 @@ The agent-facing `fallow_run` tool passes command-specific flags as separate `ar
 When `fallow_run` is active, its compact Pi prompt guidance tells the model to inspect or trace before deletion, treat incomplete type-aware evidence as advisory, preview fixes before applying them, avoid unrequested changes, and reserve raw detail for necessary diagnostics.
 
 `--type-aware-project` selects a TypeScript project and `--type-aware-require best-effort|complete` controls required completeness. Always inspect the returned type-aware completeness, omissions, and abstentions: incomplete evidence remains advisory and must not be treated as exact delete-safety proof. Fallow also supports `--baseline-mode count|identity` for health baselines and `--no-type-aware` to override config for a syntactic-only run.
+
+### Safe configuration assistant
+
+`/fallow config-assist` (or `/fallow config-assist inspect`) performs an explicit read-only inspection of Fallow's discovered source and resolved configuration. It reports only ownership, format, and bounded counts for entries, rules, workspaces, plugins, boundaries, and overrides. Resolved values, plugin names, workspace names, secrets, and unrelated configuration are not copied into the transcript or diagnostic logs. The probe uses the installed `config`, `config --path`, and—when previewing—`config-schema` commands with installing `npx` fallback disabled. It never runs during extension load, startup, autocomplete, or ordinary analysis.
+
+Customization is deliberately narrow and structured: `preview-rule RULE error|warn|off` previews one schema-recognized rule severity, while `apply-rule RULE error|warn|off` shows the same bounded preview and is available only in interactive TUI mode. Natural-language edits, arbitrary schema paths, Fallow `init`, global configuration management, Pi/provider settings, and prompt-template management remain out of scope. Malformed or unknown inputs are refused with the source file and schema path.
+
+Inspection and preview never write. Apply requires a direct confirmation in Pi's TUI, then repeats config discovery, installed-schema hashing, and source-content checks. Any concurrent drift or cancellation refuses the stale plan. Pi Fallow modifies only a recognized config file directly in the active project root; inherited or external configuration remains read-only, and a project-local `.fallowrc.jsonc` references the inherited source through `extends` without copying its values. Existing JSON/JSONC/TOML files are patched at only the requested scalar, preserving comments and surrounding formatting. A byte-exact, same-permission backup is written beside an existing file as `.pi-fallow.bak` (using the first free numeric suffix), and the replacement uses a synced same-directory temporary file plus atomic rename. New files use an exclusive atomic link so a concurrently created config is never overwritten. Failed or cancelled pre-commit writes clean up temporary backups/files.
 
 ### Optional analysis controls
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,8 +13,8 @@ This roadmap describes the current baseline and likely next work. It is planning
 
 Unless noted otherwise, these are repository-specific measurements from the `0.5.0` release candidate, not universal expectations for other machines, hosts, Fallow installations, or providers.
 
-- **Tests and coverage:** 412 tests; current coverage is **92.57% statements/lines**, **88.47% branches**, and **92.40% functions**. The `0.5.0` release-candidate snapshot recorded **88.50% statements/lines**, **86.35% branches**, and **85.44% functions**; subprocess-sensitive reruns can vary slightly by run and Node line while CI continues to enforce the coverage thresholds.
-- **Fallow quality:** Fallow 3.22 reports health **83.8 (B)**, average maintainability **90.3**, and zero threshold findings, dead-code issues, or clone groups.
+- **Tests and coverage:** 419 tests; current coverage is **91.94% statements/lines**, **87.37% branches**, and **91.16% functions**. The `0.5.0` release-candidate snapshot recorded **88.50% statements/lines**, **86.35% branches**, and **85.44% functions**; subprocess-sensitive reruns can vary slightly by run and Node line while CI continues to enforce the coverage thresholds.
+- **Fallow quality:** Fallow 3.22 reports health **83.9 (B)**, average maintainability **90.3**, and zero threshold findings, dead-code issues, or clone groups.
 - **Dependency audits:** strict production and complete-tree npm audits report zero vulnerabilities. These audit results are separate from Fallow's modeled security-candidate analysis.
 - **Host compatibility:** packaged, provider-free Pi **0.84.4** behavior is certified on Node **22.19** and **24**. Pi host libraries intentionally remain external wildcard peers; this is a tested compatibility matrix, not a restrictive peer range or provider-backed/PTY/tmux certification. See the [README compatibility section](./README.md#tested-compatibility).
 - **Token baseline:** the current `fallow_run` tool contract is **421 tokens under both pinned tokenizers**. Across the frozen corpus, bounded tool results total **8,036 `o200k_base` / 7,925 `cl100k_base` tokens**. The output-detail work leaves the benchmarked slash-command and editor-prompt surfaces unchanged and reduces aggregate `o200k_base` tool-result tokens by **82.16%** from the immediate pre-output-detail baseline. These are deterministic corpus measurements, not provider billing claims; see [`benchmarks/README.md`](./benchmarks/README.md).
@@ -33,6 +33,7 @@ The long measurement history belongs in the benchmark documentation rather than 
 - measured model guidance for deletion evidence, fix previews, advisory type-aware results, and routine bounded detail;
 - a typed command registry shared by tool, slash, autocomplete, and smoke-test surfaces, including architecture-to-`guard` support;
 - explicit, read-only `/fallow compatibility` diagnostics over the installed capability manifest, with bounded additive guidance, affected-command incompatibilities, frozen drift mutations, and no startup probe or runtime gate;
+- a bounded `/fallow config-assist` workflow for read-only ownership/count inspection and schema-checked rule-severity previews, with TUI-only confirmation, drift refusal, exact backups, atomic project-local writes, inherited-config isolation, and no secret-bearing resolved values in transcripts;
 - authoritative normalized-report selection shared across output and prompts, with complete-report hydration and drift protection;
 - bounded, project-isolated session history with digest-validated report reopening and conservative compatible-run comparison;
 - explicit opt-in semantic similar-code status, discovery, inspect, and review flows with local-model provenance and advisory completion, plus TUI-only previewed and confirmed model setup and reproducible, no-cache model-backed certification over a frozen tiny project;
@@ -44,10 +45,9 @@ See [`benchmarks/README.md`](./benchmarks/README.md), [`benchmarks/PERFORMANCE.m
 ## Remaining priorities
 
 1. **Keep command and report compatibility honest.** Frozen capability-schema, installed-capability diagnostics, and live registry-prefix checks cover managed output, positional targets, selected type-aware flags, issue registries, and bounded additive/removal guidance (see [`fixture scope`](./tests/fixtures/fallow/README.md)). Real dead-code, duplication, health, security, combined, unavailable/partial type-aware, signed runtime-coverage, and complete model-backed Similar Code discovery/inspect/review evidence supplement those checks. Continue refreshing this evidence deliberately as Fallow evolves while preserving graceful behavior with separately installed versions.
-2. **Decide whether user-owned customization is still desired.** If demand remains, design Pi Fallow-specific global/project configuration, prompt templates, and a safe prompt/config preview without taking ownership of Fallow's configuration file.
-3. **Refine navigator workflows from evidence.** Make any remaining history, comparison, or UI density improvements only when real large-report use identifies a concrete need.
-4. **Improve quality where evidence points.** Raise coverage and maintainability gradually around real execution, command-flow, rendering, project-state, and PR-summary hotspots. Do not split files cosmetically merely to improve a metric.
-5. **Maintain compatibility and supply-chain gates.** Keep Pi, Fallow, Node, and dependency compatibility current with strict production/complete-tree audits and repeatable package-boundary certification.
+2. **Refine navigator workflows from evidence.** Make any remaining history, comparison, or UI density improvements only when real large-report use identifies a concrete need.
+3. **Improve quality where evidence points.** Raise coverage and maintainability gradually around real execution, command-flow, rendering, project-state, configuration assistance, and PR-summary hotspots. Do not split files cosmetically merely to improve a metric.
+4. **Maintain compatibility and supply-chain gates.** Keep Pi, Fallow, Node, and dependency compatibility current with strict production/complete-tree audits and repeatable package-boundary certification.
 
 ## Invariants
 
@@ -61,5 +61,5 @@ Future work must preserve these boundaries:
 
 ## Suggested delivery order
 
-1. Confirm demand and scope before implementing user-owned configuration or prompt customization/preview.
-2. Iterate on navigator density, performance evidence, hotspot coverage, maintainability, and dependency compatibility in small independently reviewed changes.
+1. Iterate on navigator density and project-issues performance evidence where measured use identifies a concrete problem.
+2. Improve hotspot coverage, maintainability, and dependency compatibility in small independently reviewed changes.

--- a/extensions/fallow.ts
+++ b/extensions/fallow.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { fallowCompletions } from "./fallow/autocomplete";
 import { fallowCli } from "./fallow/cli";
 import { renderFallowCompatibilityMessage } from "./fallow/compatibility";
+import { renderFallowConfigAssistantMessage } from "./fallow/config-assistant";
 import { fallowToolContract } from "./fallow/contract";
 import { runFallowCommandHandler } from "./fallow/command/handler";
 import { fallowArgumentHint } from "./fallow/registry";
@@ -59,5 +60,8 @@ function registerFallowResultRenderer(pi: ExtensionAPI): void {
 	);
 	pi.registerMessageRenderer("fallow-compatibility", (message, options, theme) =>
 		renderFallowCompatibilityMessage(message, options, theme),
+	);
+	pi.registerMessageRenderer("fallow-config-assistant", (message, options, theme) =>
+		renderFallowConfigAssistantMessage(message, options, theme),
 	);
 }

--- a/extensions/fallow/autocomplete.ts
+++ b/extensions/fallow/autocomplete.ts
@@ -240,6 +240,17 @@ const HISTORY_SUBCOMMANDS: CompletionSpec[] = [
 	{ value: "clear", description: "Clear project history metadata without deleting report files" },
 ];
 
+const CONFIG_ASSIST_SUBCOMMANDS: CompletionSpec[] = [
+	{ value: "inspect", description: "Summarize resolved configuration without exposing values" },
+	{ value: "preview-rule", description: "Preview a project rule-severity change without writing" },
+	{ value: "apply-rule", description: "Preview, confirm, drift-check, and atomically apply a rule severity" },
+];
+
+const CONFIG_SEVERITIES: CompletionSpec[] = ["error", "warn", "off"].map((value) => ({
+	value,
+	description: `Set rule severity to ${value}`,
+}));
+
 const IMPACT_FLAGS: FlagSpec[] = [
 	{ flag: "--all", description: "Aggregate every tracked project" },
 	{ flag: "--sort", description: "Sort --all rows", values: ["recent", "resolved", "contained", "name"] },
@@ -430,7 +441,7 @@ function isCoverageAnalyze(first: string, second: string | undefined): boolean {
 	return first === "coverage" && second === "analyze";
 }
 
-const COMMANDS_WITHOUT_FLAGS = new Set(["rerun", "about", "version", "update", "compatibility"]);
+const COMMANDS_WITHOUT_FLAGS = new Set(["rerun", "about", "version", "update", "compatibility", "config-assist"]);
 
 function allFlags(command: string | undefined): FlagSpec[] {
 	if (isCommandWithoutFlags(command)) return [];
@@ -604,9 +615,24 @@ function resolvePositionalCompletions(context: ReturnType<typeof analyzeFallowAr
 
 function completeCommandPosition(context: ReturnType<typeof analyzeFallowArgumentContext>): AutocompleteItem[] | null {
 	if (shouldCompleteCoverageAnalyze(context.previousTokens)) return completeCoverageAnalyze(context);
+	return completeNamedCommandPosition(context);
+}
+
+function completeNamedCommandPosition(context: ReturnType<typeof analyzeFallowArgumentContext>): AutocompleteItem[] | null {
 	if (shouldCompleteSimilarCodeSubcommand(context)) return completeSimilarCodeSubcommand(context);
 	if (shouldCompleteHistorySubcommand(context)) return completeHistorySubcommand(context);
+	if (isConfigAssistPosition(context)) return completeConfigAssistPosition(context);
 	return completeFlags(context.beforeCurrent, context.current, context.flags, context.usedFlags);
+}
+
+function isConfigAssistPosition(context: ReturnType<typeof analyzeFallowArgumentContext>): boolean {
+	return context.command === "config-assist";
+}
+
+function completeConfigAssistPosition(context: ReturnType<typeof analyzeFallowArgumentContext>): AutocompleteItem[] | null {
+	if (shouldCompleteConfigAssistSubcommand(context)) return completeConfigAssistSubcommand(context);
+	if (shouldCompleteConfigSeverity(context)) return completeConfigSeverity(context);
+	return null;
 }
 
 function shouldCompleteCoverageAnalyze(tokens: string[]): boolean {
@@ -621,6 +647,16 @@ function shouldCompleteSimilarCodeSubcommand(context: ReturnType<typeof analyzeF
 
 function shouldCompleteHistorySubcommand(context: ReturnType<typeof analyzeFallowArgumentContext>): boolean {
 	return context.command === "history" && context.previousTokens.length === 1 && !context.current.startsWith("-");
+}
+
+function shouldCompleteConfigAssistSubcommand(context: ReturnType<typeof analyzeFallowArgumentContext>): boolean {
+	return context.command === "config-assist" && context.previousTokens.length === 1;
+}
+
+function shouldCompleteConfigSeverity(context: ReturnType<typeof analyzeFallowArgumentContext>): boolean {
+	return context.command === "config-assist"
+		&& ["preview-rule", "apply-rule"].includes(context.previousTokens[1] ?? "")
+		&& context.previousTokens.length === 3;
 }
 
 function completeRootPosition(context: ReturnType<typeof analyzeFallowArgumentContext>): AutocompleteItem[] | null {
@@ -643,6 +679,16 @@ function completeSimilarCodeSubcommand(context: ReturnType<typeof analyzeFallowA
 
 function completeHistorySubcommand(context: ReturnType<typeof analyzeFallowArgumentContext>): AutocompleteItem[] | null {
 	const items = completeToken(context.beforeCurrent, context.current, HISTORY_SUBCOMMANDS);
+	return items.length ? items : null;
+}
+
+function completeConfigAssistSubcommand(context: ReturnType<typeof analyzeFallowArgumentContext>): AutocompleteItem[] | null {
+	const items = completeToken(context.beforeCurrent, context.current, CONFIG_ASSIST_SUBCOMMANDS);
+	return items.length ? items : null;
+}
+
+function completeConfigSeverity(context: ReturnType<typeof analyzeFallowArgumentContext>): AutocompleteItem[] | null {
+	const items = completeToken(context.beforeCurrent, context.current, CONFIG_SEVERITIES);
 	return items.length ? items : null;
 }
 

--- a/extensions/fallow/command/args.ts
+++ b/extensions/fallow/command/args.ts
@@ -6,7 +6,7 @@ import { fallowProjectIssues } from "./issues";
 type Notify = (message: string, level: "info" | "warning") => void;
 
 const FALLBACK_DEFAULT_COMMAND = ["issues"];
-const INVALID_DEFAULT_COMMANDS = new Set(["run", "rerun", "history", "about", "version", "update", "compatibility"]);
+const INVALID_DEFAULT_COMMANDS = new Set(["run", "rerun", "history", "about", "version", "update", "compatibility", "config-assist"]);
 
 export function resolveFallowRunArgs(rawArgs: string[], configuredDefaultArgs: string[]): string[] {
 	if (isExplicitFallowCommand(rawArgs)) return rawArgs;

--- a/extensions/fallow/command/config-assistant.ts
+++ b/extensions/fallow/command/config-assistant.ts
@@ -1,0 +1,103 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+	createFallowConfigAssistant,
+	formatFallowConfigApply,
+	formatFallowConfigPreview,
+	sendConfigMessage,
+	sendFallowConfigInspection,
+} from "../config-assistant";
+import type { FallowCommandContext } from "./types";
+
+type ConfigAssistant = ReturnType<typeof createFallowConfigAssistant>;
+type ConfigRequest = { kind: "inspect" } | { kind: "preview-rule" | "apply-rule"; rule: string; severity: string };
+
+export async function runFallowConfigAssistantCommand(
+	pi: ExtensionAPI,
+	ctx: FallowCommandContext,
+	args: string[],
+	assistant = createFallowConfigAssistant(pi),
+): Promise<void> {
+	const request = parseConfigRequest(args);
+	if (request.kind === "inspect") return sendFallowConfigInspection(pi, ctx, assistant);
+	return runRuleRequest(pi, ctx, request, assistant);
+}
+
+function parseConfigRequest(args: string[]): ConfigRequest {
+	const subcommand = args[1] || "inspect";
+	if (subcommand === "inspect") return parseInspectRequest(args);
+	return parseRuleConfigRequest(args, subcommand);
+}
+
+function parseInspectRequest(args: string[]): ConfigRequest {
+	if (args.length > 2) throw usageError();
+	return { kind: "inspect" };
+}
+
+function parseRuleConfigRequest(args: string[], subcommand: string): ConfigRequest {
+	if (args.length !== 4) throw usageError();
+	const kind = configRuleRequestKind(subcommand);
+	return { kind, rule: args[2]!, severity: args[3]! };
+}
+
+function configRuleRequestKind(value: string): "preview-rule" | "apply-rule" {
+	if (value === "preview-rule" || value === "apply-rule") return value;
+	throw usageError();
+}
+
+async function runRuleRequest(
+	pi: ExtensionAPI,
+	ctx: FallowCommandContext,
+	request: Exclude<ConfigRequest, { kind: "inspect" }>,
+	assistant: ConfigAssistant,
+): Promise<void> {
+	const plan = await assistant.previewRule(ctx.cwd, request.rule, request.severity, ctx.signal);
+	sendConfigMessage(pi, formatFallowConfigPreview(plan.preview), plan.preview);
+	if (request.kind === "preview-rule") return;
+	if (plan.preview.status === "unchanged") return;
+	assertInteractive(ctx);
+	return confirmAndApply(pi, ctx, plan, assistant);
+}
+
+async function confirmAndApply(
+	pi: ExtensionAPI,
+	ctx: FallowCommandContext & { hasUI: true },
+	plan: Awaited<ReturnType<ConfigAssistant["previewRule"]>>,
+	assistant: ConfigAssistant,
+): Promise<void> {
+	if (ctx.signal?.aborted) return reportCancellation(ctx);
+	const confirmed = await ctx.ui.confirm(
+		"Apply Fallow configuration change?",
+		`${plan.preview.schemaPath}: ${plan.preview.change}\n\n${plan.preview.backupPolicy}\nA fresh drift check runs before the atomic write.`,
+	);
+	return finishConfirmedApply(pi, ctx, plan, assistant, confirmed);
+}
+
+async function finishConfirmedApply(
+	pi: ExtensionAPI,
+	ctx: FallowCommandContext & { hasUI: true },
+	plan: Awaited<ReturnType<ConfigAssistant["previewRule"]>>,
+	assistant: ConfigAssistant,
+	confirmed: boolean,
+): Promise<void> {
+	if (!confirmed) return reportCancellation(ctx);
+	if (ctx.signal?.aborted) return reportCancellation(ctx);
+	const result = await assistant.apply(plan, ctx.cwd, { confirmed: true, signal: ctx.signal });
+	sendConfigMessage(pi, formatFallowConfigApply(result), result);
+	ctx.ui.notify(configApplyNotice(result), "info");
+}
+
+function configApplyNotice(result: { status: string; summary: string }): string {
+	return result.status === "applied" ? "Confirmed Fallow configuration change applied." : result.summary;
+}
+
+function assertInteractive(ctx: FallowCommandContext): asserts ctx is FallowCommandContext & { hasUI: true } {
+	if (!ctx.hasUI) throw new Error("Applying Fallow configuration requires an interactive TUI confirmation. Use preview-rule in non-interactive modes.");
+}
+
+function usageError(): Error {
+	return new Error("Usage: /fallow config-assist [inspect|preview-rule RULE error|warn|off|apply-rule RULE error|warn|off]");
+}
+
+function reportCancellation(ctx: FallowCommandContext): void {
+	ctx.ui.notify("Fallow configuration apply cancelled; no config write was performed.", "info");
+}

--- a/extensions/fallow/command/handler.ts
+++ b/extensions/fallow/command/handler.ts
@@ -7,6 +7,7 @@ import type { FallowExecutionOptions, FallowNavigatorResult, FallowNavigatorStat
 import { sendFallowAboutMessage } from "../update-notice";
 import { normalizeFallowArgs, resolveFallowRunArgs } from "./args";
 import { resolveFallowCommandBaseRef } from "./base";
+import { runFallowConfigAssistantCommand } from "./config-assistant";
 import { executeFallowHistoryCommand } from "./history";
 import { isFallowTuiMode } from "./mode";
 import { runFallowNavigatorLoop } from "./navigator-loop";
@@ -45,7 +46,14 @@ function splitOptionalFallowArgs(value: string): string[] {
 async function runFallowExtensionCommand(pi: ExtensionAPI, ctx: FallowCommandContext, args: string[]): Promise<boolean> {
 	if (isFallowAboutCommand(args)) await sendFallowAboutMessage(pi, ctx);
 	else if (isFallowCompatibilityCommand(args)) await sendFallowCompatibilityMessage(pi, ctx);
-	else return false;
+	else return runConfigAssistantIfRequested(pi, ctx, args);
+	return true;
+}
+
+async function runConfigAssistantIfRequested(pi: ExtensionAPI, ctx: FallowCommandContext, args: string[]): Promise<boolean> {
+	if (args[0] !== "config-assist") return false;
+	try { await runFallowConfigAssistantCommand(pi, ctx, args); }
+	catch (error) { reportFallowInputError(ctx, error); }
 	return true;
 }
 

--- a/extensions/fallow/config-assistant.ts
+++ b/extensions/fallow/config-assistant.ts
@@ -1,0 +1,523 @@
+import { constants } from "node:fs";
+import { lstat, link, open, realpath, rename, stat, unlink } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { asRecord } from "./data";
+import { createFallowRuleConfig, editFallowRuleConfig } from "./config-edit";
+import { readSizedFile } from "./read-sized-file";
+import { createFallowRunner } from "./runner";
+
+const MAX_CONFIG_BYTES = 1_048_576;
+const CONFIG_TIMEOUT_SECS = 30;
+const PROJECT_CONFIG_NAMES = new Set([".fallowrc.json", ".fallowrc.jsonc", "fallow.toml", ".fallow.toml"]);
+const SEVERITIES = new Set(["error", "warn", "off"]);
+
+type ConfigOwnership = "project" | "inherited" | "none";
+type AssistantRunner = ReturnType<typeof createFallowRunner>;
+
+type SourceSnapshot = {
+	path?: string;
+	digest?: string;
+	content?: string;
+	mode?: number;
+};
+
+interface FallowConfigInspection {
+	status: "ready" | "invalid" | "unavailable";
+	source?: string;
+	ownership: ConfigOwnership;
+	format?: "jsonc" | "toml";
+	summary: string;
+	counts?: { entries: number; rules: number; workspaces: number; plugins: number; boundaries: number; overrides: number };
+	diagnostic?: string;
+}
+
+export interface FallowConfigPreview {
+	status: "change" | "unchanged";
+	source: string;
+	ownership: "project";
+	format: "jsonc" | "toml";
+	schemaPath: string;
+	change: string;
+	backupPolicy: string;
+	writePolicy: string;
+}
+
+interface FallowConfigPlan {
+	preview: FallowConfigPreview;
+	targetPath: string;
+	candidate: string;
+	source: SourceSnapshot;
+	discoveredSource?: string;
+	schemaDigest: string;
+}
+
+export interface FallowConfigApplyResult {
+	status: "applied" | "unchanged";
+	source: string;
+	backup?: string;
+	summary: string;
+}
+
+export function createFallowConfigAssistant(
+	pi: ExtensionAPI,
+	runner: AssistantRunner = createFallowRunner({ allowNpxFallback: false }),
+) {
+	async function inspect(cwd: string, signal?: AbortSignal): Promise<FallowConfigInspection> {
+		let root = resolve(cwd);
+		let sourcePath: string | undefined;
+		try {
+			root = await canonicalRoot(cwd);
+			const discovered = await discoverConfig(pi, runner, root, signal);
+			sourcePath = discovered.path;
+			const resolvedConfig = await executeJson(pi, runner, ["config", "--format", "json", "--quiet", "--no-cache"], root, signal, discovered.displaySource);
+			return buildInspection(root, sourcePath, resolvedConfig);
+		} catch (error) {
+			return {
+				status: error instanceof InvalidConfigError ? "invalid" : "unavailable",
+				source: sourcePath ? displayPath(root, sourcePath) : undefined,
+				ownership: configOwnership(root, sourcePath),
+				summary: "Fallow configuration could not be inspected safely.",
+				diagnostic: safeError(error),
+			};
+		}
+	}
+
+	async function previewRule(cwd: string, rule: string, severity: string, signal?: AbortSignal): Promise<FallowConfigPlan> {
+		throwIfCancelled(signal);
+		const root = await canonicalRoot(cwd);
+		const discovered = await discoverConfig(pi, runner, root, signal);
+		validateRuleInput(rule, severity, discovered.displaySource);
+		await executeJson(pi, runner, ["config", "--format", "json", "--quiet", "--no-cache"], root, signal, discovered.displaySource);
+		const schema = await loadConfigSchema(pi, runner, root, signal);
+		validateRuleAgainstSchema(schema.value, rule, discovered.displaySource);
+		const source = await snapshotSource(root, discovered.path);
+		return buildRulePlan(root, discovered.path, source, schema.digest, rule, severity);
+	}
+
+	async function apply(
+		plan: FallowConfigPlan,
+		cwd: string,
+		confirmation: { confirmed: true; signal?: AbortSignal },
+	): Promise<FallowConfigApplyResult> {
+		assertConfirmed(confirmation);
+		if (plan.preview.status === "unchanged") return unchangedApplyResult(plan);
+		const signal = confirmation.signal;
+		throwIfCancelled(signal);
+		const root = await canonicalRoot(cwd);
+		assertProjectTarget(root, plan.targetPath);
+		const discovered = await discoverConfig(pi, runner, root, signal);
+		assertSameValue(discovered.path, plan.discoveredSource, "config discovery changed after preview");
+		await assertSourceUnchanged(root, plan.source);
+		const schema = await loadConfigSchema(pi, runner, root, signal);
+		assertSameValue(schema.digest, plan.schemaDigest, "installed Fallow config schema changed after preview");
+		throwIfCancelled(signal);
+		return writePlanAtomically(plan, signal);
+	}
+
+	return { inspect, previewRule, apply };
+}
+
+function buildRulePlan(
+	root: string,
+	discoveredSource: string | undefined,
+	source: SourceSnapshot,
+	schemaDigest: string,
+	rule: string,
+	severity: string,
+): FallowConfigPlan {
+	const targetPath = writableProjectTarget(root, discoveredSource);
+	const shownSource = displayPath(root, targetPath);
+	const edit = safelyEditConfig(source, targetPath, shownSource, rule, severity);
+	const preview = buildRulePreview(edit, source.path === targetPath, targetPath, shownSource, rule, severity);
+	return { preview, targetPath, candidate: edit.content, source, discoveredSource, schemaDigest };
+}
+
+function safelyEditConfig(source: SourceSnapshot, targetPath: string, shownSource: string, rule: string, severity: string): ReturnType<typeof editFallowRuleConfig> {
+	try {
+		const edit = source.path === targetPath
+			? editFallowRuleConfig(source.content!, targetPath, rule, severity)
+			: createFallowRuleConfig(rule, severity, inheritedReference(source.path, targetPath));
+		editFallowRuleConfig(edit.content, targetPath, rule, severity);
+		return edit;
+	} catch (error) {
+		throw new InvalidConfigError(`Invalid Fallow config ${shownSource}: ${safeError(error)}`);
+	}
+}
+
+function buildRulePreview(
+	edit: ReturnType<typeof editFallowRuleConfig>,
+	existingTarget: boolean,
+	targetPath: string,
+	shownSource: string,
+	rule: string,
+	severity: string,
+): FallowConfigPreview {
+	const previous = edit.previous || "default (not explicitly configured)";
+	return {
+		status: edit.changed ? "change" : "unchanged",
+		source: shownSource,
+		ownership: "project",
+		format: edit.format,
+		schemaPath: `$.rules.${rule}`,
+		change: `${previous} → ${severity}`,
+		backupPolicy: existingTarget ? existingBackupPolicy(targetPath) : "No backup is needed when creating a new project config.",
+		writePolicy: "No write occurs during preview. Apply requires interactive confirmation, then repeats discovery, schema, and content drift checks before an atomic same-directory replacement.",
+	};
+}
+
+function inheritedReference(sourcePath: string | undefined, targetPath: string): string | undefined {
+	if (!sourcePath) return undefined;
+	const path = relative(dirname(targetPath), sourcePath).replaceAll("\\", "/");
+	return path.startsWith(".") ? path : `./${path}`;
+}
+
+function existingBackupPolicy(targetPath: string): string {
+	return `Before replacement, preserve the exact prior file as ${basename(targetPath)}.pi-fallow.bak (or the first free numeric suffix).`;
+}
+
+function assertConfirmed(confirmation: { confirmed: true; signal?: AbortSignal } | undefined): asserts confirmation is { confirmed: true; signal?: AbortSignal } {
+	if (confirmation?.confirmed !== true) throw new Error("Explicit confirmation is required before a Fallow configuration write.");
+}
+
+function unchangedApplyResult(plan: FallowConfigPlan): FallowConfigApplyResult {
+	return { status: "unchanged", source: plan.preview.source, summary: "The requested rule severity is already configured." };
+}
+
+function assertSameValue(actual: unknown, expected: unknown, message: string): void {
+	if (actual !== expected) throw driftError(message);
+}
+
+export async function sendFallowConfigInspection(
+	pi: ExtensionAPI,
+	ctx: { cwd: string; signal?: AbortSignal; hasUI: boolean; ui?: { notify(message: string, level: "info" | "warning" | "error"): void } },
+	assistant = createFallowConfigAssistant(pi),
+): Promise<void> {
+	const report = await assistant.inspect(ctx.cwd, ctx.signal);
+	sendConfigMessage(pi, formatFallowConfigInspection(report), report);
+	if (ctx.hasUI) ctx.ui?.notify("Read-only Fallow configuration inspection added to the transcript.", report.status === "ready" ? "info" : "warning");
+}
+
+function formatFallowConfigInspection(report: FallowConfigInspection): string {
+	const lines = ["Fallow configuration assistant", "", `Status: ${report.status}`, `Ownership: ${ownershipLabel(report.ownership)}`, report.summary];
+	appendOptionalLine(lines, "Source", report.source);
+	appendOptionalLine(lines, "Format", report.format);
+	appendInspectionCounts(lines, report.counts);
+	appendOptionalLine(lines, "Diagnostic", report.diagnostic);
+	lines.push("Resolved values are intentionally omitted so secrets and unrelated configuration do not enter the transcript.");
+	return lines.join("\n");
+}
+
+function appendOptionalLine(lines: string[], label: string, value: string | undefined): void {
+	if (value) lines.push(`${label}: ${value}`);
+}
+
+function appendInspectionCounts(lines: string[], counts: FallowConfigInspection["counts"]): void {
+	if (!counts) return;
+	lines.push(`Resolved summary: ${counts.entries} entries · ${counts.rules} rules · ${counts.workspaces} workspaces · ${counts.plugins} plugins · ${counts.boundaries} boundaries · ${counts.overrides} overrides`);
+}
+
+export function formatFallowConfigPreview(preview: FallowConfigPreview): string {
+	return [
+		"Fallow configuration preview",
+		"",
+		`Status: ${preview.status}`,
+		`Project source: ${preview.source}`,
+		`Format: ${preview.format}`,
+		`Schema path: ${preview.schemaPath}`,
+		`Proposed change: ${preview.change}`,
+		`Backup policy: ${preview.backupPolicy}`,
+		`Write policy: ${preview.writePolicy}`,
+		"No unrelated configuration values are included in this preview.",
+	].join("\n");
+}
+
+export function formatFallowConfigApply(result: FallowConfigApplyResult): string {
+	const lines = ["Fallow configuration apply", "", `Status: ${result.status}`, `Project source: ${result.source}`, result.summary];
+	if (result.backup) lines.push(`Backup: ${result.backup}`);
+	return lines.join("\n");
+}
+
+export function renderFallowConfigAssistantMessage(message: { content: string; details?: unknown }, _options: unknown, theme: any): Text {
+	const tone = configMessageTone(asRecord(message.details)?.status);
+	return new Text(`${theme.fg("toolTitle", theme.bold("Fallow configuration assistant"))}\n${theme.fg(tone, message.content)}`, 0, 0);
+}
+
+function configMessageTone(status: unknown): "warning" | "success" | "toolTitle" {
+	if (status === "invalid" || status === "unavailable") return "warning";
+	return status === "applied" ? "success" : "toolTitle";
+}
+
+export function sendConfigMessage(pi: ExtensionAPI, content: string, details: unknown): void {
+	pi.sendMessage({ customType: "fallow-config-assistant", content, display: true, details });
+}
+
+async function discoverConfig(pi: ExtensionAPI, runner: AssistantRunner, root: string, signal?: AbortSignal): Promise<{ path?: string; displaySource: string }> {
+	throwIfCancelled(signal);
+	runner.clear(pi);
+	const { result } = await runner.execute(pi, ["config", "--path", "--quiet", "--no-cache"], root, signal, CONFIG_TIMEOUT_SECS);
+	const state = configDiscoveryState(result);
+	if (state === "none") return { displaySource: "zero-config project" };
+	const line = validatedConfigPathOutput(result.stdout);
+	const candidate = resolve(root, line);
+	const path = join(await realpath(dirname(candidate)), basename(candidate));
+	return { path, displaySource: displayPath(root, path) };
+}
+
+function configDiscoveryState(result: { code: number; killed?: boolean; terminationReason?: string }): "found" | "none" {
+	if (result.killed) throw new Error(discoveryTerminationMessage(result.terminationReason));
+	if (result.code === 3) return "none";
+	if (result.code !== 0) throw new InvalidConfigError("Fallow config discovery failed at schema path $.");
+	return "found";
+}
+
+function discoveryTerminationMessage(reason: string | undefined): string {
+	return reason === "timed-out" ? "Fallow config discovery timed out." : "Fallow config discovery was cancelled.";
+}
+
+function validatedConfigPathOutput(stdout: string): string {
+	const line = stdout.trim();
+	if (!line || line.includes("\n") || line.includes("\0")) throw new InvalidConfigError("Fallow returned an invalid config path at schema path $.");
+	return line;
+}
+
+async function executeJson(
+	pi: ExtensionAPI,
+	runner: AssistantRunner,
+	args: string[],
+	root: string,
+	signal: AbortSignal | undefined,
+	source: string,
+): Promise<Record<string, any>> {
+	throwIfCancelled(signal);
+	const { result } = await runner.execute(pi, args, root, signal, CONFIG_TIMEOUT_SECS);
+	assertConfigExecution(result, source);
+	return parseConfigJson(result.stdout, source);
+}
+
+function assertConfigExecution(result: { code: number; killed?: boolean; terminationReason?: string }, source: string): void {
+	if (result.killed) throw new Error(configTerminationMessage(result.terminationReason));
+	if (result.code !== 0) throw new InvalidConfigError(`Invalid Fallow config ${source} at schema path $ (exit ${result.code}).`);
+}
+
+function configTerminationMessage(reason: string | undefined): string {
+	return reason === "timed-out" ? "Fallow configuration validation timed out." : "Fallow configuration validation was cancelled.";
+}
+
+function parseConfigJson(stdout: string, source: string): Record<string, any> {
+	try {
+		const parsed = asRecord(JSON.parse(stdout));
+		if (!parsed) throw new Error();
+		return parsed;
+	} catch {
+		throw new InvalidConfigError(`Fallow returned unreadable JSON for ${source} at schema path $.`);
+	}
+}
+
+async function loadConfigSchema(pi: ExtensionAPI, runner: AssistantRunner, root: string, signal?: AbortSignal): Promise<{ value: Record<string, any>; digest: string }> {
+	const value = await executeJson(pi, runner, ["config-schema", "--format", "json", "--quiet", "--no-cache"], root, signal, "installed config schema");
+	return { value, digest: digest(JSON.stringify(value)) };
+}
+
+function validateRuleAgainstSchema(schema: Record<string, any>, rule: string, source: string): void {
+	const properties = configRuleProperties(schema);
+	if (!Object.hasOwn(properties, rule)) throw new InvalidConfigError(`Invalid Fallow config request for ${source} at schema path $.rules.${rule}: unknown rule id.`);
+}
+
+function configRuleProperties(schema: Record<string, any>): Record<string, any> {
+	const definitions = asRecord(schema.$defs) || {};
+	const rules = asRecord(definitions.RulesConfig) || {};
+	return asRecord(rules.properties) || {};
+}
+
+function validateRuleInput(rule: string, severity: string, source: string): void {
+	if (!/^[a-z][a-z0-9-]{0,79}$/.test(rule)) throw new InvalidConfigError(`Invalid Fallow config request for ${source} at schema path $.rules: rule id must be kebab-case.`);
+	if (!SEVERITIES.has(severity)) throw new InvalidConfigError(`Invalid Fallow config request for ${source} at schema path $.rules.${rule}: severity must be error, warn, or off.`);
+}
+
+async function snapshotSource(root: string, sourcePath: string | undefined): Promise<SourceSnapshot> {
+	if (!sourcePath) return {};
+	if (configOwnership(root, sourcePath) === "project") await validateProjectSource(root, sourcePath);
+	const content = (await readSizedFile(sourcePath, { minimum: 0, maximum: MAX_CONFIG_BYTES })).toString("utf8");
+	const info = await stat(sourcePath);
+	return { path: sourcePath, content, digest: digest(content), mode: info.mode & 0o777 };
+}
+
+async function validateProjectSource(root: string, sourcePath: string): Promise<void> {
+	const info = await lstat(sourcePath);
+	if (info.isSymbolicLink()) throw new InvalidConfigError(`Refusing project config symlink ${displayPath(root, sourcePath)} at schema path $.`);
+	if (!info.isFile()) throw new InvalidConfigError(`Invalid project config ${displayPath(root, sourcePath)} at schema path $: expected a regular file.`);
+}
+
+function writableProjectTarget(root: string, discovered: string | undefined): string {
+	if (discovered && configOwnership(root, discovered) === "project") {
+		assertProjectTarget(root, discovered);
+		return discovered;
+	}
+	return join(root, ".fallowrc.jsonc");
+}
+
+function assertProjectTarget(root: string, target: string): void {
+	if (dirname(resolve(target)) !== root || !PROJECT_CONFIG_NAMES.has(basename(target))) {
+		throw new InvalidConfigError("Pi Fallow only writes a recognized config file directly inside the project root at schema path $.");
+	}
+}
+
+async function assertSourceUnchanged(root: string, source: SourceSnapshot): Promise<void> {
+	if (!source.path) return;
+	const current = await snapshotSource(root, source.path);
+	if (current.digest !== source.digest) throw driftError("source config content changed after preview");
+}
+
+async function writePlanAtomically(plan: FallowConfigPlan, signal?: AbortSignal): Promise<FallowConfigApplyResult> {
+	return plan.source.path === plan.targetPath
+		? replaceProjectConfig(plan, signal)
+		: createProjectConfig(plan, signal);
+}
+
+async function replaceProjectConfig(plan: FallowConfigPlan, signal?: AbortSignal): Promise<FallowConfigApplyResult> {
+	const backup = await writeBackup(plan.targetPath, plan.source.content!, plan.source.mode || 0o600);
+	const temporary = temporaryConfigPath(plan.targetPath);
+	try {
+		await writeTemporary(plan, temporary, signal);
+		const current = await snapshotSource(dirname(plan.targetPath), plan.targetPath);
+		assertSameValue(current.digest, plan.source.digest, "source config content changed during apply");
+		await rename(temporary, plan.targetPath);
+		return appliedResult(plan, backup);
+	} catch (error) {
+		await cleanupPaths(temporary, backup);
+		throw error;
+	}
+}
+
+async function createProjectConfig(plan: FallowConfigPlan, signal?: AbortSignal): Promise<FallowConfigApplyResult> {
+	if (await pathExists(plan.targetPath)) throw driftError("project config appeared after preview");
+	const temporary = temporaryConfigPath(plan.targetPath);
+	try {
+		await writeTemporary(plan, temporary, signal);
+		await link(temporary, plan.targetPath);
+		await unlink(temporary).catch(ignoreCleanupError);
+		return appliedResult(plan);
+	} catch (error) {
+		await cleanupPaths(temporary);
+		throw error;
+	}
+}
+
+async function writeTemporary(plan: FallowConfigPlan, temporary: string, signal?: AbortSignal): Promise<void> {
+	throwIfCancelled(signal);
+	await writeSyncedExclusive(temporary, plan.candidate, plan.source.mode || 0o600);
+	throwIfCancelled(signal);
+}
+
+function temporaryConfigPath(target: string): string {
+	return join(dirname(target), `.${basename(target)}.pi-fallow-${randomUUID()}.tmp`);
+}
+
+function appliedResult(plan: FallowConfigPlan, backup?: string): FallowConfigApplyResult {
+	return {
+		status: "applied",
+		source: plan.preview.source,
+		backup: backup ? basename(backup) : undefined,
+		summary: "Applied the confirmed rule-severity change with a same-directory atomic update.",
+	};
+}
+
+async function cleanupPaths(...paths: Array<string | undefined>): Promise<void> {
+	await Promise.all(paths.filter((path): path is string => Boolean(path)).map((path) => unlink(path).catch(ignoreCleanupError)));
+}
+
+function ignoreCleanupError(): void {}
+
+async function writeBackup(target: string, content: string, mode: number): Promise<string> {
+	for (let suffix = 0; suffix <= 99; suffix++) {
+		const candidate = backupPath(target, suffix);
+		try {
+			await writeSyncedExclusive(candidate, content, mode);
+			return candidate;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+		}
+	}
+	throw new Error("No free Pi Fallow backup filename is available.");
+}
+
+function backupPath(target: string, suffix: number): string {
+	return suffix ? `${target}.pi-fallow.bak.${suffix}` : `${target}.pi-fallow.bak`;
+}
+
+async function writeSyncedExclusive(path: string, content: string, mode: number): Promise<void> {
+	const file = await open(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, mode);
+	try {
+		await file.writeFile(content, "utf8");
+		await file.chmod(mode);
+		await file.sync();
+	} finally {
+		await file.close();
+	}
+}
+
+function buildInspection(root: string, sourcePath: string | undefined, config: Record<string, any>): FallowConfigInspection {
+	const ownership = configOwnership(root, sourcePath);
+	return {
+		status: "ready",
+		source: sourcePath ? displayPath(root, sourcePath) : undefined,
+		ownership,
+		format: configFormat(sourcePath),
+		summary: ownershipSummary(ownership),
+		counts: inspectionCounts(config),
+	};
+}
+
+function configFormat(sourcePath: string | undefined): "toml" | "jsonc" | undefined {
+	if (!sourcePath) return undefined;
+	return sourcePath.endsWith(".toml") ? "toml" : "jsonc";
+}
+
+function ownershipSummary(ownership: ConfigOwnership): string {
+	if (ownership === "none") return "No config file is present; Fallow's effective defaults are active.";
+	if (ownership === "project") return "A project-owned Fallow config is active.";
+	return "An inherited config is active and remains externally owned; Pi Fallow will only create or modify a project-root config.";
+}
+
+function inspectionCounts(config: Record<string, any>): NonNullable<FallowConfigInspection["counts"]> {
+	const boundaries = asRecord(config.boundaries) || {};
+	return {
+		entries: arrayLength(config.entry),
+		rules: objectLength(config.rules),
+		workspaces: arrayLength(config.workspaces),
+		plugins: arrayLength(config.plugins),
+		boundaries: arrayLength(boundaries.zones) + arrayLength(boundaries.rules),
+		overrides: arrayLength(config.overrides),
+	};
+}
+
+function configOwnership(root: string, sourcePath: string | undefined): ConfigOwnership {
+	if (!sourcePath) return "none";
+	return dirname(resolve(sourcePath)) === root && PROJECT_CONFIG_NAMES.has(basename(sourcePath)) ? "project" : "inherited";
+}
+
+function ownershipLabel(ownership: ConfigOwnership): string {
+	if (ownership === "project") return "project-owned";
+	if (ownership === "inherited") return "inherited/external (read-only)";
+	return "zero-config (no owned file)";
+}
+
+function displayPath(root: string, path: string): string {
+	const value = relative(root, path);
+	if (!value) return basename(path);
+	return value.startsWith("..") || isAbsolute(value) ? path : value;
+}
+
+async function canonicalRoot(cwd: string): Promise<string> { return realpath(resolve(cwd)); }
+function arrayLength(value: unknown): number { return Array.isArray(value) ? value.length : 0; }
+function objectLength(value: unknown): number { return Object.keys(asRecord(value) ?? {}).length; }
+function digest(value: string): string { return createHash("sha256").update(value).digest("hex"); }
+async function pathExists(path: string): Promise<boolean> { try { await lstat(path); return true; } catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return false; throw error; } }
+function driftError(message: string): Error { return new Error(`Refusing stale Fallow configuration preview: ${message}. Preview again before applying.`); }
+function throwIfCancelled(signal?: AbortSignal): void { if (signal?.aborted) throw new Error("Fallow configuration assistant cancelled; no config write was performed."); }
+function safeError(error: unknown): string { return error instanceof Error ? error.message.slice(0, 500) : "Unknown configuration error."; }
+
+class InvalidConfigError extends Error {}

--- a/extensions/fallow/config-edit.ts
+++ b/extensions/fallow/config-edit.ts
@@ -1,0 +1,376 @@
+type JsonNode = JsonObjectNode | JsonArrayNode | JsonValueNode;
+
+type JsonMember = {
+	key: string;
+	keyStart: number;
+	value: JsonNode;
+	hasComma: boolean;
+};
+
+type JsonObjectNode = {
+	type: "object";
+	start: number;
+	end: number;
+	members: JsonMember[];
+	trailingTriviaStart: number;
+};
+
+type JsonArrayNode = { type: "array"; start: number; end: number };
+type JsonValueNode = { type: "value"; start: number; end: number; value: unknown };
+
+type TomlLine = { text: string; index: number; offset: number; table?: string };
+type TomlRule = { start: number; end: number; severity: string };
+
+export type ConfigTextEdit = {
+	content: string;
+	previous: string | undefined;
+	changed: boolean;
+	format: "jsonc" | "toml";
+};
+
+/** Updates only one rule severity. No unrelated config value is returned to callers. */
+export function editFallowRuleConfig(source: string, fileName: string, rule: string, severity: string): ConfigTextEdit {
+	return isTomlFile(fileName) ? editTomlRule(source, rule, severity) : editJsonRule(source, rule, severity);
+}
+
+export function createFallowRuleConfig(rule: string, severity: string, inheritedSource?: string): ConfigTextEdit {
+	const extendsLine = inheritedSource ? `  "extends": ${JSON.stringify(inheritedSource)},\n` : "";
+	const content = `{
+  "$schema": "https://unpkg.com/fallow/schema.json",
+${extendsLine}  "rules": {
+    ${JSON.stringify(rule)}: ${JSON.stringify(severity)}
+  }
+}
+`;
+	return { content, previous: undefined, changed: true, format: "jsonc" };
+}
+
+function isTomlFile(fileName: string): boolean {
+	return fileName.endsWith(".toml");
+}
+
+function editJsonRule(source: string, rule: string, severity: string): ConfigTextEdit {
+	const root = new JsoncParser(source).parse();
+	assertObjectNode(root, "$", "configuration root must be an object");
+	const rulesMember = memberNamed(root, "rules");
+	return rulesMember
+		? editJsonRulesMember(source, rulesMember, rule, severity)
+		: addedJsonEdit(source, root, `"rules": { ${JSON.stringify(rule)}: ${JSON.stringify(severity)} }`);
+}
+
+function editJsonRulesMember(source: string, rulesMember: JsonMember, rule: string, severity: string): ConfigTextEdit {
+	assertObjectNode(rulesMember.value, "$.rules", "must be an object");
+	const ruleMember = memberNamed(rulesMember.value, rule);
+	return ruleMember
+		? replaceJsonSeverity(source, ruleMember, rule, severity)
+		: addedJsonEdit(source, rulesMember.value, `${JSON.stringify(rule)}: ${JSON.stringify(severity)}`);
+}
+
+function replaceJsonSeverity(source: string, member: JsonMember, rule: string, severity: string): ConfigTextEdit {
+	const value = member.value;
+	assertStringNode(value, `$.rules.${rule}`);
+	if (value.value === severity) return { content: source, previous: severity, changed: false, format: "jsonc" };
+	return {
+		content: `${source.slice(0, value.start)}${JSON.stringify(severity)}${source.slice(value.end)}`,
+		previous: value.value,
+		changed: true,
+		format: "jsonc",
+	};
+}
+
+function addedJsonEdit(source: string, object: JsonObjectNode, entry: string): ConfigTextEdit {
+	return { content: insertJsonMember(source, object, entry), previous: undefined, changed: true, format: "jsonc" };
+}
+
+function assertObjectNode(node: JsonNode, path: string, message: string): asserts node is JsonObjectNode {
+	if (node.type !== "object") throw configSyntaxError(path, message);
+}
+
+function assertStringNode(node: JsonNode, path: string): asserts node is JsonValueNode & { value: string } {
+	if (node.type !== "value" || typeof node.value !== "string") throw configSyntaxError(path, "must be a severity string");
+}
+
+function memberNamed(node: JsonObjectNode, name: string): JsonMember | undefined {
+	return node.members.find((member) => member.key === name);
+}
+
+function insertJsonMember(source: string, object: JsonObjectNode, entry: string): string {
+	const newline = source.includes("\r\n") ? "\r\n" : "\n";
+	const closeIndent = indentationAt(source, object.end - 1);
+	const childIndent = inferChildIndent(source, object, closeIndent);
+	return object.members.length
+		? insertIntoPopulatedObject(source, object, entry, newline, childIndent)
+		: `${source.slice(0, object.end - 1)}${newline}${childIndent}${entry}${newline}${closeIndent}${source.slice(object.end - 1)}`;
+}
+
+function insertIntoPopulatedObject(source: string, object: JsonObjectNode, entry: string, newline: string, indent: string): string {
+	const last = object.members.at(-1)!;
+	const before = source.slice(0, object.trailingTriviaStart);
+	const withComma = last.hasComma ? before : `${source.slice(0, last.value.end)},${source.slice(last.value.end, object.trailingTriviaStart)}`;
+	return `${withComma}${newline}${indent}${entry}${source.slice(object.trailingTriviaStart)}`;
+}
+
+function inferChildIndent(source: string, object: JsonObjectNode, closeIndent: string): string {
+	const existing = object.members[0] ? indentationAt(source, object.members[0]!.keyStart) : "";
+	if (existing.length > closeIndent.length) return existing;
+	return `${closeIndent}${/\n\t+[^\s]/.test(source) ? "\t" : "  "}`;
+}
+
+function indentationAt(source: string, offset: number): string {
+	const lineStart = Math.max(source.lastIndexOf("\n", offset - 1) + 1, 0);
+	return /^[\t ]*/.exec(source.slice(lineStart, offset))?.[0] ?? "";
+}
+
+function editTomlRule(source: string, rule: string, severity: string): ConfigTextEdit {
+	const newline = source.includes("\r\n") ? "\r\n" : "\n";
+	const lines = tomlLines(source);
+	const tables = lines.filter((line) => line.table === "rules");
+	assertSingleTomlItem(tables.length, "$.rules", "duplicate [rules] table");
+	return tables[0]
+		? editTomlRulesTable(source, lines, tables[0], rule, severity, newline)
+		: addTomlRulesTable(source, rule, severity, newline);
+}
+
+function editTomlRulesTable(source: string, lines: TomlLine[], table: TomlLine, rule: string, severity: string, newline: string): ConfigTextEdit {
+	const range = tomlTableRange(lines, table);
+	const matches = lines.slice(range.start + 1, range.end)
+		.map((line) => parseTomlRule(line, rule))
+		.filter((value): value is TomlRule => Boolean(value));
+	assertSingleTomlItem(matches.length, `$.rules.${rule}`, "duplicate rule key");
+	return matches[0]
+		? replaceTomlSeverity(source, matches[0], severity)
+		: insertTomlRule(source, lines, range.end, rule, severity, newline);
+}
+
+function assertSingleTomlItem(count: number, path: string, message: string): void {
+	if (count > 1) throw configSyntaxError(path, message);
+}
+
+function tomlLines(source: string): TomlLine[] {
+	let offset = 0;
+	return source.split(/(?<=\n)/).map((text, index) => {
+		const line = { text, index, offset, table: parseTomlTable(text) };
+		offset += text.length;
+		return line;
+	});
+}
+
+function parseTomlTable(line: string): string | undefined {
+	return /^\s*\[([^\]]+)]\s*(?:#.*)?(?:\r?\n)?$/.exec(line)?.[1]?.trim();
+}
+
+function tomlTableRange(lines: TomlLine[], table: TomlLine): { start: number; end: number } {
+	const next = lines.find((line) => line.index > table.index && line.table !== undefined);
+	return { start: table.index, end: next?.index ?? lines.length };
+}
+
+function parseTomlRule(line: TomlLine, expectedRule: string): TomlRule | undefined {
+	const match = /^(\s*)("(?:\\.|[^"])*"|'[^']*'|[A-Za-z0-9_-]+)(\s*=\s*)([^\r\n]*)/.exec(line.text);
+	if (!match || decodeTomlKey(match[2]!) !== expectedRule) return undefined;
+	return parseTomlSeverity(match, line.offset, expectedRule);
+}
+
+function decodeTomlKey(token: string): string {
+	if (token.startsWith('"')) return decodeTomlBasicKey(token);
+	return token.startsWith("'") ? token.slice(1, -1) : token;
+}
+
+function decodeTomlBasicKey(token: string): string {
+	try { return JSON.parse(token); }
+	catch { throw configSyntaxError("$.rules", "unsupported quoted rule key"); }
+}
+
+function parseTomlSeverity(match: RegExpExecArray, offset: number, rule: string): TomlRule {
+	const value = /^(["'])(error|warn|off)\1/.exec(match[4]!);
+	if (!value) throw configSyntaxError(`$.rules.${rule}`, "must be a severity string");
+	const start = offset + match[1]!.length + match[2]!.length + match[3]!.length;
+	return { start, end: start + value[2]!.length + 2, severity: value[2]! };
+}
+
+function replaceTomlSeverity(source: string, current: TomlRule, severity: string): ConfigTextEdit {
+	if (current.severity === severity) return { content: source, previous: severity, changed: false, format: "toml" };
+	const quote = source[current.start]!;
+	return {
+		content: `${source.slice(0, current.start)}${quote}${severity}${quote}${source.slice(current.end)}`,
+		previous: current.severity,
+		changed: true,
+		format: "toml",
+	};
+}
+
+function addTomlRulesTable(source: string, rule: string, severity: string, newline: string): ConfigTextEdit {
+	const separator = source.length && !source.endsWith("\n") ? newline : "";
+	const blank = source.trim() ? newline : "";
+	return tomlAddition(`${source}${separator}${blank}[rules]${newline}${tomlAssignment(rule, severity, newline)}`);
+}
+
+function insertTomlRule(source: string, lines: TomlLine[], endIndex: number, rule: string, severity: string, newline: string): ConfigTextEdit {
+	const insertionOffset = lines.slice(0, endIndex).reduce((sum, line) => sum + line.text.length, 0);
+	const before = source.slice(0, insertionOffset);
+	const separator = before && !before.endsWith("\n") ? newline : "";
+	return tomlAddition(`${before}${separator}${tomlAssignment(rule, severity, newline)}${source.slice(insertionOffset)}`);
+}
+
+function tomlAssignment(rule: string, severity: string, newline: string): string {
+	return `${rule} = ${JSON.stringify(severity)}${newline}`;
+}
+
+function tomlAddition(content: string): ConfigTextEdit {
+	return { content, previous: undefined, changed: true, format: "toml" };
+}
+
+function configSyntaxError(path: string, message: string): Error {
+	return new Error(`Invalid Fallow configuration at schema path ${path}: ${message}.`);
+}
+
+class JsoncParser {
+	private index = 0;
+	constructor(private readonly source: string) {}
+
+	parse(): JsonNode {
+		this.skipTrivia();
+		const value = this.parseValue("$");
+		this.skipTrivia();
+		if (this.index !== this.source.length) this.fail("$", "unexpected trailing content");
+		return value;
+	}
+
+	private parseValue(path: string): JsonNode {
+		this.skipTrivia();
+		const char = this.source[this.index];
+		if (char === "{") return this.parseObject(path);
+		if (char === "[") return this.parseArray(path);
+		return char === '"' ? this.stringValue(path) : this.parsePrimitive(path);
+	}
+
+	private stringValue(path: string): JsonValueNode {
+		const token = this.parseString(path);
+		return { type: "value", start: token.start, end: token.end, value: token.value };
+	}
+
+	private parseObject(path: string): JsonObjectNode {
+		const start = this.index++;
+		const members: JsonMember[] = [];
+		this.skipTrivia();
+		while (this.source[this.index] !== "}") {
+			if (this.index >= this.source.length) this.fail(path, "unterminated object");
+			members.push(this.parseMember(path, members));
+		}
+		const trailingTriviaStart = this.index;
+		this.index++;
+		return { type: "object", start, end: this.index, members, trailingTriviaStart };
+	}
+
+	private parseMember(path: string, members: JsonMember[]): JsonMember {
+		const key = this.parseString(path);
+		this.assertUniqueMember(path, key.value, members);
+		this.skipTrivia();
+		if (this.source[this.index++] !== ":") this.fail(`${path}.${key.value}`, "expected ':'");
+		const value = this.parseValue(`${path}.${key.value}`);
+		this.skipTrivia();
+		const hasComma = this.consumeComma();
+		this.assertMemberSeparator(path, hasComma);
+		return { key: key.value, keyStart: key.start, value, hasComma };
+	}
+
+	private assertUniqueMember(path: string, key: string, members: JsonMember[]): void {
+		if (members.some((member) => member.key === key)) this.fail(`${path}.${key}`, "duplicate key");
+	}
+
+	private assertMemberSeparator(path: string, hasComma: boolean): void {
+		if (this.source[this.index] !== "}" && !hasComma) this.fail(path, "expected ','");
+	}
+
+	private consumeComma(): boolean {
+		if (this.source[this.index] !== ",") return false;
+		this.index++;
+		this.skipTrivia();
+		return true;
+	}
+
+	private parseArray(path: string): JsonArrayNode {
+		const start = this.index++;
+		this.skipTrivia();
+		while (this.source[this.index] !== "]") this.parseArrayItem(path);
+		this.index++;
+		return { type: "array", start, end: this.index };
+	}
+
+	private parseArrayItem(path: string): void {
+		if (this.index >= this.source.length) this.fail(path, "unterminated array");
+		this.parseValue(`${path}[]`);
+		this.skipTrivia();
+		const hasComma = this.consumeComma();
+		if (this.source[this.index] !== "]" && !hasComma) this.fail(path, "expected ','");
+	}
+
+	private parseString(path: string): { start: number; end: number; value: string } {
+		const start = this.index;
+		if (this.source[this.index++] !== '"') this.fail(path, "expected a quoted key");
+		while (this.index < this.source.length) {
+			if (this.consumeStringCharacter()) return this.decodeString(path, start);
+		}
+		this.fail(path, "unterminated string");
+	}
+
+	private consumeStringCharacter(): boolean {
+		const char = this.source[this.index++];
+		if (char === "\\") this.index++;
+		return char === '"';
+	}
+
+	private decodeString(path: string, start: number): { start: number; end: number; value: string } {
+		try { return { start, end: this.index, value: JSON.parse(this.source.slice(start, this.index)) }; }
+		catch { this.fail(path, "invalid string"); }
+	}
+
+	private parsePrimitive(path: string): JsonValueNode {
+		const start = this.index;
+		this.scanPrimitive();
+		return { type: "value", start, end: this.index, value: this.decodePrimitive(path, start) };
+	}
+
+	private scanPrimitive(): void {
+		while (this.index < this.source.length && !/[\s,}\]]/.test(this.source[this.index]!) && !this.startsComment()) this.index++;
+	}
+
+	private decodePrimitive(path: string, start: number): unknown {
+		try {
+			const value = JSON.parse(this.source.slice(start, this.index));
+			if (typeof value === "object" && value !== null) this.fail(path, "invalid value");
+			return value;
+		} catch {
+			this.fail(path, "invalid value");
+		}
+	}
+
+	private skipTrivia(): void {
+		while (this.skipOneTrivia()) { /* consume */ }
+	}
+
+	private skipOneTrivia(): boolean {
+		if (/\s/.test(this.source.charAt(this.index))) { this.index++; return true; }
+		if (this.source.startsWith("//", this.index)) { this.skipLineComment(); return true; }
+		if (this.source.startsWith("/*", this.index)) { this.skipBlockComment(); return true; }
+		return false;
+	}
+
+	private skipLineComment(): void {
+		const end = this.source.indexOf("\n", this.index + 2);
+		this.index = end < 0 ? this.source.length : end + 1;
+	}
+
+	private skipBlockComment(): void {
+		const end = this.source.indexOf("*/", this.index + 2);
+		if (end < 0) this.fail("$", "unterminated comment");
+		this.index = end + 2;
+	}
+
+	private startsComment(): boolean {
+		return this.source.startsWith("//", this.index) || this.source.startsWith("/*", this.index);
+	}
+
+	private fail(path: string, message: string): never {
+		throw configSyntaxError(path, `${message} near character ${this.index}`);
+	}
+}

--- a/extensions/fallow/config-edit.ts
+++ b/extensions/fallow/config-edit.ts
@@ -165,7 +165,7 @@ function tomlTableRange(lines: TomlLine[], table: TomlLine): { start: number; en
 }
 
 function parseTomlRule(line: TomlLine, expectedRule: string): TomlRule | undefined {
-	const match = /^(\s*)("(?:\\.|[^"])*"|'[^']*'|[A-Za-z0-9_-]+)(\s*=\s*)([^\r\n]*)/.exec(line.text);
+	const match = /^(\s*)("(?:\\.|[^"\\])*"|'[^']*'|[A-Za-z0-9_-]+)(\s*=\s*)([^\r\n]*)/.exec(line.text);
 	if (!match || decodeTomlKey(match[2]!) !== expectedRule) return undefined;
 	return parseTomlSeverity(match, line.offset, expectedRule);
 }

--- a/extensions/fallow/registry.ts
+++ b/extensions/fallow/registry.ts
@@ -61,6 +61,10 @@ const fallowCommandRegistry = [
 		slash: { root: { value: "compatibility", description: "Compare the installed Fallow capabilities with Pi Fallow's certified surface", hintOrder: 0 } },
 	},
 	{
+		name: "config-assist",
+		slash: { root: { value: "config-assist", description: "Inspect or safely preview/apply a project rule-severity change", hintOrder: 17 } },
+	},
+	{
 		name: "issues",
 		slash: {
 			root: { value: "issues", description: "Aggregate project code-quality and security findings in one report", hintOrder: 1 },

--- a/tests/autocomplete.test.mjs
+++ b/tests/autocomplete.test.mjs
@@ -42,6 +42,9 @@ describe("Fallow autocomplete", () => {
 		assert.ok(labels(rootCompletions).includes("issues"));
 		assert.ok(labels(rootCompletions).includes("compatibility"));
 		assert.equal(fallowCompletions.getFallowArgumentCompletions("compatibility "), null);
+		assert.ok(labels(rootCompletions).includes("config-assist"));
+		assert.deepEqual(completionLabels("config-assist "), ["inspect", "preview-rule", "apply-rule"]);
+		assert.deepEqual(completionLabels("config-assist preview-rule unused-exports "), ["error", "warn", "off"]);
 		const runIndex = labels(rootCompletions).indexOf("run");
 		assert.notEqual(runIndex, -1);
 		assert.equal(rootCompletions[runIndex].description, "Run the configured default command (project issues unless overridden)");

--- a/tests/command-args.test.mjs
+++ b/tests/command-args.test.mjs
@@ -31,7 +31,7 @@ describe("resolveFallowRunArgs", () => {
 	});
 
 	it("rejects recursive or extension-only defaults", () => {
-		for (const command of ["run", "rerun", "history", "about", "version", "update", "compatibility"]) {
+		for (const command of ["run", "rerun", "history", "about", "version", "update", "compatibility", "config-assist"]) {
 			assert.throws(() => resolveFallowRunArgs([], [command]), /PI_FALLOW_DEFAULT_COMMAND must start/);
 		}
 	});

--- a/tests/config-assistant.test.mjs
+++ b/tests/config-assistant.test.mjs
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { createJiti } from "jiti";
+
+const jiti = createJiti(import.meta.url);
+const {
+	createFallowConfigAssistant,
+	formatFallowConfigPreview,
+} = await jiti.import("../extensions/fallow/config-assistant.ts");
+const { runFallowConfigAssistantCommand } = await jiti.import("../extensions/fallow/command/config-assistant.ts");
+
+const schema = {
+	$defs: {
+		RulesConfig: {
+			properties: {
+				"unused-exports": { $ref: "#/$defs/Severity" },
+				"security-sink": { $ref: "#/$defs/Severity" },
+			},
+		},
+	},
+};
+
+function success(stdout = "") {
+	return { result: { code: 0, killed: false, stdout, stderr: "" } };
+}
+
+function fixtureRunner(source, options = {}) {
+	const calls = [];
+	return {
+		calls,
+		clear() {},
+		async execute(_pi, args, cwd, signal, timeout) {
+			calls.push({ args, cwd, signal, timeout });
+			if (args.includes("--path")) return configPathResult(source);
+			return configPayloadResult(args[0], options);
+		},
+	};
+}
+
+function configPathResult(source) {
+	return source ? success(`${source}\n`) : { result: { code: 3, killed: false, stdout: "", stderr: "" } };
+}
+
+function configPayloadResult(command, options) {
+	if (command === "config-schema") return configSchemaResult(options);
+	return resolvedConfigResult(options);
+}
+
+function configSchemaResult(options) {
+	return success(JSON.stringify(options.schema ?? schema));
+}
+
+function resolvedConfigResult(options) {
+	if (options.configFailure) return { result: { code: 2, killed: false, stdout: "", stderr: "sensitive raw config must not escape" } };
+	return success(JSON.stringify(options.resolved ?? {
+		entry: ["src/index.ts"],
+		rules: { "unused-exports": "error", secretToken: "do-not-copy" },
+		workspaces: ["private-workspace"],
+		plugins: ["private-plugin"],
+		boundaries: { zones: [{}], rules: [{}] },
+		overrides: [{}],
+	}));
+}
+
+async function workspace() {
+	return mkdtemp(join(tmpdir(), "pi-fallow-config-assistant-"));
+}
+
+async function withWorkspace(run) {
+	const root = await workspace();
+	try { await run(root); }
+	finally { await rm(root, { recursive: true, force: true }); }
+}
+
+function assistantFor(source, options) {
+	return createFallowConfigAssistant({}, fixtureRunner(source, options));
+}
+
+describe("safe Fallow configuration assistant", () => {
+	it("inspects only bounded counts and separates project from inherited ownership", async () => {
+		await withWorkspace(async (root) => {
+			const project = join(root, ".fallowrc.json");
+			await writeFile(project, '{"private":"do-not-copy"}\n');
+			const assistant = assistantFor(project);
+			const report = await assistant.inspect(root);
+			assert.equal(report.status, "ready");
+			assert.equal(report.ownership, "project");
+			assert.deepEqual(report.counts, { entries: 1, rules: 2, workspaces: 1, plugins: 1, boundaries: 2, overrides: 1 });
+			assert.doesNotMatch(JSON.stringify(report), /do-not-copy|private-plugin|private-workspace|secretToken/);
+
+			const child = join(root, "packages", "child");
+			await mkdir(child, { recursive: true });
+			const inherited = await assistant.inspect(child);
+			assert.equal(inherited.ownership, "inherited");
+			assert.match(inherited.summary, /externally owned/);
+		});
+	});
+
+	it("keeps JSON preview read-only, then backs up and atomically applies only after use", async () => {
+		await withWorkspace(async (root) => {
+			const path = join(root, ".fallowrc.json");
+			const original = '{\n  "rules": { "unused-exports": "error" },\n  "private": "keep-me"\n}\n';
+			await writeFile(path, original);
+			await chmod(path, 0o640);
+			const assistant = assistantFor(path);
+			const plan = await assistant.previewRule(root, "unused-exports", "warn");
+			assert.equal(await readFile(path, "utf8"), original, "preview must not write");
+			assert.doesNotMatch(formatFallowConfigPreview(plan.preview), /keep-me/);
+			assert.equal(plan.preview.schemaPath, "$.rules.unused-exports");
+			await assert.rejects(assistant.apply(plan, root), /Explicit confirmation is required/);
+			assert.equal(await readFile(path, "utf8"), original);
+			const result = await assistant.apply(plan, root, { confirmed: true });
+			assert.equal(result.status, "applied");
+			assert.equal(await readFile(`${path}.pi-fallow.bak`, "utf8"), original);
+			assert.match(await readFile(path, "utf8"), /"unused-exports": "warn"/);
+			assert.match(await readFile(path, "utf8"), /"private": "keep-me"/);
+			if (process.platform !== "win32") assert.equal((await stat(path)).mode & 0o777, 0o640);
+			assert.ok((await readdir(root)).every((name) => !name.endsWith(".tmp")));
+		});
+	});
+
+	it("preserves JSONC comments and TOML formatting while changing an existing rule", async () => {
+		for (const [name, original, expected] of [
+			[".fallowrc.jsonc", '{\n  // retain this comment\n  "rules": {\n    "unused-exports": "error", // retain trailing comma\n  },\n}\n', /"unused-exports": "off", \/\/ retain trailing comma/],
+			["fallow.toml", '# retain this comment\n[rules]\n"unused\\u002Dexports" = "error" # retain inline comment\n', /"unused\\u002Dexports" = "off" # retain inline comment/],
+		]) {
+			await withWorkspace(async (root) => {
+				const path = join(root, name);
+				await writeFile(path, original);
+				const assistant = assistantFor(path);
+				const plan = await assistant.previewRule(root, "unused-exports", "off");
+				assert.equal(await readFile(path, "utf8"), original);
+				await assistant.apply(plan, root, { confirmed: true });
+				assert.match(await readFile(path, "utf8"), expected);
+				assert.match(await readFile(`${path}.pi-fallow.bak`, "utf8"), /retain/);
+			});
+		}
+	});
+
+	it("creates a project-owned JSONC override instead of modifying inherited configuration", async () => {
+		await withWorkspace(async (root) => {
+			const inherited = join(root, ".fallowrc.jsonc");
+			const inheritedText = '{"rules":{"unused-exports":"error"},"private":"ancestor"}\n';
+			await writeFile(inherited, inheritedText);
+			const child = join(root, "child");
+			await mkdir(child);
+			const assistant = assistantFor(inherited);
+			const plan = await assistant.previewRule(child, "unused-exports", "warn");
+			assert.equal(plan.preview.source, ".fallowrc.jsonc");
+			assert.match(plan.preview.backupPolicy, /No backup/);
+			await assistant.apply(plan, child, { confirmed: true });
+			assert.equal(await readFile(inherited, "utf8"), inheritedText);
+			const local = await readFile(join(child, ".fallowrc.jsonc"), "utf8");
+			assert.match(local, /"extends": "\.\.\/\.fallowrc\.jsonc"/);
+			assert.match(local, /"unused-exports": "warn"/);
+			assert.doesNotMatch(local, /ancestor/);
+		});
+	});
+
+	it("names source and schema path for malformed input and invalid requests", async () => {
+		await withWorkspace(async (root) => {
+			const path = join(root, ".fallowrc.jsonc");
+			await writeFile(path, '{"rules": { invalid }}');
+			const assistant = assistantFor(path);
+			await assert.rejects(
+				assistant.previewRule(root, "unused-exports", "warn"),
+				(error) => /\.fallowrc\.jsonc/.test(error.message) && /schema path \$/.test(error.message),
+			);
+			await assert.rejects(assistant.previewRule(root, "unknown-rule", "warn"), /schema path \$\.rules\.unknown-rule/);
+			await assert.rejects(assistant.previewRule(root, "unused-exports", "fatal"), /schema path \$\.rules\.unused-exports/);
+
+			const failed = createFallowConfigAssistant({}, fixtureRunner(path, { configFailure: true }));
+			const inspection = await failed.inspect(root);
+			assert.equal(inspection.status, "invalid");
+			assert.match(inspection.diagnostic, /\.fallowrc\.jsonc.*schema path \$/);
+			assert.doesNotMatch(inspection.diagnostic, /sensitive raw config/);
+		});
+	});
+
+	it("refuses concurrent content/schema drift and cancellation without creating config writes or backups", async () => {
+		await withWorkspace(async (root) => {
+			const path = join(root, "fallow.toml");
+			const original = '[rules]\nunused-exports = "error"\n';
+			await writeFile(path, original);
+			const assistant = assistantFor(path);
+			const stale = await assistant.previewRule(root, "unused-exports", "warn");
+			await writeFile(path, `${original}# concurrent edit\n`);
+			await assert.rejects(assistant.apply(stale, root, { confirmed: true }), /Refusing stale.*content changed/);
+			assert.ok(!(await readdir(root)).some((name) => name.includes("pi-fallow.bak")));
+
+			await writeFile(path, original);
+			const mutable = { schema: structuredClone(schema) };
+			const schemaAssistant = assistantFor(path, mutable);
+			const schemaPlan = await schemaAssistant.previewRule(root, "unused-exports", "warn");
+			mutable.schema.$defs.RulesConfig.properties["future-rule"] = {};
+			await assert.rejects(schemaAssistant.apply(schemaPlan, root, { confirmed: true }), /config schema changed/);
+			assert.ok(!(await readdir(root)).some((name) => name.includes("pi-fallow.bak")));
+
+			const cancelled = await assistant.previewRule(root, "unused-exports", "warn");
+			const controller = new AbortController();
+			controller.abort();
+			await assert.rejects(assistant.apply(cancelled, root, { confirmed: true, signal: controller.signal }), /cancelled; no config write/);
+			assert.equal(await readFile(path, "utf8"), original);
+			assert.ok(!(await readdir(root)).some((name) => name.includes("pi-fallow.bak")));
+		});
+	});
+
+	it("requires interactive confirmation and treats decline as a no-write cancellation", async () => {
+		await withWorkspace(async (root) => {
+			const path = join(root, ".fallowrc.json");
+			const original = '{"rules":{"unused-exports":"error"}}\n';
+			await writeFile(path, original);
+			const messages = [];
+			const notices = [];
+			let confirms = 0;
+			const pi = { sendMessage(message) { messages.push(message); } };
+			const assistant = createFallowConfigAssistant(pi, fixtureRunner(path));
+			await runFallowConfigAssistantCommand(pi, {
+				cwd: root, mode: "tui", hasUI: true,
+				ui: { async confirm() { confirms++; return false; }, notify(message) { notices.push(message); } },
+			}, ["config-assist", "apply-rule", "unused-exports", "warn"], assistant);
+			assert.equal(confirms, 1);
+			assert.equal(messages.length, 1);
+			assert.equal(messages[0].customType, "fallow-config-assistant");
+			assert.match(notices.at(-1), /cancelled/);
+			assert.equal(await readFile(path, "utf8"), original);
+			assert.deepEqual(await readdir(root), [".fallowrc.json"]);
+
+			await assert.rejects(runFallowConfigAssistantCommand(pi, {
+				cwd: root, mode: "rpc", hasUI: false, ui: {},
+			}, ["config-assist", "apply-rule", "unused-exports", "warn"], assistant), /interactive TUI confirmation/);
+			assert.equal(await readFile(path, "utf8"), original);
+
+			await runFallowConfigAssistantCommand(pi, {
+				cwd: root, mode: "tui", hasUI: true,
+				ui: { async confirm() { return true; }, notify(message) { notices.push(message); } },
+			}, ["config-assist", "apply-rule", "unused-exports", "warn"], assistant);
+			assert.match(await readFile(path, "utf8"), /"unused-exports":"warn"/);
+			assert.equal(messages.at(-1).details.status, "applied");
+			assert.match(notices.at(-1), /applied/);
+		});
+	});
+});

--- a/tests/package-metadata.test.mjs
+++ b/tests/package-metadata.test.mjs
@@ -34,6 +34,9 @@ describe("package and automation metadata", () => {
 		assert.match(readme, /tested compatibility; it is not an installation constraint/);
 		assert.match(readme, /Certification.*Compatibility.*Installation constraints/s);
 		assert.match(readme, /\/fallow compatibility.*never gates ordinary execution/s);
+		assert.match(readme, /\/fallow config-assist.*read-only inspection/s);
+		assert.match(readme, /Apply requires a direct confirmation.*concurrent drift or cancellation refuses/s);
+		assert.match(readme, /inherited or external configuration remains read-only/s);
 		assert.match(readme, /wildcard peer dependencies/);
 	});
 


### PR DESCRIPTION
## Summary

- add explicit `/fallow config-assist` inspection plus structured `preview-rule` and `apply-rule` workflows
- keep inspection/preview read-only and transcript-safe while separating project-owned from inherited/external configuration
- require TUI confirmation, then recheck discovery, installed schema, and source digest before backed-up atomic JSON/JSONC/TOML updates
- preserve inherited configuration through a project-local `extends` reference without copying values

Closes #78.

## Scope decision

The assistant intentionally supports one schema-recognized rule-severity change at a time. Arbitrary schema paths, natural-language edits, global config ownership, prompt-template management, and silent `fallow init` remain out of scope. This keeps previews deterministic and allows comments/formatting to be preserved safely.

## Safety evidence

- `config`, `config --path`, and `config-schema` probes use `--no-cache` and a non-installing runner
- preview writes no temporary files
- non-interactive modes cannot apply
- explicit TUI confirmation is required by both command and write API contracts
- apply refuses config-discovery, schema, source-content, symlink, and concurrent-create drift
- existing files receive byte-exact same-mode backups and same-directory atomic replacement
- inherited/external files are never modified; project overrides reference them via `extends`
- transcript details contain only bounded counts, source ownership/path, and the requested rule transition—not resolved values or raw CLI errors

## Validation

- `npm run check:publish` — 419 passing tests; bundle, health, dead-code, duplication, Fallow smoke, optional fallow-cov certification, npm audit, and package smoke passed
- `npm run coverage` — 91.94% statements/lines, 87.37% branches, 91.16% functions
- `fallow audit --base origin/main --gate new-only` — pass, zero new issues
- `fallow security --changed-since origin/main --gate new` — zero new candidates
- focused tests cover JSON, JSONC, TOML, malformed input, inherited ownership, content/schema drift, cancellation, non-interactive refusal, decline, confirmation, backups, and atomic writes
